### PR TITLE
Added exclusions to shield.

### DIFF
--- a/tests/phpunit/Drupal/EnvironmentSettingsTest.php
+++ b/tests/phpunit/Drupal/EnvironmentSettingsTest.php
@@ -260,6 +260,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = TRUE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $this->assertConfig($config);
 
@@ -331,6 +333,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = TRUE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.performance']['cache']['page']['max_age'] = 1800;
     $this->assertConfig($config);
 
@@ -379,6 +383,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['purge_control.settings']['purge_auto_control'] = FALSE;
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = FALSE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.logging']['error_level'] = 'all';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $config['seckit.settings']['seckit_xss']['csp']['upgrade-req'] = FALSE;
@@ -428,6 +434,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['purge_control.settings']['purge_auto_control'] = FALSE;
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = FALSE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.logging']['error_level'] = 'all';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $config['seckit.settings']['seckit_xss']['csp']['upgrade-req'] = FALSE;
@@ -479,6 +487,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['purge_control.settings']['purge_auto_control'] = FALSE;
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = FALSE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $config['seckit.settings']['seckit_xss']['csp']['upgrade-req'] = FALSE;
     $this->assertConfig($config);
@@ -529,6 +539,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = TRUE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $this->assertConfig($config);
 
@@ -581,6 +593,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = TRUE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $this->assertConfig($config);
 
@@ -633,6 +647,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
     $config['robots_txt.settings']['content'] = "User-agent: *\r\nDisallow:";
     $config['shield.settings']['shield_enable'] = TRUE;
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $this->assertConfig($config);
 
@@ -683,6 +699,8 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['environment_indicator.indicator']['name'] = static::ENVIRONMENT_PROD;
     $config['environment_indicator.settings']['favicon'] = TRUE;
     $config['environment_indicator.settings']['toolbar_integration'] = [TRUE];
+    $config['shield.settings']['method'] = 0;
+    $config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $config['system.performance']['css']['preprocess'] = TRUE;
     $config['system.performance']['js']['preprocess'] = TRUE;

--- a/tests/phpunit/Drupal/SwitchableSettingsTest.php
+++ b/tests/phpunit/Drupal/SwitchableSettingsTest.php
@@ -348,7 +348,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
         static::ENVIRONMENT_LOCAL,
         [],
         [
-          'shield.settings' => ['shield_enable' => FALSE],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*'],
         ],
         [
           'shield.settings' => ['credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
@@ -360,7 +360,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_USER' => 'drupal_shield_user',
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*'],
         ],
         [
           'shield.settings' => ['credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
@@ -374,7 +374,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_PRINT' => 'drupal_shield_print',
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -386,7 +386,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_PRINT' => 'drupal_shield_print',
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -398,7 +398,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_PRINT' => 'drupal_shield_print',
         ],
         [
-          'shield.settings' => ['shield_enable' => TRUE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => TRUE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -410,7 +410,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_PRINT' => 'drupal_shield_print',
         ],
         [
-          'shield.settings' => ['shield_enable' => TRUE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => TRUE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -422,7 +422,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_PRINT' => 'drupal_shield_print',
         ],
         [
-          'shield.settings' => ['credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
         [
           'shield.settings' => ['shield_enable' => FALSE],
@@ -437,7 +437,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_PRINT' => 'drupal_shield_print',
         ],
         [
-          'shield.settings' => ['shield_enable' => TRUE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => TRUE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -450,7 +450,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => '',
         ],
         [
-          'shield.settings' => ['shield_enable' => TRUE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => TRUE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -463,7 +463,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => 0,
         ],
         [
-          'shield.settings' => ['shield_enable' => TRUE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => TRUE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
       [
@@ -475,7 +475,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => 1,
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -488,7 +488,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => '0',
         ],
         [
-          'shield.settings' => ['shield_enable' => TRUE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => TRUE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
       [
@@ -500,7 +500,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => '1',
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
       [
@@ -512,7 +512,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => 'false',
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
       [
@@ -524,7 +524,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => 'true',
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE, 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*', 'credentials' => ['shield' => ['user' => 'drupal_shield_user', 'pass' => 'drupal_shield_pass']], 'print' => 'drupal_shield_print'],
         ],
       ],
 
@@ -534,7 +534,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => TRUE,
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*'],
         ],
       ],
       [
@@ -543,7 +543,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => TRUE,
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*'],
         ],
       ],
       [
@@ -552,7 +552,7 @@ class SwitchableSettingsTest extends SettingsTestCase {
           'DRUPAL_SHIELD_DISABLED' => TRUE,
         ],
         [
-          'shield.settings' => ['shield_enable' => FALSE],
+          'shield.settings' => ['shield_enable' => FALSE, 'method' => 0, 'paths' => '/.well-known/acme-challenge/*'],
         ],
       ],
     ];

--- a/web/sites/default/includes/modules/settings.shield.php
+++ b/web/sites/default/includes/modules/settings.shield.php
@@ -41,6 +41,10 @@ if (getenv('DRUPAL_SHIELD_PRINT')) {
   $config['shield.settings']['print'] = getenv('DRUPAL_SHIELD_PRINT');
 }
 
+// Allow ACME challenge path for Let's Encrypt certificate generation.
+$config['shield.settings']['method'] = 0;
+$config['shield.settings']['paths'] = '/.well-known/acme-challenge/*';
+
 // Allow to disable Shield completely in the environment.
 if (!empty(getenv('DRUPAL_SHIELD_DISABLED'))) {
   $config['shield.settings']['shield_enable'] = FALSE;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Shield now permits Let's Encrypt ACME HTTP-01 challenge requests by default, allowing certificate issuance without disabling protection.
  - Default allowance includes the ACME challenge path and associated method so certificate workflows succeed transparently.

- Tests
  - PHPUnit expectations updated across environments to include the new Shield defaults for ACME challenges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->