### PR TITLE
[#132] Add Highlight.js syntax highlighter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "drupal/gin": "^4.0.6",
         "drupal/gin_toolbar": "^2",
         "drupal/google_tag": "^2.0.9",
+        "drupal/highlight_js": "^1.2",
         "drupal/lagoon_logs": "^3.0.1",
         "drupal/metatag": "^2.2",
         "drupal/pathauto": "^1.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce081e63b3639ce500037147a974b7aa",
+    "content-hash": "10f5f7ef2ef52dfff4ae130462216282",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3703,6 +3703,58 @@
             "homepage": "https://www.drupal.org/project/google_tag",
             "support": {
                 "source": "https://git.drupalcode.org/project/google_tag"
+            }
+        },
+        {
+            "name": "drupal/highlight_js",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/highlight_js.git",
+                "reference": "1.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/highlight_js-1.2.0.zip",
+                "reference": "1.2.0",
+                "shasum": "ae389f3a03ee09d4dcb83cd3d731e6910bfe1a5c"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.2.0",
+                    "datestamp": "1763546332",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "a.dmitriiev",
+                    "homepage": "https://www.drupal.org/user/3235287"
+                },
+                {
+                    "name": "norman.lol",
+                    "homepage": "https://www.drupal.org/user/2482808"
+                },
+                {
+                    "name": "sujan shrestha",
+                    "homepage": "https://www.drupal.org/user/3475737"
+                }
+            ],
+            "description": "Adds the HighlightJs plugin to CKEditor 5 with syntax highlighting provided by HighlightJs.",
+            "homepage": "https://www.drupal.org/project/highlight_js",
+            "support": {
+                "source": "https://git.drupalcode.org/project/highlight_js"
             }
         },
         {
@@ -12248,29 +12300,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -12290,9 +12342,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/instantiator",

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -47,6 +47,7 @@ module:
   gin_toolbar: 0
   google_tag: 0
   help: 0
+  highlight_js: 0
   history: 0
   image: 0
   image_captcha: 0

--- a/config/default/editor.editor.civictheme_rich_text.yml
+++ b/config/default/editor.editor.civictheme_rich_text.yml
@@ -6,6 +6,7 @@ dependencies:
     - filter.format.civictheme_rich_text
   module:
     - ckeditor5
+    - highlight_js
 _core:
   default_config_hash: SztHd9Hrw3-1EuKex-O6V-Kc5EpxLGsSam2HEDXSgDM
 format: civictheme_rich_text
@@ -40,6 +41,8 @@ settings:
       - subscript
       - '|'
       - sourceEditing
+      - '|'
+      - highlightJs
   plugins:
     ckeditor5_alignment:
       enabled_alignments:

--- a/config/default/filter.format.civictheme_rich_text.yml
+++ b/config/default/filter.format.civictheme_rich_text.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.media.embedded
   module:
     - editor
+    - highlight_js
     - linkit
     - media
 _core:
@@ -44,9 +45,15 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p class="ct-text-large ct-text-small text-align-left text-align-center text-align-right"> <h2 id class> <h3 id class="text-align-left text-align-center text-align-right"> <h4 id class="text-align-left text-align-center text-align-right"> <h5 id class="text-align-left text-align-center text-align-right"> <h6 id class="text-align-left text-align-center text-align-right"> <a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular ct-button--secondary ct-button--large" hreflang target title href data-entity-type data-entity-uuid data-entity-substitution> <table class="ct-theme-light ct-theme-dark ct-table ct-table--striped"> <cite> <dl> <dt> <dd> <img src alt data-entity-type data-entity-uuid> <drupal-entity alt title data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button> <span class="ct-visually-hidden"> <svg role viewBox aria-hidden width height class="ct-icon"> <path d> <blockquote cite> <drupal-media title data-entity-type data-entity-uuid alt data-caption data-align> <strong> <em> <u> <code class="language-*"> <pre class="text-align-left text-align-center text-align-right"> <s> <sub> <sup> <ul type> <ol type start> <li> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption>'
+      allowed_html: '<br> <p class="ct-text-large ct-text-small text-align-left text-align-center text-align-right"> <h2 id class> <h3 id class="text-align-left text-align-center text-align-right"> <h4 id class="text-align-left text-align-center text-align-right"> <h5 id class="text-align-left text-align-center text-align-right"> <h6 id class="text-align-left text-align-center text-align-right"> <a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular ct-button--secondary ct-button--large" hreflang target title href data-entity-type data-entity-uuid data-entity-substitution> <table class="ct-theme-light ct-theme-dark ct-table ct-table--striped"> <cite> <dl> <dt> <dd> <img src alt data-entity-type data-entity-uuid> <drupal-entity alt title data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button> <span class="ct-visually-hidden"> <svg role viewBox aria-hidden width height class="ct-icon"> <path d> <blockquote cite> <drupal-media title data-entity-type data-entity-uuid alt data-caption data-align> <strong> <em> <u> <code class="language-*"> <pre class="text-align-left text-align-center text-align-right"> <s> <sub> <sup> <ul type> <ol type start> <li> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <highlight-js data-plugin-config data-plugin-id>'
       filter_html_help: true
       filter_html_nofollow: false
+  highlight_js:
+    id: highlight_js
+    provider: highlight_js
+    status: true
+    weight: -40
+    settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter

--- a/config/default/highlight_js.settings.yml
+++ b/config/default/highlight_js.settings.yml
@@ -1,0 +1,12 @@
+copy_enable: true
+copy_bg_transparent: false
+copy_bg_color: '#4243b1'
+copy_txt_color: '#ffffff'
+copy_btn_text: ''
+copy_success_text: ''
+success_txt_color: '#ffffff'
+role_copy_access: {  }
+languages: {  }
+theme: github
+success_bg_transparent: false
+success_bg_color: '#4243b1'


### PR DESCRIPTION
Closes #132

## Changes

Adds the [Highlight.js](https://www.drupal.org/project/highlight_js) module for source code syntax highlighting in CKEditor 5.

- Added `drupal/highlight_js` ^1.2 to `composer.json`
- Enabled module in `core.extension.yml`
- Added `highlight_js.settings.yml` — GitHub theme, copy button enabled
- Updated `civictheme_rich_text` text format:
  - Added `highlight_js` filter
  - Added `<highlight-js>` to allowed HTML tags
- Updated CKEditor config:
  - Added `highlightJs` toolbar button
  - Added `highlight_js` module dependency

## Note

`composer.lock` needs updating — could not run `composer update` locally due to SSH access issue with `drevops/test-private-package`. This will need to be resolved in CI or by someone with the private repo access.

## Theme

Set to `github` — clean and professional. Can be changed at `/admin/config/content/highlight-js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Syntax highlighting functionality added to the rich text editor with a dedicated toolbar button
  * Copy-to-clipboard feature for highlighted code blocks
  * Configurable theme and styling options for code highlighting, including color customization and transparency settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->