### PR TITLE
Updated 'drevops/vortex-tooling' to '1.1.0'.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
         "drevops/test-private-package": "^1.0",
-        "drevops/vortex-tooling": "dev-main as 1.0.0",
+        "drevops/vortex-tooling": "^1.1.0",
         "drupal/admin_toolbar": "^3.6.3",
         "drupal/ai_image_alt_text": "^1.0.2",
         "drupal/ai_provider_openai": "^1.2.1",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
         "drevops/test-private-package": "^1.0",
-        "drevops/vortex-tooling": "^1.0",
+        "drevops/vortex-tooling": "dev-main as 1.0.0",
         "drupal/admin_toolbar": "^3.6.3",
         "drupal/ai_image_alt_text": "^1.0.2",
         "drupal/ai_provider_openai": "^1.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1c41436087dbb30a7ed277ae21baaac",
+    "content-hash": "eaf032a7b827f0d2a1a24a475fe3a5c5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1548,21 +1548,22 @@
         },
         {
             "name": "drevops/vortex-tooling",
-            "version": "1.0.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drevops/vortex-tooling.git",
-                "reference": "30a9cb0e70d3863e25397b9fa3a830f795d4ed44"
+                "reference": "19a9c69536e52c22441097dc726067cf549dd310"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drevops/vortex-tooling/zipball/30a9cb0e70d3863e25397b9fa3a830f795d4ed44",
-                "reference": "30a9cb0e70d3863e25397b9fa3a830f795d4ed44",
+                "url": "https://api.github.com/repos/drevops/vortex-tooling/zipball/19a9c69536e52c22441097dc726067cf549dd310",
+                "reference": "19a9c69536e52c22441097dc726067cf549dd310",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1582,7 +1583,7 @@
                 "issues": "https://github.com/drevops/vortex/issues",
                 "source": "https://github.com/drevops/vortex"
             },
-            "time": "2026-05-25T04:16:12+00:00"
+            "time": "2026-05-31T01:07:58+00:00"
         },
         {
             "name": "drupal/admin_toolbar",
@@ -17651,9 +17652,17 @@
             "time": "2026-04-11T10:33:05+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "drevops/vortex-tooling",
+            "version": "dev-main",
+            "alias": "1.0.0",
+            "alias_normalized": "1.0.0.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "drevops/vortex-tooling": 20,
         "drupal/cloudflare": 10,
         "drupal/coder": 15,
         "drupal/config_update": 15,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eaf032a7b827f0d2a1a24a475fe3a5c5",
+    "content-hash": "8d2363230a079d3edfed3db2fc6e089b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1548,22 +1548,21 @@
         },
         {
             "name": "drevops/vortex-tooling",
-            "version": "dev-main",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drevops/vortex-tooling.git",
-                "reference": "19a9c69536e52c22441097dc726067cf549dd310"
+                "reference": "19764b9bf92d94f8cf51323bd6850cf8e807e171"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drevops/vortex-tooling/zipball/19a9c69536e52c22441097dc726067cf549dd310",
-                "reference": "19a9c69536e52c22441097dc726067cf549dd310",
+                "url": "https://api.github.com/repos/drevops/vortex-tooling/zipball/19764b9bf92d94f8cf51323bd6850cf8e807e171",
+                "reference": "19764b9bf92d94f8cf51323bd6850cf8e807e171",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
-            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1583,7 +1582,7 @@
                 "issues": "https://github.com/drevops/vortex/issues",
                 "source": "https://github.com/drevops/vortex"
             },
-            "time": "2026-05-31T01:07:58+00:00"
+            "time": "2026-06-01T03:39:57+00:00"
         },
         {
             "name": "drupal/admin_toolbar",
@@ -17652,17 +17651,9 @@
             "time": "2026-04-11T10:33:05+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "drevops/vortex-tooling",
-            "version": "dev-main",
-            "alias": "1.0.0",
-            "alias_normalized": "1.0.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "drevops/vortex-tooling": 20,
         "drupal/cloudflare": 10,
         "drupal/coder": 15,
         "drupal/config_update": 15,


### PR DESCRIPTION
## Summary

Updated the `drevops/vortex-tooling` dependency from the `dev-main` alias (pinned as `1.0.0`) to the stable `^1.1.0` constraint, which resolves to the `1.1.0` release. This moves the project off a mutable dev-channel pin and onto a versioned, reproducible release tag.

## Changes

**`composer.json`**
- Changed `drevops/vortex-tooling` version constraint from `^1.0` to `^1.1.0`.

**`composer.lock`**
- Updated `drevops/vortex-tooling` from `1.0.0` (dev-main alias, commit `30a9cb0`) to the `1.1.0` release tag (commit `19764b9`).
- Updated content hash to reflect the new resolved dependency state.
