### PR TITLE
[#185] Added the front-end interactions library to the sub-theme.

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -78,9 +78,8 @@ class FeatureContext extends DrupalContext {
    *
    * No template renders the interactions hooks yet, so the reveal behaviour is
    * exercised against representative injected markup.
-   *
-   * @Then injected reveal content becomes visible
    */
+  #[\Behat\Step\Then('injected reveal content becomes visible')]
   public function assertInjectedRevealBecomesVisible(): void {
     $session = $this->getSession();
 
@@ -105,9 +104,8 @@ class FeatureContext extends DrupalContext {
    *
    * No template renders the interactions hooks yet, so the mobile navigation
    * behaviour is exercised against representative injected markup.
-   *
-   * @Then the injected mobile menu toggles open and closed
    */
+  #[\Behat\Step\Then('the injected mobile menu toggles open and closed')]
   public function assertInjectedMobileMenuToggles(): void {
     $session = $this->getSession();
 

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -85,6 +85,7 @@ class FeatureContext extends DrupalContext {
 
     $script = "
       var element = document.createElement('div');
+      element.id = 'test-reveal-target';
       element.className = 'component-reveal';
       element.textContent = '[TEST] Reveal target';
       document.body.insertBefore(element, document.body.firstChild);
@@ -92,7 +93,7 @@ class FeatureContext extends DrupalContext {
     ";
     $session->executeScript($script);
 
-    $revealed = $session->wait(5000, "document.querySelector('.component-reveal.visible')");
+    $revealed = $session->wait(5000, "document.querySelector('#test-reveal-target.visible')");
 
     if (!$revealed) {
       throw new \Exception('The injected reveal element did not become visible.');

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -73,4 +73,85 @@ class FeatureContext extends DrupalContext {
   use WaitTrait;
   use WatchdogTrait;
 
+  /**
+   * Assert that content using the reveal hook becomes visible.
+   *
+   * No template renders the interactions hooks yet, so the reveal behaviour is
+   * exercised against representative injected markup.
+   *
+   * @Then injected reveal content becomes visible
+   */
+  public function assertInjectedRevealBecomesVisible(): void {
+    $session = $this->getSession();
+
+    $script = "
+      var element = document.createElement('div');
+      element.className = 'component-reveal';
+      element.textContent = '[TEST] Reveal target';
+      document.body.insertBefore(element, document.body.firstChild);
+      Drupal.attachBehaviors(document.body);
+    ";
+    $session->executeScript($script);
+
+    $revealed = $session->wait(5000, "document.querySelector('.component-reveal.visible')");
+
+    if (!$revealed) {
+      throw new \Exception('The injected reveal element did not become visible.');
+    }
+  }
+
+  /**
+   * Assert the mobile menu toggles open and closed and locks body scrolling.
+   *
+   * No template renders the interactions hooks yet, so the mobile navigation
+   * behaviour is exercised against representative injected markup.
+   *
+   * @Then the injected mobile menu toggles open and closed
+   */
+  public function assertInjectedMobileMenuToggles(): void {
+    $session = $this->getSession();
+
+    $script = "
+      var nav = document.createElement('nav');
+      nav.id = 'siteNav';
+      nav.className = 'component-nav';
+      var toggle = document.createElement('button');
+      toggle.id = 'navToggle';
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.textContent = 'Menu';
+      var menu = document.createElement('div');
+      menu.className = 'component-nav-menu';
+      var links = document.createElement('div');
+      links.className = 'component-nav-links';
+      var link = document.createElement('a');
+      link.setAttribute('href', '#test-interaction');
+      link.textContent = '[TEST] Menu link';
+      links.appendChild(link);
+      menu.appendChild(links);
+      nav.appendChild(toggle);
+      nav.appendChild(menu);
+      document.body.insertBefore(nav, document.body.firstChild);
+      Drupal.attachBehaviors(document.body);
+    ";
+    $session->executeScript($script);
+
+    $session->executeScript("document.getElementById('navToggle').click();");
+    $opened_js = "document.getElementById('siteNav').classList.contains('is-open')"
+      . " && document.body.style.overflow === 'hidden'";
+    $opened = $session->wait(3000, $opened_js);
+
+    if (!$opened) {
+      throw new \Exception('The mobile menu did not open and lock body scrolling.');
+    }
+
+    $session->executeScript("document.querySelector('#siteNav .component-nav-links a').click();");
+    $closed_js = "!document.getElementById('siteNav').classList.contains('is-open')"
+      . " && document.body.style.overflow === ''";
+    $closed = $session->wait(3000, $closed_js);
+
+    if (!$closed) {
+      throw new \Exception('The mobile menu did not close and restore body scrolling.');
+    }
+  }
+
 }

--- a/tests/behat/features/interactions.feature
+++ b/tests/behat/features/interactions.feature
@@ -1,0 +1,25 @@
+@interactions
+Feature: Front-end interactions library
+
+  As a site visitor
+  I want the site's motion and the mobile menu to behave as designed
+  So that the experience feels polished and navigation works on a phone
+
+  @api
+  Scenario: Anonymous user can view the homepage with the interactions library
+    Given I am an anonymous user
+    When I go to the homepage
+    Then the path should be "<front>"
+    And I save screenshot
+
+  @api @javascript
+  Scenario: Content reveals as it scrolls into view
+    Given I am an anonymous user
+    When I go to the homepage
+    Then injected reveal content becomes visible
+
+  @api @javascript
+  Scenario: The mobile menu opens, locks scrolling and closes on link activation
+    Given I am an anonymous user
+    When I go to the homepage
+    Then the injected mobile menu toggles open and closed

--- a/web/themes/custom/drevops/assets/sass/base/_infrastructure.scss
+++ b/web/themes/custom/drevops/assets/sass/base/_infrastructure.scss
@@ -1,0 +1,33 @@
+//
+// Site infrastructure styles.
+//
+// Site-wide presentation that sits outside any single component: the global
+// grain overlay and smooth in-page scrolling.
+//
+
+// Grain overlay.
+//
+// A faint, fixed noise texture layered above the page. It is purely
+// decorative and never intercepts pointer events. The texture is static, so
+// it is not gated behind reduced-motion.
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  pointer-events: none;
+  opacity: 0.04;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='1'/%3E%3C/svg%3E");
+  background-size: 256px 256px;
+  background-repeat: repeat;
+}
+
+// Smooth in-page scrolling.
+//
+// Smooth scrolling is motion, so it is enabled only for visitors who have not
+// requested reduced motion.
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}

--- a/web/themes/custom/drevops/assets/sass/theme.scss
+++ b/web/themes/custom/drevops/assets/sass/theme.scss
@@ -6,5 +6,6 @@
 //
 // These overrides will not be visible in the Storybook.
 // @todo Refactor build to use direct import from the CivicTheme theme.
+@import 'base/infrastructure';
 @import 'page/page';
 @import 'block/local-tasks';

--- a/web/themes/custom/drevops/components/00-base/reveal/reveal.js
+++ b/web/themes/custom/drevops/components/00-base/reveal/reveal.js
@@ -1,0 +1,48 @@
+// phpcs:ignoreFile
+/**
+ * @file
+ * Reveal behaviour.
+ *
+ * Adds a 'visible' class to every '.component-reveal' element once it
+ * scrolls into view, driving the staggered fade-up defined in reveal.scss.
+ * Each element is revealed once and ignored on subsequent attaches.
+ *
+ * The entrance animation is gated behind 'prefers-reduced-motion' in CSS, so
+ * visitors who prefer reduced motion always see content in its final state.
+ */
+function DrevOpsReveal() {
+  const elements = document.querySelectorAll(
+    '.component-reveal:not([data-reveal-bound])',
+  );
+
+  if (!elements.length) {
+    return;
+  }
+
+  if (!('IntersectionObserver' in window)) {
+    // Reveal immediately when the observer is unavailable so that content is
+    // never left hidden.
+    elements.forEach((element) => {
+      element.setAttribute('data-reveal-bound', '');
+      element.classList.add('visible');
+    });
+
+    return;
+  }
+
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        obs.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+
+  elements.forEach((element) => {
+    element.setAttribute('data-reveal-bound', '');
+    observer.observe(element);
+  });
+}
+
+DrevOpsReveal();

--- a/web/themes/custom/drevops/components/00-base/reveal/reveal.scss
+++ b/web/themes/custom/drevops/components/00-base/reveal/reveal.scss
@@ -11,13 +11,13 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .component-reveal {
-    opacity: 0;
+    opacity: 0%;
     transform: translateY(40px);
     transition: opacity 0.9s ease, transform 0.9s ease;
   }
 
   .component-reveal.visible {
-    opacity: 1;
+    opacity: 100%;
     transform: translateY(0);
   }
 

--- a/web/themes/custom/drevops/components/00-base/reveal/reveal.scss
+++ b/web/themes/custom/drevops/components/00-base/reveal/reveal.scss
@@ -1,0 +1,47 @@
+//
+// Reveal behaviour styles.
+//
+// Scroll-triggered fade-up with staggered delay utilities. The 'visible'
+// class is added by reveal.js once the element scrolls into view.
+//
+// The hidden starting state and the transition are applied only when the
+// visitor has not requested reduced motion, so reduced-motion visitors see
+// content in its final position with no entrance animation.
+//
+
+@media (prefers-reduced-motion: no-preference) {
+  .component-reveal {
+    opacity: 0;
+    transform: translateY(40px);
+    transition: opacity 0.9s ease, transform 0.9s ease;
+  }
+
+  .component-reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .component-reveal-d1 {
+    transition-delay: 0.1s;
+  }
+
+  .component-reveal-d2 {
+    transition-delay: 0.2s;
+  }
+
+  .component-reveal-d3 {
+    transition-delay: 0.3s;
+  }
+
+  .component-reveal-d4 {
+    transition-delay: 0.4s;
+  }
+
+  .component-reveal-d5 {
+    transition-delay: 0.5s;
+  }
+
+  .component-reveal-d6 {
+    transition-delay: 0.6s;
+  }
+}

--- a/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
+++ b/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
@@ -33,6 +33,13 @@ function DrevOpsSiteNav() {
     link.addEventListener('click', () => setOpen(false));
   });
 
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && nav.classList.contains('is-open')) {
+      setOpen(false);
+      toggle.focus();
+    }
+  });
+
   toggle.setAttribute('data-site-nav-bound', '');
 }
 

--- a/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
+++ b/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
@@ -19,10 +19,16 @@ function DrevOpsSiteNav() {
     return;
   }
 
+  let previousBodyOverflow = '';
+
   const setOpen = (isOpen) => {
+    if (isOpen) {
+      previousBodyOverflow = document.body.style.overflow;
+    }
+
     nav.classList.toggle('is-open', isOpen);
     toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-    document.body.style.overflow = isOpen ? 'hidden' : '';
+    document.body.style.overflow = isOpen ? 'hidden' : previousBodyOverflow;
   };
 
   toggle.addEventListener('click', () => {

--- a/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
+++ b/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
@@ -1,0 +1,39 @@
+// phpcs:ignoreFile
+/**
+ * @file
+ * Site navigation behaviour.
+ *
+ * Drives the mobile slide-in menu. The trigger toggles the menu open and
+ * closed, body scroll is locked while the menu is open, and activating any
+ * link inside the menu closes it so navigation feels immediate.
+ *
+ * The behaviour binds by id ('siteNav' and 'navToggle'); when either is
+ * missing it is a no-op, so it can be attached globally ahead of the markup
+ * that uses it.
+ */
+function DrevOpsSiteNav() {
+  const nav = document.getElementById('siteNav');
+  const toggle = document.getElementById('navToggle');
+
+  if (!nav || !toggle || toggle.hasAttribute('data-site-nav-bound')) {
+    return;
+  }
+
+  const setOpen = (isOpen) => {
+    nav.classList.toggle('is-open', isOpen);
+    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    document.body.style.overflow = isOpen ? 'hidden' : '';
+  };
+
+  toggle.addEventListener('click', () => {
+    setOpen(!nav.classList.contains('is-open'));
+  });
+
+  nav.querySelectorAll('.component-nav-links a').forEach((link) => {
+    link.addEventListener('click', () => setOpen(false));
+  });
+
+  toggle.setAttribute('data-site-nav-bound', '');
+}
+
+DrevOpsSiteNav();


### PR DESCRIPTION
Closes #185

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#185] Verb in past tense.`
- [x] Ticket number `#185` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally.

## Changed

1. Added `web/themes/custom/drevops/components/00-base/reveal/reveal.js` - an `IntersectionObserver` behaviour that adds the `visible` class to every `.component-reveal` element once it scrolls into view (threshold `0.12`, `rootMargin` `0px 0px -40px 0px`). Idempotent via a `data-reveal-bound` guard; falls back to immediate reveal when `IntersectionObserver` is unavailable so content is never left hidden.
2. Added `web/themes/custom/drevops/components/00-base/reveal/reveal.scss` - hidden/visible states and six stagger-delay utilities (`.component-reveal-d1` through `.component-reveal-d6`), the entire animation block gated behind `@media (prefers-reduced-motion: no-preference)` so reduced-motion visitors see content in its final state.
3. Added `web/themes/custom/drevops/components/00-base/site-nav/site-nav.js` - mobile menu toggle binding `#siteNav` and `#navToggle`: toggles `is-open`, syncs `aria-expanded`, locks body scroll while the menu is open, closes on `.component-nav-links a` activation, and closes on `Escape` restoring focus to the trigger. Idempotent via `data-site-nav-bound`; a no-op when the markup is absent.
4. Added `web/themes/custom/drevops/assets/sass/base/_infrastructure.scss` - a fixed decorative grain overlay (`body::before`, `pointer-events: none`, `opacity: 0.04`) and smooth in-page scrolling (`html { scroll-behavior: smooth }` gated behind `prefers-reduced-motion: no-preference`). Imported into `assets/sass/theme.scss`.
5. Added `tests/behat/features/interactions.feature` and custom steps in `tests/behat/bootstrap/FeatureContext.php` - one non-JS smoke scenario (anonymous user reaches the homepage) plus two `@javascript` scenarios that inject representative markup and assert the reveal and mobile-nav behaviours (class toggles, body scroll lock, close-on-link-activation).

These files bundle into the sub-theme's global CSS/JS via the CivicTheme build (`00-base/**` and `assets/sass/theme.scss` compile to `dist/`), which the `civictheme/global` libraries-override attaches site-wide. No template renders the interaction hooks yet; this is deliberate infrastructure that later component stories opt into by using `.component-reveal`, `#siteNav`, and `#navToggle`.

## Screenshots

N/A

## Before / After

```
Before
┌──────────────────────────────────────────────────────┐
│ Sub-theme (drevops)                                  │
│                                                      │
│  assets/sass/theme.scss                              │
│    └── @import 'page/page'                           │
│    └── @import 'block/local-tasks'                   │
│                                                      │
│  components/00-base/  (no shared interaction layer)  │
│                                                      │
│  No grain overlay, no smooth scroll,                 │
│  no reveal behaviour, no mobile-nav behaviour.       │
│  Content always visible at load; menu toggle         │
│  relies on CivicTheme defaults only.                 │
└──────────────────────────────────────────────────────┘

After
┌──────────────────────────────────────────────────────┐
│ Sub-theme (drevops)                                  │
│                                                      │
│  assets/sass/theme.scss                              │
│    └── @import 'base/infrastructure'  ← NEW          │
│    └── @import 'page/page'                           │
│    └── @import 'block/local-tasks'                   │
│                                                      │
│  assets/sass/base/_infrastructure.scss  ← NEW        │
│    ├── body::before  grain overlay (opacity 0.04)    │
│    └── html { scroll-behavior: smooth }              │
│         (gated: prefers-reduced-motion: no-pref)     │
│                                                      │
│  components/00-base/reveal/                          │
│    ├── reveal.js  ← NEW                              │
│    │    IntersectionObserver → adds 'visible' to     │
│    │    .component-reveal elements (idempotent)      │
│    └── reveal.scss  ← NEW                            │
│         opacity/translateY transitions + d1–d6       │
│         stagger (gated: prefers-reduced-motion)      │
│                                                      │
│  components/00-base/site-nav/                        │
│    └── site-nav.js  ← NEW                            │
│         Toggle #siteNav/#navToggle: is-open,         │
│         aria-expanded, body scroll lock,             │
│         close-on-link, close-on-Escape + refocus     │
│                                                      │
│  Behaviours dormant until component markup opts in   │
│  via .component-reveal / #siteNav / #navToggle.      │
└──────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scroll-triggered “reveal on scroll” animations for `.component-reveal`, including graceful fallback when IntersectionObserver isn’t available and staggered transition delays.
  * Added mobile site navigation with open/close behavior, ARIA state updates, Escape-to-close, link-based closing, and scroll locking.
  * Introduced a site-wide decorative grain/noise overlay and enabled smooth in-page scrolling when motion preferences allow it.
* **Tests**
  * Added Behat coverage for injected reveal visibility and mobile menu toggle behavior, including scroll lock/unlock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->