### PR TITLE
Added support for `DRUPAL_TRUSTED_HOSTS`.

### DIFF
--- a/.env
+++ b/.env
@@ -54,6 +54,14 @@ DRUPAL_THEME=drevops
 # Drupal maintenance theme name.
 DRUPAL_MAINTENANCE_THEME=drevops
 
+# Trusted host patterns.
+#
+# Comma-separated list of domains for trusted host patterns. These domains will
+# be added to the trusted host patterns alongside any other routes defined by
+# the hosting provider.
+# Example: yourdomain.com,www.yourdomain.com,cdn.yourdomain.com
+DRUPAL_TRUSTED_HOSTS=drevops.com,www.drevops.com
+
 # Stage file proxy origin.
 #
 # If using Shield, the HTTP authentication credentials will be automatically

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ x-environment: &default-environment
   DATABASE_COLLATION: utf8mb4_general_ci
   # Drupal theme name.
   DRUPAL_THEME: ${DRUPAL_THEME:-}
+  # Trusted host patterns.
+  DRUPAL_TRUSTED_HOSTS: ${DRUPAL_TRUSTED_HOSTS:-}
   # Drupal file paths.
   DRUPAL_PUBLIC_FILES: ${DRUPAL_PUBLIC_FILES:-sites/default/files}
   DRUPAL_PRIVATE_FILES: ${DRUPAL_PRIVATE_FILES:-sites/default/files/private}

--- a/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -730,4 +730,100 @@ class SwitchableSettingsTest extends SettingsTestCase {
     ];
   }
 
+  /**
+   * Test trusted host patterns settings.
+   */
+  #[DataProvider('dataProviderTrustedHostPatterns')]
+  public function testTrustedHostPatterns(array $vars, array $expected_patterns): void {
+    $this->setEnvVars($vars);
+
+    $this->requireSettingsFile();
+
+    $this->assertSame($expected_patterns, $this->settings['trusted_host_patterns']);
+  }
+
+  /**
+   * Data provider for testTrustedHostPatterns().
+   */
+  public static function dataProviderTrustedHostPatterns(): array {
+    return [
+      'empty environment variable' => [
+        [],
+        [
+          '^localhost$',
+        ],
+      ],
+      'single domain' => [
+        ['DRUPAL_TRUSTED_HOSTS' => 'example.com'],
+        [
+          '^localhost$',
+          '^example\.com$',
+        ],
+      ],
+      'multiple domains' => [
+        ['DRUPAL_TRUSTED_HOSTS' => 'example.com,www.example.com,cdn.example.org'],
+        [
+          '^localhost$',
+          '^example\.com$',
+          '^www\.example\.com$',
+          '^cdn\.example\.org$',
+        ],
+      ],
+      'whitespace and empty values' => [
+        ['DRUPAL_TRUSTED_HOSTS' => ' example.com , , www.example.com '],
+        [
+          '^localhost$',
+          '^example\.com$',
+          '^www\.example\.com$',
+        ],
+      ],
+      'special regex characters' => [
+        ['DRUPAL_TRUSTED_HOSTS' => 'sub-domain.example.com,test.example-site.org'],
+        [
+          '^localhost$',
+          '^sub\-domain\.example\.com$',
+          '^test\.example\-site\.org$',
+        ],
+      ],
+      'complex domains' => [
+        ['DRUPAL_TRUSTED_HOSTS' => 'api.v2.example.com,cdn-assets.example-site.co.uk'],
+        [
+          '^localhost$',
+          '^api\.v2\.example\.com$',
+          '^cdn\-assets\.example\-site\.co\.uk$',
+        ],
+      ],
+      'duplicates' => [
+        ['DRUPAL_TRUSTED_HOSTS' => 'example.com,test.org,example.com,another.com,test.org'],
+        [
+          '^localhost$',
+          '^example\.com$',
+          '^test\.org$',
+          '^example\.com$',
+          '^another\.com$',
+          '^test\.org$',
+        ],
+      ],
+      'uppercase hosts' => [
+        ['DRUPAL_TRUSTED_HOSTS' => 'EXAMPLE.COM,Test.ORG,www.EXAMPLE-SITE.CO.UK'],
+        [
+          '^localhost$',
+          '^example\.com$',
+          '^test\.org$',
+          '^www\.example\-site\.co\.uk$',
+        ],
+      ],
+      'explicit localhost' => [
+        ['DRUPAL_TRUSTED_HOSTS' => 'localhost,example.com,localhost,test.org'],
+        [
+          '^localhost$',
+          '^localhost$',
+          '^example\.com$',
+          '^localhost$',
+          '^test\.org$',
+        ],
+      ],
+    ];
+  }
+
 }

--- a/web/sites/default/includes/modules/settings.trusted_hosts.php
+++ b/web/sites/default/includes/modules/settings.trusted_hosts.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Trusted host patterns settings.
+ *
+ * Provides custom domain support for trusted host patterns when CDN is in
+ * front of Lagoon or when custom domains need to be explicitly trusted.
+ */
+
+declare(strict_types=1);
+
+// Add custom domains to trusted host patterns if specified.
+$trusted_hosts = getenv('DRUPAL_TRUSTED_HOSTS');
+if (!empty($trusted_hosts)) {
+  $domains = array_map('trim', explode(',', $trusted_hosts));
+  foreach ($domains as $domain) {
+    if (!empty($domain)) {
+      $domain = strtolower($domain);
+      $escaped_domain = preg_quote($domain, '/');
+      $settings['trusted_host_patterns'][] = '^' . $escaped_domain . '$';
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure a comma-separated list of trusted hostnames via a new environment variable, applied across environments (including Docker) with sensible defaults.

* **Documentation**
  * Added examples and comments in environment configuration showing how to set trusted hosts.

* **Tests**
  * Added automated tests validating parsing, trimming, escaping and pattern generation for trusted hostnames, including edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->