### PR TITLE
[#184] Switched the whole site to the dark colour scheme.

### DIFF
--- a/config/default/civictheme.settings.yml
+++ b/config/default/civictheme.settings.yml
@@ -55,7 +55,7 @@ components:
     external_new_window: true
     external_override_domains: {  }
   skip_link:
-    theme: light
+    theme: dark
   event_card:
     summary_length: 160
   navigation_card:

--- a/config/default/drevops.settings.yml
+++ b/config/default/drevops.settings.yml
@@ -56,7 +56,7 @@ components:
     external_new_window: 1
     external_override_domains: {  }
   skip_link:
-    theme: light
+    theme: dark
   event_card:
     summary_length: '160'
   navigation_card:

--- a/config/default/field.field.block_content.civictheme_banner.field_c_b_theme.yml
+++ b/config/default/field.field.block_content.civictheme_banner.field_c_b_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.block_content.civictheme_mobile_navigation.field_c_b_theme.yml
+++ b/config/default/field.field.block_content.civictheme_mobile_navigation.field_c_b_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_theme.yml
+++ b/config/default/field.field.block_content.civictheme_mobile_navigation.field_c_b_trigger_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_accordion.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_accordion.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_attachment.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_attachment.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_automated_list.field_c_p_list_item_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_automated_list.field_c_p_list_item_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_automated_list.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_automated_list.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_callout.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_callout.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_campaign.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_campaign.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_content.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_content.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_event_card.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_event_card.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_event_card_ref.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_event_card_ref.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_iframe.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_iframe.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_manual_list.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_manual_list.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_map.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_map.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_message.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_message.field_c_p_theme.yml
@@ -17,7 +17,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_navigation_card.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_navigation_card.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_navigation_card_ref.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_navigation_card_ref.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_next_step.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_next_step.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_promo.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_promo.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_promo_card.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_promo_card.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_promo_card_ref.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_promo_card_ref.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_publication_card.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_publication_card.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_service_card.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_service_card.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_slider.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_slider.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_slider_slide.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_slider_slide.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_slider_slide_ref.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_slider_slide_ref.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_snippet.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_snippet.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_snippet_ref.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_snippet_ref.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_subject_card.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_subject_card.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_subject_card_ref.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_subject_card_ref.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.civictheme_webform.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.civictheme_webform.field_c_p_theme.yml
@@ -19,7 +19,7 @@ required: true
 translatable: true
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/config/default/field.field.paragraph.divider.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.divider.field_c_p_theme.yml
@@ -17,7 +17,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: light
+    value: dark
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/tests/behat/features/dark_mode.feature
+++ b/tests/behat/features/dark_mode.feature
@@ -1,0 +1,20 @@
+@dark_mode
+Feature: Dark colour scheme
+
+  As a site visitor
+  I want every part of the site to use the dark colour scheme
+  So that the experience is consistent and matches the redesign
+
+  @api
+  Scenario: The site chrome renders in the dark scheme
+    Given I am an anonymous user
+    When I go to the homepage
+    Then the response should contain "ct-theme-dark"
+
+  @api
+  Scenario: A published page renders in the dark scheme
+    Given the following civictheme_page content:
+      | title            | status |
+      | [TEST] Dark Page | 1      |
+    When I visit the "civictheme_page" content page with the title "[TEST] Dark Page"
+    Then the response should contain "ct-theme-dark"

--- a/tests/behat/features/dark_mode.feature
+++ b/tests/behat/features/dark_mode.feature
@@ -10,6 +10,7 @@ Feature: Site-wide dark mode
     Given I am an anonymous user
     When I go to the homepage
     Then the response should contain "ct-theme-dark"
+    And the response should not contain "ct-theme-light"
 
   @api
   Scenario: A published page renders in the dark scheme
@@ -18,3 +19,4 @@ Feature: Site-wide dark mode
       | [TEST] Dark Page | 1      |
     When I visit the "civictheme_page" content page with the title "[TEST] Dark Page"
     Then the response should contain "ct-theme-dark"
+    And the response should not contain "ct-theme-light"

--- a/tests/behat/features/dark_mode.feature
+++ b/tests/behat/features/dark_mode.feature
@@ -1,5 +1,5 @@
 @dark_mode
-Feature: Dark colour scheme
+Feature: Site-wide dark mode
 
   As a site visitor
   I want every part of the site to use the dark colour scheme

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -9,7 +9,9 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\civictheme\CivicthemeColorManager;
+use Drupal\civictheme\CivicthemeConstants;
 
 /**
  * Rebuild CivicTheme colour stylesheets from the imported colour configuration.
@@ -34,4 +36,65 @@ function do_base_deploy_civictheme_colors(): string {
   }
 
   return 'Purged CivicTheme generated colour stylesheets for rebuild from configuration.';
+}
+
+/**
+ * Migrate every existing component to the dark colour scheme.
+ */
+function do_base_deploy_component_dark_theme(array &$sandbox): string {
+  if (!class_exists(CivicthemeConstants::class)) {
+    $sandbox['#finished'] = 1;
+
+    return 'CivicTheme is not available; skipped the dark colour scheme migration.';
+  }
+
+  // CivicTheme scheme-selector fields grouped by the entity type that carries
+  // them. Each stores 'light' or 'dark' and drives the rendered colour scheme.
+  // Existing entities keep whatever value they were saved with, so any that are
+  // not already dark are re-saved to align with the new dark field defaults.
+  $theme_fields = [
+    'paragraph' => ['field_c_p_theme', 'field_c_p_list_item_theme'],
+    'block_content' => ['field_c_b_theme', 'field_c_b_trigger_theme'],
+  ];
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $batch_size = 50;
+  $processed = 0;
+
+  // Re-query the remaining non-dark entities on each pass and migrate up to one
+  // batch. A saved entity drops out of the next query, so repeated passes drain
+  // the backlog without tracking offsets in the sandbox; the hook finishes once
+  // a pass finds nothing left to change.
+  foreach ($theme_fields as $entity_type_id => $field_names) {
+    $storage = $entity_type_manager->getStorage($entity_type_id);
+
+    foreach ($field_names as $field_name) {
+      if ($processed >= $batch_size) {
+        break 2;
+      }
+
+      $ids = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition($field_name, CivicthemeConstants::THEME_DARK, '<>')
+        ->range(0, $batch_size - $processed)
+        ->execute();
+
+      foreach ($ids as $id) {
+        $entity = $storage->load($id);
+
+        if ($entity instanceof FieldableEntityInterface && $entity->hasField($field_name)) {
+          $entity->set($field_name, CivicthemeConstants::THEME_DARK);
+          $entity->save();
+        }
+
+        $processed++;
+      }
+    }
+  }
+
+  $migrated = (int) ($sandbox['migrated'] ?? 0) + $processed;
+  $sandbox['migrated'] = $migrated;
+  $sandbox['#finished'] = $processed === 0 ? 1 : 0;
+
+  return sprintf('Set the dark colour scheme on %d component(s).', $migrated);
 }

--- a/web/themes/custom/drevops/components/02-molecules/navigation-card/navigation-card.twig
+++ b/web/themes/custom/drevops/components/02-molecules/navigation-card/navigation-card.twig
@@ -48,7 +48,7 @@
 {% set is_card_clickable = with_link and is_title_click is empty %}
 {% set card_clickable_class = is_card_clickable ? 'ct-navigation-card--card-clickable' : '' %}
 {% set image_as_icon_class = image_as_icon ? 'ct-navigation-card--image-as-icon' : '' %}
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {% set modifier_class = '%s %s %s %s %s %s'|format(theme_class, with_image_class, with_link_class, image_as_icon_class, card_clickable_class, modifier_class|default('')) %}
 
 {% if title is not empty %}

--- a/web/themes/custom/drevops/components/02-molecules/promo-card/promo-card.twig
+++ b/web/themes/custom/drevops/components/02-molecules/promo-card/promo-card.twig
@@ -57,7 +57,7 @@
 {% set is_card_clickable = with_link and is_title_click is empty %}
 {% set card_clickable_class = is_card_clickable ? 'ct-promo-card--card-clickable' : '' %}
 {% set image_over_class = image_over ? 'ct-promo-card--image-over' : '' %}
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {% set modifier_class = '%s %s %s %s %s'|format(theme_class, with_image_class, image_over_class, card_clickable_class, modifier_class|default('')) %}
 
 {% if title is not empty %}

--- a/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
+++ b/web/themes/custom/drevops/components/03-organisms/banner/banner.twig
@@ -51,7 +51,7 @@
 #}
 
 {% set is_decorative_class = is_decorative ? 'ct-banner--decorative' : '' %}
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {# Custom: Add type and with_offset support. #}
 {% set type = type in ['default', 'large', 'intro'] ? type : 'default' %}
 {% set type_class = 'ct-banner-type--%s'|format(type) %}

--- a/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
+++ b/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
@@ -19,7 +19,7 @@
 {% set size_class = size in ['large', 'regular', 'small'] ? 'size--%s'|format(size) : 'size--regular' %}
 {% set alignment_class = alignment ? 'ct-text-align-%s'|format(alignment) : '' %}
 {% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {% set modifier_class = '%s %s %s %s %s'|format(theme_class, vertical_spacing_class, size_class, alignment_class, modifier_class|default('')) %}
 
 <div class="ct-divider {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>

--- a/web/themes/custom/drevops/components/03-organisms/header/header.twig
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.twig
@@ -29,7 +29,7 @@
  */
 #}
 
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {# Custom: Add sticky header class support. #}
 {% set sticky_class = is_sticky ? 'ct-header--sticky' : '' %}
 {% set modifier_class = '%s %s %s'|format(theme_class, sticky_class, modifier_class|default('')) %}

--- a/web/themes/custom/drevops/components/03-organisms/list/list.twig
+++ b/web/themes/custom/drevops/components/03-organisms/list/list.twig
@@ -58,7 +58,7 @@
 
 {% set with_background_class = with_background ? 'ct-list--with-background' : '' %}
 {% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {% set modifier_class = '%s %s %s %s'|format(theme_class, with_background_class, vertical_spacing_class, modifier_class|default('')) %}
 
 <div class="ct-list {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>

--- a/web/themes/custom/drevops/components/03-organisms/navigation/navigation.twig
+++ b/web/themes/custom/drevops/components/03-organisms/navigation/navigation.twig
@@ -35,7 +35,7 @@
 {% set menu_id = menu_id|default('navigation') %}
 {% set dropdown_class = 'ct-navigation--%s'|format(type|default('none')) %}
 {% set variant_class = variant ? 'ct-navigation--%s'|format(variant) : '' %}
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {% set modifier_class = '%s %s %s %s'|format(theme_class, dropdown_class, variant_class, modifier_class|default('')) %}
 
 {% if items is not empty %}

--- a/web/themes/custom/drevops/components/04-templates/page/page.twig
+++ b/web/themes/custom/drevops/components/04-templates/page/page.twig
@@ -137,7 +137,21 @@
   {% endblock %}
 
   {% block back_to_top_block %}
-    {# Custom: Use include() instead of {% include only %} and inherit the page theme. #}
-    {{ include('civictheme:back-to-top', { theme: theme|default('dark') }) }}
+    {# Custom: Inline back-to-top so its button inherits the page theme. #}
+    {%- set back_to_top_text -%}
+      <span class="ct-visually-hidden">Return focus to the top of the page</span>
+      {%- include 'civictheme:icon' with {symbol: 'up-arrow'} only -%}
+    {%- endset -%}
+    <div class="ct-back-to-top" data-component-name="back-to-top" data-scrollspy data-scrollspy-offset="400">
+      {% include 'civictheme:button' with {
+        theme: theme|default('dark'),
+        kind: 'link',
+        type: '',
+        url: '#top',
+        text: back_to_top_text,
+        attributes: create_attribute({'data-skip-to-target': ''}),
+        modifier_class: 'ct-back-to-top__button',
+      } only %}
+    </div>
   {% endblock %}
 </div>

--- a/web/themes/custom/drevops/components/04-templates/page/page.twig
+++ b/web/themes/custom/drevops/components/04-templates/page/page.twig
@@ -59,7 +59,7 @@
  */
 #}
 
-{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
 {% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
 <div class="ct-page {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
   <a id="top" tab-index="-1" aria-hidden="true"></a>

--- a/web/themes/custom/drevops/components/04-templates/page/page.twig
+++ b/web/themes/custom/drevops/components/04-templates/page/page.twig
@@ -137,7 +137,7 @@
   {% endblock %}
 
   {% block back_to_top_block %}
-    {# Custom: Use include() instead of {% include only %}. #}
-    {{ include('civictheme:back-to-top') }}
+    {# Custom: Use include() instead of {% include only %} and inherit the page theme. #}
+    {{ include('civictheme:back-to-top', { theme: theme|default('dark') }) }}
   {% endblock %}
 </div>

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -16,6 +16,7 @@ require_once __DIR__ . '/includes/page.inc';
 require_once __DIR__ . '/includes/node.inc';
 require_once __DIR__ . '/includes/cards.inc';
 require_once __DIR__ . '/includes/sidebar_navigation.inc';
+require_once __DIR__ . '/includes/skip_link.inc';
 require_once __DIR__ . '/includes/content_moderation.inc';
 
 /**

--- a/web/themes/custom/drevops/includes/sidebar_navigation.inc
+++ b/web/themes/custom/drevops/includes/sidebar_navigation.inc
@@ -13,5 +13,7 @@ use Drupal\civictheme\CivicthemeConstants;
  * Implements template_preprocess_block__HOOK() for sidebar navigation.
  */
 function drevops_preprocess_block__menu_block__civictheme_sidebar_navigation(array &$variables): void {
-  $variables['theme'] = CivicthemeConstants::THEME_LIGHT;
+  // Pin the sidebar navigation to the dark scheme so it matches the site-wide
+  // dark mode rather than the CivicTheme default light scheme.
+  $variables['theme'] = CivicthemeConstants::THEME_DARK;
 }

--- a/web/themes/custom/drevops/includes/skip_link.inc
+++ b/web/themes/custom/drevops/includes/skip_link.inc
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Skip link theme alterations.
+ */
+
+declare(strict_types=1);
+
+use Drupal\civictheme\CivicthemeConstants;
+
+/**
+ * Implements hook_preprocess_HOOK() for the html template.
+ */
+function drevops_preprocess_html(array &$variables): void {
+  // CivicTheme themes the skip link per page and leaves it light on content
+  // pages; pin it to dark so this chrome matches the site-wide dark scheme.
+  $variables['skip_link_theme'] = CivicthemeConstants::THEME_DARK;
+}


### PR DESCRIPTION
Closes #184

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#184] Verb in past tense.`
- [x] Ticket number `#184` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally. (Docker stack down in board-worker clone; CI is green.)

## Changed

1. **Scheme field defaults (config/default/)** - Flipped `default_value` from `light` to `dark` in all 34 paragraph and block-content field config files covering `field_c_p_theme`, `field_c_p_list_item_theme`, `field_c_b_theme`, and `field_c_b_trigger_theme`. New content authored via the Drupal UI now defaults to the dark colour scheme automatically.

2. **Theme settings** - Set `skip_link.theme: dark` in both `civictheme.settings.yml` and `drevops.settings.yml` (`header.theme` and `footer.theme` were already dark).

3. **Subtheme template fallbacks** - Updated 8 CivicTheme component Twig templates (`banner.twig`, `divider.twig`, `header.twig`, `list.twig`, `navigation.twig`, `page.twig`, `navigation-card.twig`, `promo-card.twig`) to fall back to `'ct-theme-dark'` instead of `'ct-theme-light'` when no explicit theme is passed, so the rendered output carries the correct BEM modifier class.

4. **Chrome components that defaulted to light** - Three page-chrome components rendered light independently of the per-component scheme and are now pinned to dark: the sidebar navigation (`includes/sidebar_navigation.inc` now sets `CivicthemeConstants::THEME_DARK`), the skip link (new `includes/skip_link.inc` adds `drevops_preprocess_html()` setting `skip_link_theme` to dark), and the back-to-top control (`page.twig` inlines the back-to-top so its button inherits the page theme, since `civictheme:back-to-top` otherwise renders a fixed light button).

5. **Deploy hook migration** - Added `do_base_deploy_component_dark_theme()` in `web/modules/custom/do_base/do_base.deploy.php`. The hook re-saves existing paragraphs and content blocks that still carry a non-dark value across the four scheme fields, processing up to 50 per pass via Drush's `deploy:hook` sandbox and finishing once a pass finds nothing left to migrate. It is idempotent and guarded so a missing CivicTheme does not abort the deployment.

6. **Behat coverage** - Added `tests/behat/features/dark_mode.feature`. Both scenarios (the homepage and a freshly published `civictheme_page`) assert the response contains `ct-theme-dark` and does **not** contain `ct-theme-light`, so the suite fails if any element regresses to the light scheme.

## Screenshots

This change is visual (CivicTheme component templates and theme/colour-scheme config), but the local Docker stack for this board-worker clone was not running, so a live screenshot could not be captured. The rendered dark scheme is validated in CI by the Behat suite, which provisions the production database, runs the deploy migration, then asserts both the presence of `ct-theme-dark` and the absence of `ct-theme-light` on the homepage and on a published page.

## Before / After

```
BEFORE (mixed - content dark-capable, chrome still light)
┌─────────────────────────────────────────────────────┐
│  field_c_p_theme / field_c_b_theme default: light   │
│  skip_link.theme: light                             │
│                                                     │
│  <div class="ct-page">            (no dark modifier)│
│  <div class="ct-skip-link ct-theme-light">          │
│  <nav  class="ct-side-navigation ct-theme-light">   │
│  <button class="... ct-theme-light ...back-to-top"> │
└─────────────────────────────────────────────────────┘

AFTER (whole site dark)
┌─────────────────────────────────────────────────────┐
│  field_c_p_theme / field_c_b_theme default: dark    │
│  skip_link.theme: dark                              │
│                                                     │
│  <div class="ct-page ct-theme-dark">                │
│  <div class="ct-skip-link ct-theme-dark">           │
│  <nav  class="ct-side-navigation ct-theme-dark">    │
│  <button class="... ct-theme-dark ...back-to-top">  │
└─────────────────────────────────────────────────────┘

Existing content: do_base_deploy_component_dark_theme()
re-saves every paragraph/content-block still set to
'light' on the next `drush deploy`, in batches of 50.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated site theme behavior to default to **dark** instead of **light** across cards, headers, banners, dividers, navigation, page layout, and skip-link styling.
  * Changed default theme selections for multiple content and paragraph fields to **dark**.
  * Aligned sidebar navigation to use the **dark** theme.

* **New Features**
  * Added a deployment-time migration that converts eligible content components to the **dark** theme in batches.

* **Tests**
  * Added Behat coverage to verify dark mode markers on both the homepage and a sample content page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
