### PR TITLE
[#186] Added OpenGraph and Twitter card metadata defaults.

### DIFF
--- a/config/default/metatag.metatag_defaults.front.yml
+++ b/config/default/metatag.metatag_defaults.front.yml
@@ -9,3 +9,6 @@ label: 'Front page'
 tags:
   canonical_url: '[site:url]'
   shortlink: '[site:url]'
+  og_url: '[site:url]'
+  og_description: '[node:field_c_n_summary:value]'
+  twitter_cards_description: '[node:field_c_n_summary:value]'

--- a/config/default/metatag.metatag_defaults.global.yml
+++ b/config/default/metatag.metatag_defaults.global.yml
@@ -9,5 +9,12 @@ label: Global
 tags:
   canonical_url: '[current-page:url]'
   title: '[current-page:title] | [site:name]'
+  robots: 'index, follow'
+  og_site_name: '[site:name]'
+  og_type: website
+  og_url: '[current-page:url]'
+  og_title: '[current-page:title]'
   og_image: '[site:url]themes/custom/drevops/dist/assets/images/og-image.png'
+  twitter_cards_type: summary_large_image
+  twitter_cards_title: '[current-page:title]'
   twitter_cards_image: '[site:url]themes/custom/drevops/dist/assets/images/og-image.png'

--- a/config/default/metatag.metatag_defaults.node.yml
+++ b/config/default/metatag.metatag_defaults.node.yml
@@ -10,3 +10,5 @@ tags:
   title: '[node:title] | [site:name]'
   description: '[node:summary]'
   canonical_url: '[node:url]'
+  og_description: '[node:summary]'
+  twitter_cards_description: '[node:summary]'

--- a/config/default/metatag.metatag_defaults.node__civictheme_page.yml
+++ b/config/default/metatag.metatag_defaults.node__civictheme_page.yml
@@ -6,3 +6,5 @@ id: node__civictheme_page
 label: 'Content: Page'
 tags:
   description: '[node:field_c_n_summary:value]'
+  og_description: '[node:field_c_n_summary:value]'
+  twitter_cards_description: '[node:field_c_n_summary:value]'

--- a/tests/behat/features/metatags.feature
+++ b/tests/behat/features/metatags.feature
@@ -14,6 +14,28 @@ Feature: Page content metatags
     Then the response should contain "<title>Test Metatags Page | "
     And the response should contain "<meta name=\"description\" content=\"This is a test summary for metatags testing\""
     And the response should contain "<link rel=\"canonical\" href=\""
+    And the response should contain "test-metatags-page"
+    And the meta tag should exist with the following attributes:
+      | name    | robots        |
+      | content | index, follow |
+    And the meta tag should exist with the following attributes:
+      | property | og:type |
+      | content  | website |
+    And the meta tag should exist with the following attributes:
+      | property | og:title           |
+      | content  | Test Metatags Page |
+    And the meta tag should exist with the following attributes:
+      | property | og:description                              |
+      | content  | This is a test summary for metatags testing |
+    And the meta tag should exist with the following attributes:
+      | name    | twitter:card        |
+      | content | summary_large_image |
+    And the meta tag should exist with the following attributes:
+      | name    | twitter:title      |
+      | content | Test Metatags Page |
+    And the meta tag should exist with the following attributes:
+      | name    | twitter:description                         |
+      | content | This is a test summary for metatags testing |
 
   @api
   Scenario: Pages expose the branded Open Graph and Twitter share image
@@ -22,3 +44,12 @@ Feature: Page content metatags
     Then the response should contain "<meta property=\"og:image\" content=\"http"
     And the response should contain "<meta name=\"twitter:image\" content=\"http"
     And the response should contain "/themes/custom/drevops/dist/assets/images/og-image.png\" />"
+
+  @api
+  Scenario: Content editor can override metatags on a page
+    Given I am logged in as a user with the "civictheme_content_author" role
+    And the following civictheme_page content:
+      | title                  | status |
+      | Test Metatags Override | 1      |
+    When I visit the "civictheme_page" content edit page with the title "Test Metatags Override"
+    Then I should see "Metatags"

--- a/tests/behat/features/metatags.feature
+++ b/tests/behat/features/metatags.feature
@@ -46,10 +46,12 @@ Feature: Page content metatags
     And the response should contain "/themes/custom/drevops/dist/assets/images/og-image.png\" />"
 
   @api
-  Scenario: Content editor can override metatags on a page
+  Scenario: Content editor can access the metatags override fields on a page
     Given I am logged in as a user with the "civictheme_content_author" role
     And the following civictheme_page content:
       | title                  | status |
       | Test Metatags Override | 1      |
     When I visit the "civictheme_page" content edit page with the title "Test Metatags Override"
     Then I should see "Metatags"
+    And I should see "Open Graph"
+    And I should see "Twitter Cards"


### PR DESCRIPTION
Closes #186

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added `robots`, `og_site_name`, `og_type`, `og_url`, `og_title`, `twitter_cards_type`, and `twitter_cards_title` to `metatag.metatag_defaults.global.yml`, giving every page a complete Open Graph and Twitter Card baseline via `[current-page:*]` tokens. The `og_image` / `twitter_cards_image` defaults that point at the branded share image already exist on the base branch and are reused as-is.
2. Added `og_description` and `twitter_cards_description` from `[node:summary]` to `metatag.metatag_defaults.node.yml`.
3. Added `og_description` and `twitter_cards_description` from `[node:field_c_n_summary:value]` to `metatag.metatag_defaults.node__civictheme_page.yml`.
4. Added `og_url`, `og_description`, and `twitter_cards_description` to `metatag.metatag_defaults.front.yml`. The front-page route applies the global and front defaults but not the node or bundle defaults, so the front page needs its own description tokens, and `og_url` is aligned to the canonical home URL.
5. Extended `tests/behat/features/metatags.feature`: asserted the Open Graph tags, the Twitter Card tags, the `robots` directive, and the clean Pathauto alias on a content page, and added a scenario asserting a content author can access the Metatags, Open Graph, and Twitter Cards override groups on the page edit form.

## Screenshots

N/A - metadata-only change. The Open Graph and Twitter Card tags reference the existing branded share image (`og-image.png`).

## Before / After

```
Page <head> social metadata (content page)

  BEFORE (base branch)           AFTER (this PR)
  -----------------------        ------------------------------------
  <title>                        <title>
  <meta description>             <meta description>
  <link canonical>               <link canonical>
  <meta og:image>                <meta robots="index, follow">
  <meta twitter:image>           <meta og:site_name|og:type|og:url|
                       ---->       og:title|og:description|og:image>
  (no og:title/desc/type)        <meta twitter:card|twitter:title|
  (no twitter:card/title)         twitter:description|twitter:image>
  (no robots)
```
