### PR TITLE
Add Information page deployment hook and Behat test

### DIFF
--- a/tests/behat/features/information_page.feature
+++ b/tests/behat/features/information_page.feature
@@ -1,0 +1,20 @@
+@information @smoke
+Feature: Information page
+
+  As a site visitor
+  I want to access the Information page
+  So that I can view information content on the site
+
+  @api
+  Scenario: Anonymous user visits Information page
+    When I visit the "civictheme_page" content page with the title "Information"
+    Then the response status code should be 200
+    And I should see "Information"
+    And I save screenshot
+
+  @api
+  Scenario: Information page is accessible via alias
+    When I go to "/information"
+    Then the response status code should be 200
+    And I should see "Information"
+    And I save screenshot

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -8,3 +8,47 @@
  */
 
 declare(strict_types=1);
+
+use Drupal\node\Entity\Node;
+use Drupal\path_alias\Entity\PathAlias;
+
+/**
+ * Create Information page with civic theme and alias.
+ */
+function do_base_deploy_create_information_page(): void {
+  // Check if page already exists.
+  $existing_nodes = \Drupal::entityTypeManager()
+    ->getStorage('node')
+    ->loadByProperties([
+      'type' => 'civictheme_page',
+      'title' => 'Information',
+    ]);
+
+  if (empty($existing_nodes)) {
+    // Create the node.
+    $node = Node::create([
+      'type' => 'civictheme_page',
+      'title' => 'Information',
+      'status' => 1,
+      'uid' => 1,
+      'body' => [
+        'value' => '',
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+
+    // Create the path alias.
+    $path_alias = PathAlias::create([
+      'path' => '/node/' . $node->id(),
+      'alias' => '/information',
+      'langcode' => 'en',
+    ]);
+    $path_alias->save();
+
+    \Drupal::logger('do_base')->info('Information page created with ID: @id and alias /information', ['@id' => $node->id()]);
+  }
+  else {
+    \Drupal::logger('do_base')->info('Information page already exists, skipping creation');
+  }
+}


### PR DESCRIPTION
## Summary
- Added deployment hook to create Information page with civictheme_page content type
- Created URL alias `/information` for easy access
- Added comprehensive Behat test coverage for page functionality

## Test plan
- [x] Deployment hook runs successfully
- [x] Information page created with correct content type
- [x] URL alias `/information` works correctly  
- [x] Behat tests pass for both direct page access and alias
- [x] Code linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an “Information” page, published by default and accessible at /information and via its content route.

- Tests
  - Added Behat smoke tests verifying the page loads with status 200, displays expected content, and captures screenshots for both routes.

- Chores
  - Added a deployment task to automatically create the Information page and set its friendly URL alias during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->