### PR TITLE
[#190] Added the Intro banner type.

### DIFF
--- a/config/default/field.storage.block_content.field_c_b_banner_type.yml
+++ b/config/default/field.storage.block_content.field_c_b_banner_type.yml
@@ -19,6 +19,9 @@ settings:
     -
       value: large
       label: Large
+    -
+      value: intro
+      label: Intro
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/default/field.storage.node.field_c_n_banner_type.yml
+++ b/config/default/field.storage.node.field_c_n_banner_type.yml
@@ -22,6 +22,9 @@ settings:
     -
       value: large
       label: Large
+    -
+      value: intro
+      label: Intro
   allowed_values_function: ''
 module: options
 locked: false

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
@@ -4,6 +4,7 @@
 
 .ct-banner {
   $root: &;
+  $featured_image_wrapper: #{$root}__featured-image__wrapper;
 
   position: relative;
 
@@ -14,10 +15,8 @@
   #{$root}__inner {
     @include ct-background();
 
-    & {
-      padding-top: ct-spacing(3);
-      padding-bottom: ct-spacing(10);
-    }
+    padding-top: ct-spacing(3);
+    padding-bottom: ct-spacing(10);
 
     @include ct-print() {
       padding-top: ct-spacing(2);
@@ -29,14 +28,12 @@
     margin-top: ct-spacing(2);
   }
 
-  #{$root}__featured-image__wrapper {
+  #{$featured_image_wrapper} {
     @include ct-image-fit();
 
-    & {
-      box-sizing: border-box;
-      width: $ct-banner-featured-image-width;
-      display: none;
-    }
+    box-sizing: border-box;
+    width: $ct-banner-featured-image-width;
+    display: none;
 
     @include ct-breakpoint(m) {
       display: block;
@@ -67,7 +64,7 @@
       margin-top: -1 * ct-spacing(2);
     }
 
-    #{$root}__featured-image__wrapper {
+    #{$featured_image_wrapper} {
       @include ct-breakpoint(m) {
         bottom: 0;
         top: auto;
@@ -110,7 +107,7 @@
     }
 
     &#{$root}--decorative {
-      #{$root}__featured-image__wrapper {
+      #{$featured_image_wrapper} {
         @include ct-breakpoint(m) {
           @include ct-image-shadow(ct-component-var($root, $theme, featured-image, shadow-color), 'up-left');
         }

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
@@ -117,4 +117,12 @@
       }
     }
   }
+
+  &.ct-banner-type--intro {
+    .ct-banner__title {
+      @include ct-typography('heading-large');
+    }
+
+    text-align: center;
+  }
 }

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
@@ -4,7 +4,6 @@
 
 .ct-banner {
   $root: &;
-  $featured_image_wrapper: #{$root}__featured-image__wrapper;
 
   position: relative;
 
@@ -28,7 +27,7 @@
     margin-top: ct-spacing(2);
   }
 
-  #{$featured_image_wrapper} {
+  #{$root}__featured-image__wrapper {
     @include ct-image-fit();
 
     box-sizing: border-box;
@@ -64,7 +63,7 @@
       margin-top: -1 * ct-spacing(2);
     }
 
-    #{$featured_image_wrapper} {
+    #{$root}__featured-image__wrapper {
       @include ct-breakpoint(m) {
         bottom: 0;
         top: auto;
@@ -107,7 +106,7 @@
     }
 
     &#{$root}--decorative {
-      #{$featured_image_wrapper} {
+      #{$root}__featured-image__wrapper {
         @include ct-breakpoint(m) {
           @include ct-image-shadow(ct-component-var($root, $theme, featured-image, shadow-color), 'up-left');
         }
