### PR TITLE
Skip code exports if not using artefact deployment types.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Process the codebase to run in CI
         run: find . -name "docker-compose.yml" -print0 | xargs -0 -I {} sh -c "sed -i -e '/###/d' {} && sed -i -e 's/##//' {}"
 
+      - name: Load environment variables from .env
+        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+
       - name: Validate Composer configuration
         run: composer validate --strict
         continue-on-error: ${{ vars.VORTEX_CI_COMPOSER_VALIDATE_IGNORE_FAILURE == '1' }}
@@ -230,7 +233,7 @@ jobs:
         run: docker compose up -d
 
       - name: Export built codebase
-        if: matrix.instance == 0
+        if: matrix.instance == 0 && contains(env.VORTEX_DEPLOY_TYPES, 'artifact')
         run: |
           mkdir -p "/tmp/workspace/code"
           docker compose cp -L cli:"/app/." "/tmp/workspace/code"
@@ -342,7 +345,7 @@ jobs:
 
       - name: Upload exported codebase as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') }}
+        if: ${{ matrix.instance == 0 && !startsWith(github.head_ref || github.ref_name, 'deps/') && contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/workspace/code"
@@ -384,8 +387,12 @@ jobs:
           persist-credentials: false
           ref: ${{ github.head_ref || github.ref_name }}
 
+      - name: Load environment variables from .env
+        run: t=$(mktemp) && export -p >"${t}" && set -a && . ./.env && set +a && . "${t}" && env >> "$GITHUB_ENV"
+
       - name: Download exported codebase as an artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        if: ${{ contains(env.VORTEX_DEPLOY_TYPES, 'artifact') }}
         with:
           name: code-artifact
           path: "/tmp/workspace/code"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to support an optional artifact-based deployment path when configured.
  * Environment variables are now consistently loaded across build and deploy jobs.
  * Artifact upload/download now occurs only for the primary build instance and when artifact deployment is enabled.
  * Build and deploy steps aligned for more predictable, configurable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->