### PR TITLE
Fixed GitHub notifications fail on unfinished status checks.

### DIFF
--- a/.env
+++ b/.env
@@ -173,7 +173,7 @@ VORTEX_DEPLOY_TYPES=lagoon
 # The channels of the notifications.
 #
 # A combination of comma-separated values: email,newrelic,github,jira
-VORTEX_NOTIFY_CHANNELS=email
+VORTEX_NOTIFY_CHANNELS=email,github
 
 # An email address to send notifications from.
 #

--- a/scripts/vortex/notify-github.sh
+++ b/scripts/vortex/notify-github.sh
@@ -89,7 +89,7 @@ if [ "${VORTEX_NOTIFY_EVENT}" = "pre_deployment" ]; then
     -H "Accept: application/vnd.github.v3+json" \
     -s \
     "https://api.github.com/repos/${VORTEX_NOTIFY_REPOSITORY}/deployments" \
-    -d "{\"ref\":\"${VORTEX_NOTIFY_BRANCH}\", \"environment\": \"${VORTEX_NOTIFY_ENVIRONMENT_TYPE}\", \"auto_merge\": false}")"
+    -d "{\"ref\":\"${VORTEX_NOTIFY_BRANCH}\", \"environment\": \"${VORTEX_NOTIFY_ENVIRONMENT_TYPE}\", \"auto_merge\": false, \"required_contexts\": []}")"
 
   deployment_id="$(echo "${payload}" | extract_json_value "id" || true)"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment creation no longer requires status check contexts, so deployments can be created even when CI checks are pending.
  * Releases may appear in target environments sooner due to reduced gating.
* **New Features**
  * Notification channels expanded to include GitHub in addition to existing email, enabling deployment-related notifications to GitHub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->