### PR TITLE
Fixed mobile navigation.

### DIFF
--- a/web/themes/custom/drevops/components/03-organisms/header/header.scss
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.scss
@@ -192,7 +192,10 @@
 
       #{$root}__middle {
         background-color: color-mix(in srgb, ct-component-var($root, $theme, middle, background-color) 80%, transparent);
-        backdrop-filter: blur(0.5rem);
+
+        @include ct-breakpoint($ct-mobile-navigation-breakpoint) {
+          backdrop-filter: blur(0.5rem);
+        }
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Sticky header background blur now applies only at the mobile navigation breakpoint. On small screens the header’s middle section keeps a subtle blur when sticky for contrast; on larger screens the blur is removed for sharper visuals and improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->