@@ -116,10 +115,15 @@
   }
 
   &.ct-banner-type--intro {
-    .ct-banner__title {
-      @include ct-typography('heading-large');
+    .ct-banner__inner {
+      min-height: $ct-banner-intro-min-height;
+      display: flex;
+      align-items: center;
+      text-align: center;
     }
 
-    text-align: center;
+    .ct-banner__title {
+      @include ct-typography('display-large');
+    }
   }
 }

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.scss
@@ -1,0 +1,120 @@
+//
+// Banner component.
+//
+
+.ct-banner {
+  $root: &;
+
+  position: relative;
+
+  #{$root}__wrapper {
+    position: relative;
+  }
+
+  #{$root}__inner {
+    @include ct-background();
+
+    & {
+      padding-top: ct-spacing(3);
+      padding-bottom: ct-spacing(10);
+    }
+
+    @include ct-print() {
+      padding-top: ct-spacing(2);
+      padding-bottom: ct-spacing(3);
+    }
+  }
+
+  #{$root}__content-below {
+    margin-top: ct-spacing(2);
+  }
+
+  #{$root}__featured-image__wrapper {
+    @include ct-image-fit();
+
+    & {
+      box-sizing: border-box;
+      width: $ct-banner-featured-image-width;
+      display: none;
+    }
+
+    @include ct-breakpoint(m) {
+      display: block;
+      position: absolute;
+      bottom: 0;
+      top: 0;
+      right: 0;
+    }
+  }
+
+  &#{$root}--decorative {
+    #{$root}__inner {
+      clip-path: $ct-banner-decorative-mobile-clip-path;
+
+      @include ct-breakpoint(m) {
+        padding-top: ct-spacing(8);
+        padding-bottom: ct-spacing(8);
+        clip-path: $ct-banner-decorative-desktop-clip-path;
+      }
+
+      @include ct-print() {
+        padding-top: ct-spacing(2);
+        padding-bottom: ct-spacing(3);
+      }
+    }
+
+    #{$root}__content-below {
+      margin-top: -1 * ct-spacing(2);
+    }
+
+    #{$root}__featured-image__wrapper {
+      @include ct-breakpoint(m) {
+        bottom: 0;
+        top: auto;
+        height: 100%;
+        max-height: ct-particle(75);
+        padding-top: ct-spacing(8);
+      }
+    }
+
+    #{$root}__featured-image {
+      @if $ct-banner-featured-image-clip-path != false {
+        clip-path: $ct-banner-featured-image-clip-path;
+      }
+    }
+  }
+
+  #{$root}__breadcrumb {
+    margin-bottom: ct-spacing(4);
+
+    @include ct-breakpoint(m) {
+      margin-bottom: ct-spacing(6);
+    }
+  }
+
+  #{$root}__site-section {
+    margin-bottom: ct-spacing(2);
+  }
+
+  #{$root}__title {
+    margin-bottom: ct-spacing(2);
+
+    @include ct-breakpoint(m) {
+      margin-bottom: ct-spacing(3);
+    }
+  }
+
+  @include ct-component-theme($root) using($root, $theme) {
+    #{$root}__inner {
+      @include ct-component-property($root, $theme, background-color);
+    }
+
+    &#{$root}--decorative {
+      #{$root}__featured-image__wrapper {
+        @include ct-breakpoint(m) {
+          @include ct-image-shadow(ct-component-var($root, $theme, featured-image, shadow-color), 'up-left');
+        }
+      }
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.data.js
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.data.js
@@ -1,0 +1,89 @@
+import Constants from '../../../dist/constants.json'; // eslint-disable-line import/no-unresolved
+
+import Paragraph from '../../01-atoms/paragraph/paragraph.twig';
+import Button from '../../01-atoms/button/button.twig';
+import NavigationCard from '../../02-molecules/navigation-card/navigation-card.twig';
+import Grid from '../../00-base/grid/grid.twig';
+
+export default {
+  args: (theme = 'light') => ({
+    theme,
+    breadcrumb: {
+      links: [
+        {
+          text: 'Link 1',
+          url: 'https://example.com/breadcrumb-1',
+        },
+        {
+          text: 'Link 2',
+          url: 'https://example.com/breadcrumb-2',
+        },
+        {
+          text: 'Link 3',
+          url: 'https://example.com/breadcrumb-2',
+        },
+      ],
+      active_is_link: false,
+    },
+    site_section: 'Site section name',
+    title: 'Providing visually engaging digital experiences',
+    is_decorative: true,
+    featured_image: {
+      url: './demo/images/demo2.jpg',
+      alt: 'Featured image alt text',
+    },
+    background_image: {
+      url: Constants.BACKGROUNDS[Object.keys(Constants.BACKGROUNDS)[0]],
+      alt: 'Background image alt text',
+    },
+    background_image_blend_mode: 'multiply',
+    content_top1: '',
+    content_top2: '',
+    content_top3: '',
+    content_middle: '',
+    content: Paragraph({
+      theme,
+      allow_html: true,
+      content: `<p>Government grade set of high quality design themes that are accessible, inclusive and provide a consistent digital experience for your citizen. </p><p>${Button({
+        theme,
+        text: 'Learn about our mission',
+        type: 'primary',
+        kind: 'link',
+      }).trim()}</p>`,
+    }).trim(),
+    content_bottom: '',
+    content_below: Grid({
+      theme,
+      template_column_count: 4,
+      items: [
+        NavigationCard({
+          theme,
+          title: 'Register for a workshop',
+          summary: 'Est sed aliqua ullamco occaecat velit nisi in dolor excepteur.',
+          icon: 'mortarboard',
+        }).trim(),
+        NavigationCard({
+          theme,
+          title: 'Register for a workshop',
+          summary: 'Ea dolor enim eiusmod consectetur proident adipisicing aute dolor ad est.',
+          icon: 'mortarboard',
+        }).trim(),
+        NavigationCard({
+          theme,
+          title: 'Register for a workshop',
+          summary: 'Anim occaecat ex nostrud non do sunt ut nostrud mollit aliqua.',
+          icon: 'mortarboard',
+        }).trim(),
+        NavigationCard({
+          theme,
+          title: 'Register for a workshop',
+          summary: 'Sunt duis dolore voluptate quis do in.',
+          icon: 'mortarboard',
+        }).trim(),
+      ],
+      row_class: 'row--equal-heights-content row--vertically-spaced',
+    }).trim(),
+    modifier_class: '',
+    attributes: '',
+  }),
+};

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.data.js
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.data.js
@@ -8,6 +8,7 @@ import Grid from '../../00-base/grid/grid.twig';
 export default {
   args: (theme = 'light') => ({
     theme,
+    banner_type: 'inherit',
     breadcrumb: {
       links: [
         {

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.data.js
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.data.js
@@ -8,7 +8,7 @@ import Grid from '../../00-base/grid/grid.twig';
 export default {
   args: (theme = 'light') => ({
     theme,
-    banner_type: 'inherit',
+    type: 'default',
     breadcrumb: {
       links: [
         {
@@ -21,7 +21,7 @@ export default {
         },
         {
           text: 'Link 3',
-          url: 'https://example.com/breadcrumb-2',
+          url: 'https://example.com/breadcrumb-3',
         },
       ],
       active_is_link: false,

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.js
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.js
@@ -10,9 +10,9 @@ const meta = {
       control: { type: 'radio' },
       options: ['light', 'dark'],
     },
-    banner_type: {
+    type: {
       control: { type: 'radio' },
-      options: ['inherit', 'default', 'large', 'intro'],
+      options: ['default', 'large', 'intro'],
     },
     content_top1: {
       control: { type: 'text' },

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.js
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.js
@@ -1,0 +1,82 @@
+import Component from './banner.twig';
+import BannerData from './banner.stories.data';
+import Constants from '../../../dist/constants.json'; // eslint-disable-line import/no-unresolved
+
+const meta = {
+  title: 'Organisms/Banner',
+  component: Component,
+  argTypes: {
+    theme: {
+      control: { type: 'radio' },
+      options: ['light', 'dark'],
+    },
+    content_top1: {
+      control: { type: 'text' },
+    },
+    breadcrumb: {
+      control: { type: 'array' },
+    },
+    content_top2: {
+      control: { type: 'text' },
+    },
+    content_top3: {
+      control: { type: 'text' },
+    },
+    content_middle: {
+      control: { type: 'text' },
+    },
+    content: {
+      control: { type: 'text' },
+    },
+    content_bottom: {
+      control: { type: 'text' },
+    },
+    content_below: {
+      control: { type: 'text' },
+    },
+    site_section: {
+      control: { type: 'text' },
+    },
+    title: {
+      control: { type: 'text' },
+    },
+    is_decorative: {
+      control: { type: 'boolean' },
+    },
+    featured_image: {
+      control: { type: 'object' },
+    },
+    background_image: {
+      control: { type: 'object' },
+    },
+    background_image_blend_mode: {
+      control: { type: 'select' },
+      options: Constants.SCSS_VARIABLES['ct-background-blend-modes'],
+    },
+    modifier_class: {
+      control: { type: 'text' },
+    },
+    attributes: {
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Banner = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: BannerData.args('light'),
+};
+
+export const BannerDark = {
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: {
+      default: 'Dark',
+    },
+  },
+  args: BannerData.args('dark'),
+};

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.js
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.stories.js
@@ -10,6 +10,10 @@ const meta = {
       control: { type: 'radio' },
       options: ['light', 'dark'],
     },
+    banner_type: {
+      control: { type: 'radio' },
+      options: ['inherit', 'default', 'large', 'intro'],
+    },
     content_top1: {
       control: { type: 'text' },
     },

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
@@ -1,0 +1,198 @@
+{#
+/**
+ * @file
+ * Banner component.
+ *
+ * Variables:
+ * - content_top1: [string] Content slot.
+ * - breadcrumb: [array] Breadcrumb links.
+ * - content_top2: [string] Content slot.
+ * - content_top3: [string] Content slot.
+ * - content_middle: [string] Content slot.
+ * - content: [string] Content slot.
+ * - content_bottom: [string] Content slot.
+ * - content_below: [string] Content slot.
+ * - site_section: [string] Site section.
+ * - title: [string] Title.
+ * - is_decorative: [boolean] Show as decorative.
+ * - featured_image: [object] Featured image object:
+ *   - url: [string] Source.
+ *   - alt: [string] Alt text.
+ * - background_image: [string] URL to a background image.
+ *   - url: [string] Source.
+ *   - alt: [string] Alt text.
+ * - background_image_blend_mode: [string] Type of the backgeound image blending. Defaults to 'normal'.
+ * - theme: [string] Theme: light, dark.
+ * - modifier_class: [string] Additional classes.
+ * - attributes: [string] Banner attributes.
+ */
+#}
+
+{% set is_decorative_class = is_decorative ? 'ct-banner--decorative' : '' %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set modifier_class = '%s %s %s'|format(theme_class, is_decorative_class, modifier_class|default('')) %}
+
+{% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty or site_section is not empty or title is not empty or content_middle is not empty or content is not empty or content_below is not empty or content_bottom is not empty %}
+  <div class="ct-banner {{ modifier_class -}}" id="main-content" tabindex="-1" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
+    <div class="ct-banner__wrapper">
+      <div
+        class="ct-banner__inner {% if background_image_blend_mode %}ct-background--{{ background_image_blend_mode|default('normal') }}{% endif %}"
+        {% if background_image and background_image.url is defined and background_image.url is not empty %}style="background-image: url('{{ background_image.url }}');"{% endif %}
+      >
+        {% if background_image and background_image.alt is defined and background_image.alt is not empty %}
+        <span role="img" aria-label="{{ background_image.alt }}"> </span>
+        {% endif %}
+
+        <div class="container">
+
+          {% if content_top1 is not empty %}
+            <div class="row">
+              {%- block content_top1 %}
+                <div class="col-xxs-12">
+                  <div class="ct-banner__content-top">
+                    {{- content_top1|raw -}}
+                  </div>
+                </div>
+              {% endblock -%}
+            </div>
+          {% endif %}
+
+          {% if breadcrumb is not empty or content_top2 is not empty %}
+            <div class="row">
+              {% block breadcrumb %}
+                {% if breadcrumb is not empty %}
+                  <div class="{% if featured_image is not empty %}col-xxs-12 col-m-6{% else %}col-xxs-12{% endif %}">
+                    {% include '@molecules/breadcrumb/breadcrumb.twig' with {
+                      theme: theme,
+                      links: breadcrumb.links,
+                      active_is_link: breadcrumb.active_is_link,
+                      modifier_class: 'ct-banner__breadcrumb',
+                    } only %}
+                  </div>
+                {% endif %}
+              {% endblock %}
+
+              {% if content_top2 is not empty %}
+                {%- block content_top2 %}
+                  <div class="col-xxs-12 col-m-6">
+                    <div class="ct-banner__content-top2">
+                      {{- content_top2|raw -}}
+                    </div>
+                  </div>
+                {% endblock -%}
+              {% endif %}
+            </div>
+          {% endif %}
+
+          {% if content_top3 is not empty %}
+            <div class="row">
+              {%- block content_top3 %}
+                <div class="col-xxs-12">
+                  <div class="ct-banner__content-top3">
+                    {{- content_top3|raw -}}
+                  </div>
+                </div>
+              {% endblock -%}
+            </div>
+          {% endif %}
+
+          {% if site_section is not empty %}
+            <div class="row">
+              {%- block site_section %}
+                <div class="col-xxs-12">
+                  {% include '@atoms/heading/heading.twig' with {
+                    theme: theme,
+                    content: site_section,
+                    level: 5,
+                    modifier_class: 'ct-banner__site-section',
+                  } only %}
+                </div>
+              {% endblock -%}
+            </div>
+          {% endif %}
+
+          {% if title is not empty %}
+            <div class="row">
+              {%- block title %}
+                <div class="{% if featured_image is not empty %}col-xxs-12 col-m-6{% else %}col-xxs-12{% endif %}">
+                  {% include '@atoms/heading/heading.twig' with {
+                    theme: theme,
+                    content: title,
+                    level: 1,
+                    modifier_class: 'ct-banner__title',
+                  } only %}
+                </div>
+              {% endblock -%}
+            </div>
+          {% endif %}
+
+          {% if content_middle is not empty %}
+            <div class="row">
+              {%- block content_middle %}
+                <div class="{% if featured_image is not empty %}col-xxs-12 col-m-6{% else %}col-xxs-12{% endif %}">
+                  <div class="ct-banner__content-middle">
+                    {{- content_middle|raw -}}
+                  </div>
+                </div>
+              {% endblock -%}
+            </div>
+          {% endif %}
+
+          {% if content is not empty %}
+            <div class="row">
+              {%- block content %}
+                <div class="{% if featured_image is not empty %}col-xxs-12 col-m-6{% else %}col-xxs-12{% endif %}">
+                  <div class="ct-banner__content">
+                    {{- content|raw -}}
+                  </div>
+                </div>
+              {% endblock -%}
+            </div>
+          {% endif %}
+
+        </div>
+      </div>
+
+      {% block featured_image %}
+        {% if featured_image is not empty %}
+          <div class="ct-banner__featured-image__wrapper">
+            {% include '@atoms/image/image.twig' with {
+              theme: theme,
+              url: featured_image.url,
+              alt: featured_image.alt,
+              modifier_class: 'ct-banner__featured-image',
+            } only %}
+          </div>
+        {% endif %}
+      {% endblock %}
+    </div>
+
+    {% if content_below is not empty %}
+      <div class="container">
+        <div class="row">
+          {%- block content_below %}
+            <div class="col-xxs-12">
+              <div class="ct-banner__content-below">
+                {{- content_below|raw -}}
+              </div>
+            </div>
+          {% endblock -%}
+        </div>
+      </div>
+    {% endif %}
+
+    {% if content_bottom is not empty %}
+      <div class="container">
+        <div class="row">
+          {%- block content_bottom %}
+            <div class="col-xxs-12">
+              <div class="ct-banner__content-bottom">
+                {{- content_bottom|raw -}}
+              </div>
+            </div>
+          {% endblock -%}
+        </div>
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
@@ -21,7 +21,7 @@
  * - background_image: [string] URL to a background image.
  *   - url: [string] Source.
  *   - alt: [string] Alt text.
- * - background_image_blend_mode: [string] Type of the backgeound image blending. Defaults to 'normal'.
+ * - background_image_blend_mode: [string] Type of the background image blending. Defaults to 'normal'.
  * - theme: [string] Theme: light, dark.
  * - modifier_class: [string] Additional classes.
  * - attributes: [string] Banner attributes.

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
@@ -30,7 +30,8 @@
 
 {% set is_decorative_class = is_decorative ? 'ct-banner--decorative' : '' %}
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
-{% set modifier_class = '%s %s %s'|format(theme_class, is_decorative_class, modifier_class|default('')) %}
+{% set banner_type_class = 'ct-banner-type--%s'|format(banner_type|default('default')) %}
+{% set modifier_class = '%s %s %s %s'|format(theme_class, is_decorative_class, banner_type_class, modifier_class|default('')) %}
 
 {% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty or site_section is not empty or title is not empty or content_middle is not empty or content is not empty or content_below is not empty or content_bottom is not empty %}
   <div class="ct-banner {{ modifier_class -}}" id="main-content" tabindex="-1" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
@@ -27,11 +27,15 @@
  * - attributes: [string] Banner attributes.
  */
 #}
-
 {% set is_decorative_class = is_decorative ? 'ct-banner--decorative' : '' %}
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
-{% set banner_type_class = 'ct-banner-type--%s'|format(banner_type|default('default')) %}
-{% set modifier_class = '%s %s %s %s'|format(theme_class, is_decorative_class, banner_type_class, modifier_class|default('')) %}
+{% set type = type in ['default', 'large', 'intro'] ? type : 'default' %}
+{% set type_class = 'ct-banner-type--%s'|format(type) %}
+{% set modifier_class = '%s %s %s %s'|format(theme_class, is_decorative_class, type_class, modifier_class|default('')) %}
+
+{% if type == 'intro' %}
+  {% set featured_image = null %}
+{% endif %}
 
 {% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty or site_section is not empty or title is not empty or content_middle is not empty or content is not empty or content_below is not empty or content_bottom is not empty %}
   <div class="ct-banner {{ modifier_class -}}" id="main-content" tabindex="-1" {% if attributes is not empty %}{{- attributes|raw -}}{% endif %}>
@@ -41,7 +45,7 @@
         {% if background_image and background_image.url is defined and background_image.url is not empty %}style="background-image: url('{{ background_image.url }}');"{% endif %}
       >
         {% if background_image and background_image.alt is defined and background_image.alt is not empty %}
-        <span role="img" aria-label="{{ background_image.alt }}"> </span>
+          <span role="img" aria-label="{{ background_image.alt }}"> </span>
         {% endif %}
 
         <div class="container">
@@ -61,7 +65,7 @@
           {% if breadcrumb is not empty or content_top2 is not empty %}
             <div class="row">
               {% block breadcrumb %}
-                {% if breadcrumb is not empty %}
+                {% if breadcrumb is not empty and type != 'intro' %}
                   <div class="{% if featured_image is not empty %}col-xxs-12 col-m-6{% else %}col-xxs-12{% endif %}">
                     {% include '@molecules/breadcrumb/breadcrumb.twig' with {
                       theme: theme,
@@ -73,7 +77,7 @@
                 {% endif %}
               {% endblock %}
 
-              {% if content_top2 is not empty %}
+              {% if content_top2 is not empty and type != 'intro' %}
                 {%- block content_top2 %}
                   <div class="col-xxs-12 col-m-6">
                     <div class="ct-banner__content-top2">
@@ -85,7 +89,7 @@
             </div>
           {% endif %}
 
-          {% if content_top3 is not empty %}
+          {% if content_top3 is not empty and type != 'intro' %}
             <div class="row">
               {%- block content_top3 %}
                 <div class="col-xxs-12">
@@ -97,7 +101,7 @@
             </div>
           {% endif %}
 
-          {% if site_section is not empty %}
+          {% if site_section is not empty and type != 'intro' %}
             <div class="row">
               {%- block site_section %}
                 <div class="col-xxs-12">

--- a/web/themes/custom/drevops/components/variables.base.scss
+++ b/web/themes/custom/drevops/components/variables.base.scss
@@ -108,7 +108,6 @@ $ct-fonts: (
     ),
   ),
 );
-
 $ct-particle: 8px;
 
 // Base font sizes defined in CivicTheme base variables.

--- a/web/themes/custom/drevops/components/variables.base.scss
+++ b/web/themes/custom/drevops/components/variables.base.scss
@@ -114,7 +114,7 @@ $ct-particle: 8px;
 $ct-font-base-size: $ct-particle * 2 !default;
 $ct-font-base-line-height: $ct-font-base-size !default;
 $ct-typography: (
-  'heading-large': (
+  'display-large': (
     'xxs': ($ct-font-base-size * 3, $ct-font-base-line-height * 3.5, 'bold', 'primary', -0.6px),
     'm': ($ct-font-base-size * 4, $ct-font-base-line-height * 4.75, 'bold', 'primary', -1px)
   )

--- a/web/themes/custom/drevops/components/variables.base.scss
+++ b/web/themes/custom/drevops/components/variables.base.scss
@@ -108,3 +108,15 @@ $ct-fonts: (
     ),
   ),
 );
+
+$ct-particle: 8px;
+
+// Base font sizes defined in CivicTheme base variables.
+$ct-font-base-size: $ct-particle * 2 !default;
+$ct-font-base-line-height: $ct-font-base-size !default;
+$ct-typography: (
+  'heading-large': (
+    'xxs': ($ct-font-base-size * 3, $ct-font-base-line-height * 3.5, 'bold', 'primary', -0.6px),
+    'm': ($ct-font-base-size * 4, $ct-font-base-line-height * 4.75, 'bold', 'primary', -1px)
+  )
+);

--- a/web/themes/custom/drevops/components/variables.components.scss
+++ b/web/themes/custom/drevops/components/variables.components.scss
@@ -17,3 +17,16 @@ $ct-divider-light-background-color: ct-color-light('background-light') !default;
 $ct-divider-dark-background-color: ct-color-dark('background') !default;
 $ct-divider-light-border-color: ct-color-light('border-light') !default;
 $ct-divider-dark-border-color: ct-color-dark('border') !default;
+
+//
+// Banner.
+//
+$ct-banner-intro-min-height: 50vh !default;
+$ct-banner-decorative-mobile-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(2)}), 0% 100%) !default;
+$ct-banner-decorative-desktop-clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - #{ct-spacing(6)}), 0% 100%) !default;
+$ct-banner-featured-image-width: 40% !default;
+$ct-banner-featured-image-clip-path: polygon(13% 10%, 100% 0, 100% 100%, 0% 100%) !default;
+$ct-banner-light-background-color: ct-color-light('background') !default;
+$ct-banner-light-featured-image-shadow-color: ct-color-light('background-light') !default;
+$ct-banner-dark-background-color: ct-color-dark('background') !default;
+$ct-banner-dark-featured-image-shadow-color: ct-color-dark('background') !default;

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -7,10 +7,9 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/includes/banner.inc';
 require_once __DIR__ . '/includes/paragraphs.inc';
 require_once __DIR__ . '/includes/divider.inc';
-
-use Drupal\civictheme\CivicthemeConstants;
 
 /**
  * Implements hook_preprocess_HOOK() for container templates.
@@ -31,39 +30,4 @@ function drevops_preprocess_civictheme_tag_list(array &$variables): void {
  */
 function drevops_preprocess_block(array &$variables): void {
   _drevops_preprocess_block__civictheme_banner($variables);
-}
-
-/**
- * Pre-process for Banner block.
- *
- * 3 parts:
- * 1. Properties from the block.
- * 2. Properties from the node that may override properties from the block.
- * 3. Cache tags.
- *
- * @SuppressWarnings(PHPMD.StaticAccess)
- * @SuppressWarnings(PHPMD.CyclomaticComplexity)
- * @SuppressWarnings(PHPMD.NPathComplexity)
- *
- * @see _civictheme_preprocess_block__civictheme_banner()
- */
-function _drevops_preprocess_block__civictheme_banner(array &$variables): void {
-  if ($variables['base_plugin_id'] !== 'block_content') {
-    return;
-  }
-
-  $block = $variables['elements']['content']['#block_content'];
-  if ($block->bundle() !== 'civictheme_banner' || ($block->hasField('field_c_b_type') && $block->field_c_b_type->isEmpty())) {
-    return;
-  }
-
-  // Finds a banner type.
-  $banner_type = civictheme_get_field_value($block, 'field_c_b_banner_type', TRUE, CivicthemeConstants::BANNER_TYPE_DEFAULT);
-  $route_match = \Drupal::routeMatch();
-  $node = $route_match->getParameter('node_revision') ?: $route_match->getParameter('node');
-  if (!empty($node)) {
-    $banner_type = civictheme_get_field_value($node, 'field_c_n_banner_type', TRUE, CivicthemeConstants::INHERIT);
-  }
-
-  $variables['banner_type'] = $banner_type;
 }

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -11,7 +11,6 @@ require_once __DIR__ . '/includes/paragraphs.inc';
 require_once __DIR__ . '/includes/divider.inc';
 
 use Drupal\civictheme\CivicthemeConstants;
-use Drupal\Component\Utility\Html;
 
 /**
  * Implements hook_preprocess_HOOK() for container templates.
@@ -49,21 +48,22 @@ function drevops_preprocess_block(array &$variables): void {
  * @see _civictheme_preprocess_block__civictheme_banner()
  */
 function _drevops_preprocess_block__civictheme_banner(array &$variables): void {
-  if ($variables['base_plugin_id'] != 'block_content') {
+  if ($variables['base_plugin_id'] !== 'block_content') {
     return;
   }
 
   $block = $variables['elements']['content']['#block_content'];
-  if ($block->bundle() != 'civictheme_banner' || ($block->hasField('field_c_b_type') && $block->field_c_b_type->isEmpty())) {
+  if ($block->bundle() !== 'civictheme_banner' || ($block->hasField('field_c_b_type') && $block->field_c_b_type->isEmpty())) {
     return;
   }
 
   // Finds a banner type.
   $banner_type = civictheme_get_field_value($block, 'field_c_b_banner_type', TRUE, CivicthemeConstants::BANNER_TYPE_DEFAULT);
-  $node = \Drupal::routeMatch()->getParameter('node_revision') ?: \Drupal::routeMatch()->getParameter('node');
+  $route_match = \Drupal::routeMatch();
+  $node = $route_match->getParameter('node_revision') ?: $route_match->getParameter('node');
   if (!empty($node)) {
     $banner_type = civictheme_get_field_value($node, 'field_c_n_banner_type', TRUE, CivicthemeConstants::INHERIT);
   }
 
-  $variables['modifier_class'] = Html::cleanCssIdentifier('drevops-block--' . $banner_type);
+  $variables['banner_type'] = $banner_type;
 }

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -6,6 +6,7 @@
  */
 
 declare(strict_types=1);
+
 use Drupal\civictheme\CivicthemeConstants;
 use Drupal\Component\Utility\Html;
 

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -6,6 +6,8 @@
  */
 
 declare(strict_types=1);
+use Drupal\civictheme\CivicthemeConstants;
+use Drupal\Component\Utility\Html;
 
 /**
  * Implements hook_preprocess_HOOK() for container templates.
@@ -19,4 +21,45 @@ function drevops_preprocess_container(array &$variables): void {
  */
 function drevops_preprocess_civictheme_tag_list(array &$variables): void {
   $variables['attributes']['class'][] = 'container';
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function drevops_preprocess_block(array &$variables): void {
+  _drevops_preprocess_block__civictheme_banner($variables);
+}
+
+/**
+ * Pre-process for Banner block.
+ *
+ * 3 parts:
+ * 1. Properties from the block.
+ * 2. Properties from the node that may override properties from the block.
+ * 3. Cache tags.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ * @SuppressWarnings(PHPMD.NPathComplexity)
+ *
+ * @see _civictheme_preprocess_block__civictheme_banner()
+ */
+function _drevops_preprocess_block__civictheme_banner(array &$variables): void {
+  if ($variables['base_plugin_id'] != 'block_content') {
+    return;
+  }
+
+  $block = $variables['elements']['content']['#block_content'];
+  if ($block->bundle() != 'civictheme_banner' || ($block->hasField('field_c_b_type') && $block->field_c_b_type->isEmpty())) {
+    return;
+  }
+
+  // Finds a banner type.
+  $banner_type = civictheme_get_field_value($block, 'field_c_b_banner_type', TRUE, CivicthemeConstants::BANNER_TYPE_DEFAULT);
+  $node = \Drupal::routeMatch()->getParameter('node_revision') ?: \Drupal::routeMatch()->getParameter('node');
+  if (!empty($node)) {
+    $banner_type = civictheme_get_field_value($node, 'field_c_n_banner_type', TRUE, CivicthemeConstants::INHERIT);
+  }
+
+  $variables['modifier_class'] = Html::cleanCssIdentifier('drevops-block--' . $banner_type);
 }

--- a/web/themes/custom/drevops/includes/banner.inc
+++ b/web/themes/custom/drevops/includes/banner.inc
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * DrevOps Banner paragraph component.
+ */
+
+declare(strict_types=1);
+
+use Drupal\civictheme\CivicthemeConstants;
+
+/**
+ * Pre-process for Banner block.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ * @SuppressWarnings(PHPMD.NPathComplexity)
+ *
+ * @see _civictheme_preprocess_block__civictheme_banner()
+ * @see https://www.drupal.org/project/civictheme/issues/3525185
+ */
+function _drevops_preprocess_block__civictheme_banner(array &$variables): void {
+  if ($variables['base_plugin_id'] !== 'block_content') {
+    return;
+  }
+
+  $block = $variables['elements']['content']['#block_content'];
+  if ($block->bundle() !== 'civictheme_banner' || ($block->hasField('field_c_b_type') && $block->field_c_b_type->isEmpty())) {
+    return;
+  }
+
+  // Finds a banner type.
+  $type = civictheme_get_field_value($block, 'field_c_b_banner_type', TRUE, CivicthemeConstants::BANNER_TYPE_DEFAULT);
+  $route_match = \Drupal::routeMatch();
+  $node = $route_match->getParameter('node_revision') ?: $route_match->getParameter('node');
+  if (!empty($node)) {
+    $type = civictheme_get_field_value($node, 'field_c_n_banner_type', TRUE, CivicthemeConstants::INHERIT);
+  }
+
+  $variables['type'] = $type;
+}

--- a/web/themes/custom/drevops/templates/block/block--civictheme-banner--default.html.twig
+++ b/web/themes/custom/drevops/templates/block/block--civictheme-banner--default.html.twig
@@ -1,0 +1,7 @@
+{#
+/**
+ * @file
+ * CivicTheme implementation to display a Banner block.
+ */
+#}
+{% include '@organisms/banner/banner.twig' %}

--- a/web/themes/custom/drevops/templates/block/block--civictheme-banner--default.html.twig
+++ b/web/themes/custom/drevops/templates/block/block--civictheme-banner--default.html.twig
@@ -1,7 +1,0 @@
-{#
-/**
- * @file
- * CivicTheme implementation to display a Banner block.
- */
-#}
-{% include '@organisms/banner/banner.twig' %}


### PR DESCRIPTION
https://trello.com/c/xTfbPidY/190-website-create-intro-banner-variant

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally.

## Changed

1. Added a new option to the Banner Type field.
2. Created a preprocess function for adding extra classes to the Banner twig template.
3. Added some styles.

## Screenshots
![image](https://github.com/user-attachments/assets/60c39e7c-00ee-42cb-aff2-f50327764493)
![image](https://github.com/user-attachments/assets/0da53b36-cffe-4dbf-9da0-e8d080852aa2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Intro" banner type option for content blocks and nodes.
  - Added a responsive, theme-aware Banner component with decorative and "Intro" variants, supporting background and featured images, breadcrumbs, and multiple content areas.
  - Integrated new Storybook stories and sample data for the Banner component in both light and dark themes.

- **Style**
  - Implemented comprehensive SCSS styles and new typography variables for the Banner component, ensuring consistent spacing, heading styles, and responsive layouts.

- **Chores**
  - Enhanced theme preprocessing to support dynamic banner type selection based on context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->