### PR TITLE
[#77] Enabled paragraphs library.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "drupal/devel": "^5.3.1",
         "drupal/diff": "^1.8",
         "drupal/entity_clone": "^2.1@beta",
+        "drupal/entity_usage": "^2.0@beta",
         "drupal/environment_indicator": "^4.0.21",
         "drupal/field_group": "^3.6",
         "drupal/gin": "^4.0.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a74b4ab1732b98861c318792c1f8a85",
+    "content-hash": "b9e9fd2bb0a41b9a38ab53d88bf9e663",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2882,6 +2882,79 @@
             "homepage": "https://www.drupal.org/project/entity_reference_revisions",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_reference_revisions"
+            }
+        },
+        {
+            "name": "drupal/entity_usage",
+            "version": "2.0.0-beta24",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_usage.git",
+                "reference": "8.x-2.0-beta24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta24.zip",
+                "reference": "8.x-2.0-beta24",
+                "shasum": "063cf50d2b5cf7c99bb86a818c03fcfef2082151"
+            },
+            "require": {
+                "drupal/core": "^10.2 || ^11"
+            },
+            "require-dev": {
+                "drupal/block_field": "~1.0",
+                "drupal/dynamic_entity_reference": "~1.0 || ^2.0 || ^4.0",
+                "drupal/entity_browser": "~2.0",
+                "drupal/entity_browser_block": "~1.0 || ^2.0",
+                "drupal/entity_embed": "^1.7",
+                "drupal/entity_reference_revisions": "~1.0",
+                "drupal/inline_entity_form": "^1.0@RC || ^3.0@RC",
+                "drupal/paragraphs": "~1.0",
+                "drupal/redirect": "^1.11",
+                "drupal/webform": "^6.0.0-alpha4"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.0-beta24",
+                    "datestamp": "1743745774",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10 || ^11"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "lullabot",
+                    "homepage": "https://www.drupal.org/user/3815489"
+                },
+                {
+                    "name": "marcoscano",
+                    "homepage": "https://www.drupal.org/user/1288796"
+                },
+                {
+                    "name": "seanb",
+                    "homepage": "https://www.drupal.org/user/545912"
+                }
+            ],
+            "description": "Track usage of entities referenced by other entities",
+            "homepage": "https://www.drupal.org/project/entity_usage",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/entity_usage",
+                "issues": "http://drupal.org/project/issues/entity_usage"
             }
         },
         {
@@ -17975,7 +18048,8 @@
     "stability-flags": {
         "drupal/config_update": 15,
         "drupal/core-dev": 10,
-        "drupal/entity_clone": 10
+        "drupal/entity_clone": 10,
+        "drupal/entity_usage": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/default/core.base_field_override.paragraphs_library_item.paragraphs_library_item.paragraphs.yml
+++ b/config/default/core.base_field_override.paragraphs_library_item.paragraphs_library_item.paragraphs.yml
@@ -1,10 +1,8 @@
-uuid: 14a6fc58-7878-47af-b222-67465ca0cf35
+uuid: ab07191f-38d4-40c8-8786-5e0a58db88f4
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_c_n_components
-    - node.type.civictheme_page
     - paragraphs.paragraphs_type.civictheme_accordion
     - paragraphs.paragraphs_type.civictheme_attachment
     - paragraphs.paragraphs_type.civictheme_automated_list
@@ -19,31 +17,29 @@ dependencies:
     - paragraphs.paragraphs_type.civictheme_slider
     - paragraphs.paragraphs_type.civictheme_webform
     - paragraphs.paragraphs_type.divider
-    - paragraphs.paragraphs_type.from_library
   module:
     - entity_reference_revisions
-_core:
-  default_config_hash: ND7O8Cg5A_hCWvV1fcxdc4FWG4_DRnFtuPLvTJpTgLM
-id: node.civictheme_page.field_c_n_components
-field_name: field_c_n_components
-entity_type: node
-bundle: civictheme_page
-label: Components
+    - paragraphs_library
+id: paragraphs_library_item.paragraphs_library_item.paragraphs
+field_name: paragraphs
+entity_type: paragraphs_library_item
+bundle: paragraphs_library_item
+label: Paragraphs
 description: ''
-required: false
-translatable: false
+required: true
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      civictheme_content: civictheme_content
       civictheme_accordion: civictheme_accordion
       civictheme_attachment: civictheme_attachment
       civictheme_automated_list: civictheme_automated_list
       civictheme_callout: civictheme_callout
       civictheme_campaign: civictheme_campaign
+      civictheme_content: civictheme_content
       civictheme_iframe: civictheme_iframe
       civictheme_manual_list: civictheme_manual_list
       civictheme_map: civictheme_map
@@ -52,100 +48,99 @@ settings:
       civictheme_slider: civictheme_slider
       civictheme_webform: civictheme_webform
       divider: divider
-      from_library: from_library
     negate: 0
     target_bundles_drag_drop:
       civictheme_accordion:
-        weight: -58
+        weight: 32
         enabled: true
       civictheme_accordion_panel:
-        weight: -44
+        weight: 33
         enabled: false
       civictheme_attachment:
-        weight: -57
+        weight: 34
         enabled: true
       civictheme_automated_list:
-        weight: -56
+        weight: 35
         enabled: true
       civictheme_callout:
-        weight: -55
+        weight: 36
         enabled: true
       civictheme_campaign:
-        weight: -54
+        weight: 37
         enabled: true
       civictheme_content:
-        weight: -59
+        weight: 38
         enabled: true
       civictheme_event_card:
-        weight: -39
+        weight: 39
         enabled: false
       civictheme_event_card_ref:
-        weight: -38
+        weight: 40
         enabled: false
       civictheme_iframe:
-        weight: -53
+        weight: 41
         enabled: true
       civictheme_manual_list:
-        weight: -52
+        weight: 42
         enabled: true
       civictheme_map:
-        weight: -51
+        weight: 43
         enabled: true
       civictheme_navigation_card:
-        weight: -43
+        weight: 44
         enabled: false
       civictheme_navigation_card_ref:
-        weight: -37
+        weight: 45
         enabled: false
       civictheme_next_step:
-        weight: -50
+        weight: 46
         enabled: true
       civictheme_promo:
-        weight: -48
+        weight: 47
         enabled: true
       civictheme_promo_card:
-        weight: -42
+        weight: 48
         enabled: false
       civictheme_promo_card_ref:
-        weight: -40
+        weight: 49
         enabled: false
       civictheme_publication_card:
-        weight: -33
+        weight: 50
         enabled: false
       civictheme_service_card:
-        weight: -41
+        weight: 51
         enabled: false
       civictheme_slider:
-        weight: -47
+        weight: 52
         enabled: true
       civictheme_slider_slide:
-        weight: -45
+        weight: 53
         enabled: false
       civictheme_slider_slide_ref:
-        weight: -32
-        enabled: false
-      civictheme_snippet:
         weight: 54
         enabled: false
-      civictheme_snippet_ref:
+      civictheme_snippet:
         weight: 55
         enabled: false
+      civictheme_snippet_ref:
+        weight: 56
+        enabled: false
       civictheme_social_icon:
-        weight: -31
+        weight: 57
         enabled: false
       civictheme_subject_card:
-        weight: -36
+        weight: 58
         enabled: false
       civictheme_subject_card_ref:
-        weight: -35
+        weight: 59
         enabled: false
       civictheme_webform:
-        weight: -46
+        weight: 60
         enabled: true
       divider:
-        weight: 60
+        weight: 61
         enabled: true
       from_library:
         weight: 62
-        enabled: true
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/default/core.entity_form_display.paragraph.from_library.default.yml
+++ b/config/default/core.entity_form_display.paragraph.from_library.default.yml
@@ -1,0 +1,28 @@
+uuid: 9c181c91-9a64-4c3d-9f5f-781dc3c43bdd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.from_library.field_reusable_paragraph
+    - paragraphs.paragraphs_type.from_library
+_core:
+  default_config_hash: Bea-FFbHlBuiYLW8Et0hLK6VNECewxpIchDbOtC7IDo
+id: paragraph.from_library.default
+targetEntityType: paragraph
+bundle: from_library
+mode: default
+content:
+  field_reusable_paragraph:
+    type: entity_reference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/config/default/core.entity_view_display.paragraph.from_library.default.yml
+++ b/config/default/core.entity_view_display.paragraph.from_library.default.yml
@@ -1,0 +1,25 @@
+uuid: e2b9adf9-8934-4d55-9e68-15c03a361d60
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.from_library.field_reusable_paragraph
+    - paragraphs.paragraphs_type.from_library
+_core:
+  default_config_hash: cwuIPYXF5vCbzfY8wjj_shzx513Cwc122DIqGh2Uqho
+id: paragraph.from_library.default
+targetEntityType: paragraph
+bundle: from_library
+mode: default
+content:
+  field_reusable_paragraph:
+    type: entity_reference_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraphs_library_item.paragraphs_library_item.summary.yml
+++ b/config/default/core.entity_view_display.paragraphs_library_item.paragraphs_library_item.summary.yml
@@ -1,0 +1,34 @@
+uuid: 9ca751b4-dde1-4156-82d4-2a9e754efadf
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraphs_library_item.summary
+  module:
+    - paragraphs_library
+_core:
+  default_config_hash: XstmA6WDBHCnXqwpkJ4hDHdn8ELRpS3gIl9yxbsjIyM
+id: paragraphs_library_item.paragraphs_library_item.summary
+targetEntityType: paragraphs_library_item
+bundle: paragraphs_library_item
+mode: summary
+content:
+  label:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  paragraphs:
+    type: library_item_summary
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  content_moderation_control: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_mode.paragraphs_library_item.summary.yml
+++ b/config/default/core.entity_view_mode.paragraphs_library_item.summary.yml
@@ -1,0 +1,13 @@
+uuid: 661b06ad-fcea-478e-a8e7-c3a4eab20d80
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs_library
+_core:
+  default_config_hash: _YqHTUZ5t7SWq5sE0bJwbSNH9CaL_KIbwu-rURJ6sXo
+id: paragraphs_library_item.summary
+label: Summary
+description: null
+targetEntityType: paragraphs_library_item
+cache: true

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -30,6 +30,7 @@ module:
   editor: 0
   entity_clone: 0
   entity_reference_revisions: 0
+  entity_usage: 0
   environment_indicator: 0
   field: 0
   field_group: 0
@@ -64,6 +65,7 @@ module:
   node: 0
   options: 0
   page_cache: 0
+  paragraphs_library: 0
   path: 0
   path_alias: 0
   recaptcha_v3: 0

--- a/config/default/entity_clone.cloneable_entities.yml
+++ b/config/default/entity_clone.cloneable_entities.yml
@@ -60,3 +60,4 @@ cloneable_entities:
   - entity_view_mode
   - entity_form_display
   - scheduled_transition
+  - paragraphs_library_item

--- a/config/default/entity_usage.settings.yml
+++ b/config/default/entity_usage.settings.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: AXUBMTvVtpcNp0jKjDaWjSHqMy6HjuUf7j4yVbXgazI
+local_task_enabled_entity_types:
+  - paragraphs_library_item
+track_enabled_base_fields: false
+edit_warning_message_entity_types:
+  - paragraphs_library_item
+delete_warning_message_entity_types:
+  - paragraphs_library_item
+usage_controller_items_per_page: 25

--- a/config/default/field.field.paragraph.from_library.field_reusable_paragraph.yml
+++ b/config/default/field.field.paragraph.from_library.field_reusable_paragraph.yml
@@ -1,0 +1,27 @@
+uuid: 473524a9-4730-4544-a4f7-e2ec3c05ee9b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_reusable_paragraph
+    - paragraphs.paragraphs_type.from_library
+_core:
+  default_config_hash: z_H_kCDBkuITFi-RGZRiO8Ps2UxRDucMs7Dhan7d6yw
+id: paragraph.from_library.field_reusable_paragraph
+field_name: field_reusable_paragraph
+entity_type: paragraph
+bundle: from_library
+label: 'Reusable paragraph'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraphs_library_item'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/config/default/field.storage.paragraph.field_reusable_paragraph.yml
+++ b/config/default/field.storage.paragraph.field_reusable_paragraph.yml
@@ -1,0 +1,22 @@
+uuid: 9454e53d-cf62-4cd4-9733-7c5cfb2a94c8
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - paragraphs_library
+_core:
+  default_config_hash: hDS2MWDM66Mj8WBDs5oWMyh0JQ9NTZEa_jZGJBwZW1Q
+id: paragraph.field_reusable_paragraph
+field_name: field_reusable_paragraph
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: paragraphs_library_item
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/paragraphs.paragraphs_type.from_library.yml
+++ b/config/default/paragraphs.paragraphs_type.from_library.yml
@@ -1,0 +1,15 @@
+uuid: 9dd6f390-7a3f-40b5-859f-7187743b9b1d
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - paragraphs_library
+_core:
+  default_config_hash: RGSkW7xbQQkzNrGunBWMSKS6lacu7KsgZjVWGVUF0xY
+id: from_library
+label: 'From library'
+icon_uuid: null
+icon_default: null
+description: null
+behavior_plugins: {  }

--- a/config/default/views.view.paragraphs_library.yml
+++ b/config/default/views.view.paragraphs_library.yml
@@ -1,0 +1,855 @@
+uuid: 95a1f42d-55d6-4d2f-a502-fc717c561ff2
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_usage
+    - paragraphs
+    - paragraphs_library
+    - user
+_core:
+  default_config_hash: 67G2lyvlXJE8P8b1oAheELEdM5i74aipXfDIZCpAsdQ
+id: paragraphs_library
+label: 'Paragraphs library'
+module: views
+description: ''
+tag: ''
+base_table: paragraphs_library_item_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Paragraphs library'
+      fields:
+        label:
+          id: label
+          table: paragraphs_library_item_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          entity_field: label
+          plugin_id: field
+          label: Label
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: paragraphs_item_field_data
+          field: type
+          relationship: paragraphs__target_id
+          group_type: group
+          admin_label: ''
+          entity_type: paragraph
+          entity_field: type
+          plugin_id: field
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        paragraphs__target_id:
+          id: paragraphs__target_id
+          table: paragraphs_library_item_field_data
+          field: paragraphs__target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          entity_field: paragraphs
+          plugin_id: field
+          label: Paragraphs
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: paragraph_summary
+          settings: {  }
+          group_column: entity_id
+          group_columns:
+            target_id: target_id
+            target_revision_id: target_revision_id
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        langcode:
+          id: langcode
+          table: paragraphs_library_item_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          entity_field: langcode
+          plugin_id: field
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        id:
+          id: id
+          table: paragraphs_library_item_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          entity_field: id
+          plugin_id: field
+          label: ID
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: entity_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        count:
+          id: count
+          table: entity_usage
+          field: count
+          relationship: paragraphs_library_item_to_usage_entity
+          group_type: count
+          admin_label: ''
+          plugin_id: numeric
+          label: Used
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: 'admin/content/entity-usage/paragraphs_library_item/{{ id }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: false
+          format_plural_string: !!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz
+          prefix: ''
+          suffix: ''
+        changed:
+          id: changed
+          table: paragraphs_library_item_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          entity_field: changed
+          plugin_id: field
+          label: Changed
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: entity_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        operations:
+          id: operations
+          table: paragraphs_library_item
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          plugin_id: entity_operations
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer paragraphs library'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No library items available.'
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
+      filters:
+        label:
+          id: label
+          table: paragraphs_library_item_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          entity_field: label
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: label_op
+            label: Label
+            description: ''
+            use_operator: false
+            operator: label_op
+            identifier: label
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: Label
+            description: null
+            identifier: label
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+        type:
+          id: type
+          table: paragraphs_item_field_data
+          field: type
+          relationship: paragraphs__target_id
+          group_type: group
+          admin_label: ''
+          entity_type: paragraph
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        default_langcode:
+          id: default_langcode
+          table: paragraphs_library_item_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: paragraphs_library_item
+          entity_field: default_langcode
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        default_langcode_1:
+          id: default_langcode_1
+          table: paragraphs_item_field_data
+          field: default_langcode
+          relationship: paragraphs__target_id
+          group_type: group
+          admin_label: ''
+          entity_type: paragraph
+          entity_field: default_langcode
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            label: label
+            type: type
+            id: id
+            count: count
+            operations: operations
+          default: '-1'
+          info:
+            label:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            count:
+              sortable: false
+              default_sort_order: asc
+              align: views-align-right
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        paragraphs__target_id:
+          id: paragraphs__target_id
+          table: paragraphs_library_item_field_data
+          field: paragraphs__target_id
+          relationship: none
+          group_type: group
+          admin_label: Paragraphs
+          entity_type: paragraphs_library_item
+          entity_field: paragraphs
+          plugin_id: standard
+          required: true
+        paragraphs_library_item_to_usage_entity:
+          id: paragraphs_library_item_to_usage_entity
+          table: paragraphs_library_item
+          field: paragraphs_library_item_to_usage_entity
+          relationship: none
+          group_type: group
+          admin_label: 'Usage information (Paragraphs library item)'
+          entity_type: paragraphs_library_item
+          plugin_id: standard
+          required: false
+      group_by: true
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/paragraphs
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }


### PR DESCRIPTION
closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Paragraphs Library, enabling the creation, management, and reuse of paragraph components.
  * Added a new "From library" paragraph type for referencing reusable content.
  * Provided an administrative view for managing library items at `/admin/content/paragraphs`.
  * Enabled entity usage tracking and warnings for library items.
  * Allowed cloning of paragraph library items.

* **Configuration**
  * Updated field and form display settings to support the new library features.
  * Added new view and display modes for summarizing and managing library items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->