### PR TITLE
c/ezB1gKx5/208: corrected metatag settings for the Page content type.

### DIFF
--- a/config/default/metatag.metatag_defaults.node__civictheme_page.yml
+++ b/config/default/metatag.metatag_defaults.node__civictheme_page.yml
@@ -1,0 +1,8 @@
+uuid: 9510eb68-5939-4944-9151-fe114b68ea88
+langcode: en
+status: true
+dependencies: {  }
+id: node__civictheme_page
+label: 'Content: Page'
+tags:
+  description: '[node:field_c_n_summary:value]'

--- a/tests/behat/features/metatags.feature
+++ b/tests/behat/features/metatags.feature
@@ -2,14 +2,11 @@
 Feature: Page content metatags
   As a site user, I want to verify all default metatags appear for CivicTheme Page content type
 
-  Background:
+  @api
+  Scenario: CivicTheme page content type contains default metatags
     Given civictheme_page content:
       | title               | status | field_c_n_summary                           |
       | Test Metatags Page  | 1      | This is a test summary for metatags testing |
-
-  @api
-  Scenario: CivicTheme page content type contains default metatags
-    Given I am an anonymous user
     When I visit civictheme_page "Test Metatags Page"
     Then the response should contain "<title>Test Metatags Page | "
     And the response should contain "<meta name=\"description\" content=\"This is a test summary for metatags testing\""

--- a/tests/behat/features/metatags.feature
+++ b/tests/behat/features/metatags.feature
@@ -1,0 +1,16 @@
+@seo @metatags
+Feature: Page content metatags
+  As a site user, I want to verify all default metatags appear for CivicTheme Page content type
+
+  Background:
+    Given civictheme_page content:
+      | title               | status | field_c_n_summary                           |
+      | Test Metatags Page  | 1      | This is a test summary for metatags testing |
+
+  @api
+  Scenario: CivicTheme page content type contains default metatags
+    Given I am an anonymous user
+    When I visit civictheme_page "Test Metatags Page"
+    Then the response should contain "<title>Test Metatags Page | "
+    And the response should contain "<meta name=\"description\" content=\"This is a test summary for metatags testing\""
+    And the response should contain "<link rel=\"canonical\" href=\""

--- a/tests/behat/features/tracking.feature
+++ b/tests/behat/features/tracking.feature
@@ -11,6 +11,6 @@ Feature: Google Analytics is injected
 
   @api @javascript
   Scenario: Google Analytics 4 script should not be present for logged in users
-    Given I am logged in as a user with the "authenticated" role
+    Given I am logged in as a user with the "administer site configuration, access administration pages" permissions
     When I am on the homepage
     Then the response should not contain "https://www.googletagmanager.com/gtag/js?id=G-"


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Created a separate configuration file with metatag settings for the Page node type.
2. Created a behat test scenario to check default metatags presence on the Page node view.

## Screenshots
![2025-05-06_17-16](https://github.com/user-attachments/assets/db86b1f5-138e-4713-ae5d-17f7bf148a46)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added default metatag settings for CivicTheme Page content types, including dynamic description tags based on page summaries.

- **Tests**
  - Introduced automated tests to verify that CivicTheme Pages display the correct SEO-related metatags by default, such as title, description, and canonical tags.
  - Updated user role conditions in analytics tracking tests to reflect specific permissions for site administration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->