### PR TITLE
lcuFH0p0/175: added a workaround for fixing an issue with not styled status messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -166,6 +166,9 @@
             "drupal/civictheme": {
                 "Remove Shortcut from theme dependency": "patches/civictheme-remove-shortcut-mr19.diff"
             },
+            "drupal/core": {
+                "10.3 upgrade now missing status-message theme suggestions": "https://www.drupal.org/files/issues/2025-04-30/3456176-bootstrap_barrio-fix-status-message-core-11_1_6-132.patch"
+            },
             "drupal/environment_indicator": {
                 "Gin vertical toolbar submenu's overlap": "https://www.drupal.org/files/issues/2024-12-03/3487202-gin-vertical-toolbar-9.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4814f4e50f70da800adcfdf18c0d2009",
+    "content-hash": "6a973aec7a468fda678caace013fc15a",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -7,23 +7,9 @@
 
 declare(strict_types=1);
 
-use Drupal\Core\Render\Element\StatusMessages;
-
 /**
  * Implements hook_preprocess_HOOK() for container templates.
  */
 function drevops_preprocess_container(array &$variables): void {
   $variables['modifier_class'] = FALSE;
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- *
- * A workaround for fixing missing template of the status messages block
- * when the BigPipe module is enabled.
- *
- * @see https://www.drupal.org/project/drupal/issues/3456176#comment-15654729
- */
-function drevops_preprocess_block__system_messages_block(array &$variables): void {
-  $variables['content'] = StatusMessages::renderMessages();
 }

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -7,9 +7,23 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Render\Element\StatusMessages;
+
 /**
  * Implements hook_preprocess_HOOK() for container templates.
  */
 function drevops_preprocess_container(array &$variables): void {
   $variables['modifier_class'] = FALSE;
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * It's a workaround for fixing missing template of the status messages block
+ * when the BigPipe module is enabled.
+ *
+ * @link https://www.drupal.org/project/drupal/issues/3456176#comment-15654729
+ */
+function drevops_preprocess_block__system_messages_block(array &$variables): void {
+  $variables['content'] = StatusMessages::renderMessages();
 }

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -22,7 +22,7 @@ function drevops_preprocess_container(array &$variables): void {
  * It's a workaround for fixing missing template of the status messages block
  * when the BigPipe module is enabled.
  *
- * @link https://www.drupal.org/project/drupal/issues/3456176#comment-15654729
+ * @see https://www.drupal.org/project/drupal/issues/3456176#comment-15654729
  */
 function drevops_preprocess_block__system_messages_block(array &$variables): void {
   $variables['content'] = StatusMessages::renderMessages();

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -19,7 +19,7 @@ function drevops_preprocess_container(array &$variables): void {
 /**
  * Implements hook_preprocess_HOOK().
  *
- * It's a workaround for fixing missing template of the status messages block
+ * A workaround for fixing missing template of the status messages block
  * when the BigPipe module is enabled.
  *
  * @see https://www.drupal.org/project/drupal/issues/3456176#comment-15654729


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally.

https://trello.com/c/lcuFH0p0/175-website-fix-messages-templates

## Changed

1. added a workaround for fixing an issue with not styled status messages

## Screenshots
![Screenshot from 2025-04-30 00-01-54](https://github.com/user-attachments/assets/604026dc-e148-482f-bdb8-ecd9adeefed8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Applied a patch to resolve missing status-message theme suggestions after upgrading to version 10.3 of Drupal core.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->