### PR TITLE
[#79] Fixed moderation block going edge-to-edge.

### DIFF
--- a/tests/behat/features/content_moderation_container.feature
+++ b/tests/behat/features/content_moderation_container.feature
@@ -1,0 +1,14 @@
+Feature: Content moderation block container class
+
+  As a site administrator
+  I want to ensure the moderation block has proper container styling
+  So that it displays correctly when the sidebar is missing
+
+  @api
+  Scenario: Moderation block has container class
+    Given I am logged in as a user with the "administrator" role
+    And "civictheme_page" content:
+      | title           | moderation_state | field_c_n_hide_sidebar |
+      | Test Page Draft | draft            | 1                      |
+    When I visit the "civictheme_page" content page with the title "Test Page Draft"
+    Then I should see a ".block-extra-field-blocknodecivictheme-pagecontent-moderation-control.container" element

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -13,6 +13,7 @@ require_once __DIR__ . '/includes/paragraphs.inc';
 require_once __DIR__ . '/includes/divider.inc';
 require_once __DIR__ . '/includes/manual_list.inc';
 require_once __DIR__ . '/includes/page.inc';
+require_once __DIR__ . '/includes/content_moderation.inc';
 
 /**
  * Implements hook_preprocess_HOOK() for container templates.
@@ -34,6 +35,7 @@ function drevops_preprocess_civictheme_tag_list(array &$variables): void {
 function drevops_preprocess_block(array &$variables): void {
   _drevops_preprocess_block__system_main_block($variables);
   _drevops_preprocess_block__civictheme_banner($variables);
+  _drevops_preprocess_block__content_moderation_control($variables);
 }
 
 /**

--- a/web/themes/custom/drevops/includes/content_moderation.inc
+++ b/web/themes/custom/drevops/includes/content_moderation.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Content moderation block preprocessing.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_preprocess_block() for content moderation control block.
+ *
+ * Adds container class to prevent edge-to-edge display when sidebar is hidden.
+ */
+function _drevops_preprocess_block__content_moderation_control(array &$variables): void {
+  if (!isset($variables['plugin_id']) || !str_contains($variables['plugin_id'], 'content_moderation_control')) {
+    return;
+  }
+
+  $variables['attributes']['class'][] = 'container';
+}


### PR DESCRIPTION
closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content moderation blocks now include a container class for improved display when the sidebar is hidden.

* **Tests**
  * Added a test to verify the content moderation block renders correctly with the container class in hidden sidebar scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->