### PR TITLE
Removed `allow_html` from custom components.

### DIFF
--- a/web/themes/custom/drevops/components/02-molecules/navigation-card/navigation-card.twig
+++ b/web/themes/custom/drevops/components/02-molecules/navigation-card/navigation-card.twig
@@ -136,7 +136,6 @@
           {% include 'civictheme:paragraph' with {
             theme: theme,
             content: summary,
-            allow_html: true,
             no_margin: true,
             modifier_class: 'ct-navigation-card__summary',
           } only %}

--- a/web/themes/custom/drevops/components/03-organisms/list/list.twig
+++ b/web/themes/custom/drevops/components/03-organisms/list/list.twig
@@ -114,7 +114,6 @@
               <div class="col-xxs-12">
                 {% include 'civictheme:paragraph' with {
                   content: content,
-                  allow_html: true,
                   theme: theme,
                   modifier_class: 'ct-list__content__inner',
                 } only %}
@@ -202,7 +201,6 @@
               <div class="col-xxs-12">
                 {% include 'civictheme:paragraph' with {
                   content: empty,
-                  allow_html: true,
                   theme: theme,
                   modifier_class: 'ct-list__empty-results__inner',
                 } only %}


### PR DESCRIPTION
Related #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed HTML rendering behavior in navigation cards and list components to properly escape content by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->