### PR TITLE
[#112] Fix padding on user routes.

### DIFF
--- a/web/themes/custom/drevops/includes/system_main_block.inc
+++ b/web/themes/custom/drevops/includes/system_main_block.inc
@@ -17,9 +17,20 @@ function _drevops_preprocess_block__system_main_block(array &$variables): void {
 
   $route_match = \Drupal::routeMatch();
   $route_name = $route_match->getRouteName();
-  if ($route_name !== 'user.login' && $route_name !== 'user.pass') {
-    return;
-  }
 
-  $variables['attributes']['class'][] = 'ct-vertical-spacing--both';
+  $routes = [
+    'user.cancel_confirm',
+    'user.login',
+    'user.logout',
+    'user.logout.confirm',
+    'user.pass',
+    'user.register',
+    'user.reset',
+    'user.reset.form',
+    'user.reset.login',
+  ];
+
+  if (in_array($route_name, $routes, TRUE)) {
+    $variables['attributes']['class'][] = 'ct-vertical-spacing--both';
+  }
 }


### PR DESCRIPTION
Closes #112

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally.

## Changed

1. Added vertical spacing to be applied to all user routes.

## Screenshots

<img width="1094" height="545" alt="image" src="https://github.com/user-attachments/assets/64b2312d-0299-4e21-9811-8279d148a9eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of vertical spacing styling by refining which routes receive the spacing class. The block now applies spacing specifically to user account-related routes (login, registration, password reset, etc.) while removing it from other pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->