### PR TITLE
[#188] Added the expanded site footer with menus and contact details.

### DIFF
--- a/config/default/block.block.drevops_footer_acknowledgment_of_country.yml
+++ b/config/default/block.block.drevops_footer_acknowledgment_of_country.yml
@@ -1,6 +1,6 @@
 uuid: 91f028ef-9482-4092-901c-f9f6fee1667d
 langcode: en
-status: true
+status: false
 dependencies:
   content:
     - 'block_content:civictheme_component_block:7cf65f98-cbae-4e9d-b6ea-7d6d1c437c1c'

--- a/config/default/block.block.drevops_footer_brand_blurb.yml
+++ b/config/default/block.block.drevops_footer_brand_blurb.yml
@@ -1,0 +1,20 @@
+uuid: 5da7ede5-9e4c-4ef6-bbad-000cf05112af
+langcode: en
+status: true
+dependencies:
+  module:
+    - do_base
+  theme:
+    - drevops
+id: drevops_footer_brand_blurb
+theme: drevops
+region: footer_middle_1
+weight: 1
+provider: null
+plugin: do_base_footer_brand_blurb
+settings:
+  id: do_base_footer_brand_blurb
+  label: 'Footer brand blurb'
+  label_display: '0'
+  provider: do_base
+visibility: {  }

--- a/config/default/block.block.drevops_footer_company.yml
+++ b/config/default/block.block.drevops_footer_company.yml
@@ -1,23 +1,23 @@
-uuid: 1e672f42-ba50-42ce-ab5a-3e215446f9a0
+uuid: a33034da-5517-4260-921c-a0f4049f3974
 langcode: en
-status: false
+status: true
 dependencies:
   config:
-    - system.menu.civictheme-footer
+    - system.menu.footer-company
   module:
     - menu_block
   theme:
     - drevops
-id: drevops_footer_menu_3
+id: drevops_footer_company
 theme: drevops
 region: footer_middle_3
 weight: 0
 provider: null
-plugin: 'menu_block:civictheme-footer'
+plugin: 'menu_block:footer-company'
 settings:
-  id: 'menu_block:civictheme-footer'
-  label: 'Footer menu 3'
-  label_display: ''
+  id: 'menu_block:footer-company'
+  label: Company
+  label_display: visible
   provider: menu_block
   follow: false
   follow_parent: child
@@ -25,10 +25,10 @@ settings:
   label_link: false
   label_type: block
   level: 1
-  depth: 1
+  depth: 0
   expand_all_items: false
-  parent: 'civictheme-footer:'
+  parent: 'footer-company:'
   render_parent: false
-  suggestion: civictheme_footer
+  suggestion: ''
   hide_on_nonactive: false
 visibility: {  }

--- a/config/default/block.block.drevops_footer_copyright.yml
+++ b/config/default/block.block.drevops_footer_copyright.yml
@@ -1,6 +1,6 @@
 uuid: 7fd3b73d-3fae-42d4-aae1-8d3b81898049
 langcode: en
-status: true
+status: false
 dependencies:
   content:
     - 'block_content:civictheme_component_block:d7098a8c-3ba3-48f7-bc0c-5787ebaa0427'

--- a/config/default/block.block.drevops_footer_copyright_text.yml
+++ b/config/default/block.block.drevops_footer_copyright_text.yml
@@ -1,0 +1,20 @@
+uuid: 69851518-bc42-4d22-90e3-0b1e01d43cc7
+langcode: en
+status: true
+dependencies:
+  module:
+    - do_base
+  theme:
+    - drevops
+id: drevops_footer_copyright_text
+theme: drevops
+region: footer_bottom_1
+weight: 0
+provider: null
+plugin: do_base_footer_copyright
+settings:
+  id: do_base_footer_copyright
+  label: 'Footer copyright'
+  label_display: '0'
+  provider: do_base
+visibility: {  }

--- a/config/default/block.block.drevops_footer_cta.yml
+++ b/config/default/block.block.drevops_footer_cta.yml
@@ -1,23 +1,23 @@
-uuid: c47eb1b3-f060-498b-ac4b-725b0ebaf70d
+uuid: 99a550ba-7848-4620-9b2d-c83bd4768163
 langcode: en
-status: false
+status: true
 dependencies:
   config:
-    - system.menu.civictheme-footer
+    - system.menu.footer-cta
   module:
     - menu_block
   theme:
     - drevops
-id: drevops_footer_menu_4
+id: drevops_footer_cta
 theme: drevops
-region: footer_middle_4
+region: footer_bottom_2
 weight: 0
 provider: null
-plugin: 'menu_block:civictheme-footer'
+plugin: 'menu_block:footer-cta'
 settings:
-  id: 'menu_block:civictheme-footer'
-  label: 'Footer menu 4'
-  label_display: ''
+  id: 'menu_block:footer-cta'
+  label: ''
+  label_display: '0'
   provider: menu_block
   follow: false
   follow_parent: child
@@ -25,10 +25,10 @@ settings:
   label_link: false
   label_type: block
   level: 1
-  depth: 1
+  depth: 0
   expand_all_items: false
-  parent: 'civictheme-footer:'
+  parent: 'footer-cta:'
   render_parent: false
-  suggestion: civictheme_footer
+  suggestion: ''
   hide_on_nonactive: false
 visibility: {  }

--- a/config/default/block.block.drevops_footer_get_in_touch.yml
+++ b/config/default/block.block.drevops_footer_get_in_touch.yml
@@ -1,23 +1,23 @@
-uuid: 8abde768-f545-4ae5-8fdd-2fcc89e211a8
+uuid: 551dc76b-6a50-4e7b-9202-240905a37208
 langcode: en
-status: false
+status: true
 dependencies:
   config:
-    - system.menu.civictheme-footer
+    - system.menu.footer-contact
   module:
     - menu_block
   theme:
     - drevops
-id: drevops_footer_menu_2
+id: drevops_footer_get_in_touch
 theme: drevops
-region: footer_middle_2
+region: footer_middle_4
 weight: 0
 provider: null
-plugin: 'menu_block:civictheme-footer'
+plugin: 'menu_block:footer-contact'
 settings:
-  id: 'menu_block:civictheme-footer'
-  label: 'Footer menu 2'
-  label_display: ''
+  id: 'menu_block:footer-contact'
+  label: 'Get in touch'
+  label_display: visible
   provider: menu_block
   follow: false
   follow_parent: child
@@ -25,10 +25,10 @@ settings:
   label_link: false
   label_type: block
   level: 1
-  depth: 1
+  depth: 0
   expand_all_items: false
-  parent: 'civictheme-footer:'
+  parent: 'footer-contact:'
   render_parent: false
-  suggestion: civictheme_footer
+  suggestion: ''
   hide_on_nonactive: false
 visibility: {  }

--- a/config/default/block.block.drevops_footer_services.yml
+++ b/config/default/block.block.drevops_footer_services.yml
@@ -1,23 +1,23 @@
-uuid: 8a7bf8ec-1cb8-4dcf-89ba-4a0a01b5ef49
+uuid: 9475c28a-0cf8-461a-956e-3161e0cb82b6
 langcode: en
-status: false
+status: true
 dependencies:
   config:
-    - system.menu.civictheme-footer
+    - system.menu.footer-services
   module:
     - menu_block
   theme:
     - drevops
-id: drevops_footer_menu_1
+id: drevops_footer_services
 theme: drevops
-region: footer_middle_1
+region: footer_middle_2
 weight: 0
 provider: null
-plugin: 'menu_block:civictheme-footer'
+plugin: 'menu_block:footer-services'
 settings:
-  id: 'menu_block:civictheme-footer'
-  label: 'Footer menu 1'
-  label_display: ''
+  id: 'menu_block:footer-services'
+  label: Services
+  label_display: visible
   provider: menu_block
   follow: false
   follow_parent: child
@@ -25,10 +25,10 @@ settings:
   label_link: false
   label_type: block
   level: 1
-  depth: 1
+  depth: 0
   expand_all_items: false
-  parent: 'civictheme-footer:'
+  parent: 'footer-services:'
   render_parent: false
-  suggestion: civictheme_footer
+  suggestion: ''
   hide_on_nonactive: false
 visibility: {  }

--- a/config/default/block.block.drevops_footer_social_links.yml
+++ b/config/default/block.block.drevops_footer_social_links.yml
@@ -1,6 +1,6 @@
 uuid: 27d85161-27c3-4697-98c7-559fefb32f8e
 langcode: en
-status: true
+status: false
 dependencies:
   content:
     - 'block_content:civictheme_social_links:5c0ad15f-3e9c-4eeb-8525-7a064b06fc58'

--- a/config/default/block.block.drevops_sitebranding.yml
+++ b/config/default/block.block.drevops_sitebranding.yml
@@ -8,7 +8,7 @@ dependencies:
     - drevops
 id: drevops_sitebranding
 theme: drevops
-region: footer_top_1
+region: footer_middle_1
 weight: 0
 provider: null
 plugin: system_branding_block

--- a/config/default/system.menu.footer-company.yml
+++ b/config/default/system.menu.footer-company.yml
@@ -1,0 +1,8 @@
+uuid: 0f2964e7-ae7b-468d-a193-026d245d65c2
+langcode: en
+status: true
+dependencies: {  }
+id: footer-company
+label: 'Footer: Company'
+description: 'DrevOps expanded footer menu.'
+locked: false

--- a/config/default/system.menu.footer-contact.yml
+++ b/config/default/system.menu.footer-contact.yml
@@ -1,0 +1,8 @@
+uuid: 45ee750b-a1b0-4fdf-acba-1f6d5c8b4aa2
+langcode: en
+status: true
+dependencies: {  }
+id: footer-contact
+label: 'Footer: Get in touch'
+description: 'DrevOps expanded footer menu.'
+locked: false

--- a/config/default/system.menu.footer-cta.yml
+++ b/config/default/system.menu.footer-cta.yml
@@ -1,0 +1,8 @@
+uuid: 082f0027-503a-4024-9e3c-46d917ca06d7
+langcode: en
+status: true
+dependencies: {  }
+id: footer-cta
+label: 'Footer: Call to action'
+description: 'DrevOps expanded footer menu.'
+locked: false

--- a/config/default/system.menu.footer-services.yml
+++ b/config/default/system.menu.footer-services.yml
@@ -1,0 +1,8 @@
+uuid: 5c499d00-dde7-4993-a197-e1106d049061
+langcode: en
+status: true
+dependencies: {  }
+id: footer-services
+label: 'Footer: Services'
+description: 'DrevOps expanded footer menu.'
+locked: false

--- a/tests/behat/features/footer.feature
+++ b/tests/behat/features/footer.feature
@@ -1,0 +1,45 @@
+@footer @smoke
+Feature: Expanded footer
+
+  As a site visitor
+  I want a rich footer with the brand, key links and contact details
+  So that I can find my way around and reach DrevOps from the bottom of any page
+
+  @api
+  Scenario: The footer shows the brand, the three menus and the contact details
+    Given I am an anonymous user
+    When I go to the homepage
+    Then I should see "A technical digital agency that builds and supports reliable websites"
+    And I should see "Company"
+    And I should see "Get in touch"
+    And the response should contain "Website delivery"
+    And the response should contain "Ongoing support"
+    And the response should contain "AI-assisted delivery"
+    And the response should contain "Responsible AI"
+    And the response should contain "info@drevops.com"
+    And the response should contain "Open source on GitHub"
+
+  @api
+  Scenario: Every footer link resolves to its destination
+    Given I am an anonymous user
+    When I go to the homepage
+    Then the response should contain "href=\"/services\""
+    And the response should contain "href=\"/blog\""
+    And the response should contain "href=\"/responsible-ai\""
+    And the response should contain "href=\"/contact\""
+    And the response should contain "href=\"mailto:info@drevops.com\""
+    And the response should contain "href=\"tel:+61430093538\""
+    And the response should contain "href=\"https://github.com/drevops\""
+
+  @api
+  Scenario: The bottom bar shows the copyright and the call to action
+    Given I am an anonymous user
+    When I go to the homepage
+    Then I should see "Melbourne, Australia"
+    And I should see "Start a conversation"
+
+  @api @javascript
+  Scenario: The footer renders dark on the primary step-8 surface
+    Given I am an anonymous user
+    When I am on the homepage
+    Then the computed "background-color" of the element ".ct-footer" should be "#2b394d"

--- a/web/modules/custom/do_base/do_base.links.menu.yml
+++ b/web/modules/custom/do_base/do_base.links.menu.yml
@@ -9,53 +9,39 @@ do_base.admin_config_site:
 do_base.footer_services.website_delivery:
   title: 'Website delivery'
   menu_name: footer-services
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 5
+  url: 'internal:/services'
   weight: 0
 do_base.footer_services.ongoing_support:
   title: 'Ongoing support'
   menu_name: footer-services
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 18
+  url: 'internal:/services/support-plans'
   weight: 1
 do_base.footer_services.upgrades_migrations:
   title: 'Upgrades & migrations'
   menu_name: footer-services
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 26
+  url: 'internal:/services/migrations'
   weight: 2
 do_base.footer_services.ai_assisted_delivery:
   title: 'AI-assisted delivery'
   menu_name: footer-services
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 38
+  url: 'internal:/ai-integration-automation'
   weight: 3
 
 # Footer: Company.
 do_base.footer_company.blog:
   title: 'Blog'
   menu_name: footer-company
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 3
+  url: 'internal:/blog'
   weight: 0
 do_base.footer_company.responsible_ai:
   title: 'Responsible AI'
   menu_name: footer-company
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 37
+  url: 'internal:/responsible-ai'
   weight: 1
 do_base.footer_company.contact:
   title: 'Contact'
   menu_name: footer-company
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 8
+  url: 'internal:/contact'
   weight: 2
 
 # Footer: Get in touch.
@@ -75,11 +61,9 @@ do_base.footer_contact.github:
   url: 'https://github.com/drevops'
   weight: 2
 
-# Footer: Call to action.
+# Footer: Call to action. Shares the contact page with the Company > Contact link.
 do_base.footer_cta.start_conversation:
   title: 'Start a conversation'
   menu_name: footer-cta
-  route_name: entity.node.canonical
-  route_parameters:
-    node: 8
+  url: 'internal:/contact'
   weight: 0

--- a/web/modules/custom/do_base/do_base.links.menu.yml
+++ b/web/modules/custom/do_base/do_base.links.menu.yml
@@ -4,3 +4,82 @@ do_base.admin_config_site:
   parent: system.admin_config
   description: 'Site-specific configuration.'
   weight: 50
+
+# Footer: Services.
+do_base.footer_services.website_delivery:
+  title: 'Website delivery'
+  menu_name: footer-services
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 5
+  weight: 0
+do_base.footer_services.ongoing_support:
+  title: 'Ongoing support'
+  menu_name: footer-services
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 18
+  weight: 1
+do_base.footer_services.upgrades_migrations:
+  title: 'Upgrades & migrations'
+  menu_name: footer-services
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 26
+  weight: 2
+do_base.footer_services.ai_assisted_delivery:
+  title: 'AI-assisted delivery'
+  menu_name: footer-services
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 38
+  weight: 3
+
+# Footer: Company.
+do_base.footer_company.blog:
+  title: 'Blog'
+  menu_name: footer-company
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 3
+  weight: 0
+do_base.footer_company.responsible_ai:
+  title: 'Responsible AI'
+  menu_name: footer-company
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 37
+  weight: 1
+do_base.footer_company.contact:
+  title: 'Contact'
+  menu_name: footer-company
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 8
+  weight: 2
+
+# Footer: Get in touch.
+do_base.footer_contact.email:
+  title: 'info@drevops.com'
+  menu_name: footer-contact
+  url: 'mailto:info@drevops.com'
+  weight: 0
+do_base.footer_contact.phone:
+  title: '04 3009 3538'
+  menu_name: footer-contact
+  url: 'tel:+61430093538'
+  weight: 1
+do_base.footer_contact.github:
+  title: 'Open source on GitHub'
+  menu_name: footer-contact
+  url: 'https://github.com/drevops'
+  weight: 2
+
+# Footer: Call to action.
+do_base.footer_cta.start_conversation:
+  title: 'Start a conversation'
+  menu_name: footer-cta
+  route_name: entity.node.canonical
+  route_parameters:
+    node: 8
+  weight: 0

--- a/web/modules/custom/do_base/src/Plugin/Block/FooterBrandBlurbBlock.php
+++ b/web/modules/custom/do_base/src/Plugin/Block/FooterBrandBlurbBlock.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_base\Plugin\Block;
+
+use Drupal\Core\Block\Attribute\Block;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Provides the brand blurb shown in the first footer column.
+ */
+#[Block(
+  id: 'do_base_footer_brand_blurb',
+  admin_label: new TranslatableMarkup('Footer brand blurb'),
+  category: new TranslatableMarkup('DrevOps'),
+)]
+final class FooterBrandBlurbBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    return [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('A technical digital agency that builds and supports reliable websites, engineered properly. Direct with you, or as the technical partner behind your agency.'),
+    ];
+  }
+
+}

--- a/web/modules/custom/do_base/src/Plugin/Block/FooterBrandBlurbBlock.php
+++ b/web/modules/custom/do_base/src/Plugin/Block/FooterBrandBlurbBlock.php
@@ -6,6 +6,7 @@ namespace Drupal\do_base\Plugin\Block;
 
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
@@ -26,6 +27,8 @@ final class FooterBrandBlurbBlock extends BlockBase {
       '#type' => 'html_tag',
       '#tag' => 'p',
       '#value' => $this->t('A technical digital agency that builds and supports reliable websites, engineered properly. Direct with you, or as the technical partner behind your agency.'),
+      // Static brand copy: cache permanently.
+      '#cache' => ['max-age' => Cache::PERMANENT],
     ];
   }
 

--- a/web/modules/custom/do_base/src/Plugin/Block/FooterCopyrightBlock.php
+++ b/web/modules/custom/do_base/src/Plugin/Block/FooterCopyrightBlock.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_base\Plugin\Block;
+
+use Drupal\Core\Block\Attribute\Block;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Provides the copyright line shown in the footer bottom bar.
+ */
+#[Block(
+  id: 'do_base_footer_copyright',
+  admin_label: new TranslatableMarkup('Footer copyright'),
+  category: new TranslatableMarkup('DrevOps'),
+)]
+final class FooterCopyrightBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    return [
+      '#type' => 'html_tag',
+      '#tag' => 'span',
+      '#value' => $this->t('DrevOps © @year - Melbourne, Australia. Working across AU & NZ.', ['@year' => date('Y')]),
+      // The rendered year changes daily at most; refresh once a day so a
+      // cached page does not carry a stale year across a new year boundary.
+      '#cache' => ['max-age' => 86400],
+    ];
+  }
+
+}

--- a/web/themes/custom/drevops/components/03-organisms/footer/footer.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/footer/footer.component.yml
@@ -1,0 +1,55 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Footer
+status: stable
+description: Expanded footer with a four-column grid and a bottom bar.
+replaces: civictheme:footer
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+    background_image:
+      type: string
+      title: Background Image
+      description: Content background inline image.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier Class
+      description: Additional CSS classes.
+slots:
+  content_top1:
+    title: Content Top 1
+    description: Top section first content slot.
+  content_top2:
+    title: Content Top 2
+    description: Top section second content slot.
+  content_middle1:
+    title: Content Middle 1
+    description: First column - brand logo and blurb.
+  content_middle2:
+    title: Content Middle 2
+    description: Second column - first link menu.
+  content_middle3:
+    title: Content Middle 3
+    description: Third column - second link menu.
+  content_middle4:
+    title: Content Middle 4
+    description: Fourth column - contact menu.
+  content_middle5:
+    title: Content Middle 5
+    description: Full-width middle slot.
+  content_bottom1:
+    title: Content Bottom 1
+    description: Bottom bar start - copyright.
+  content_bottom2:
+    title: Content Bottom 2
+    description: Bottom bar end - call to action.

--- a/web/themes/custom/drevops/components/03-organisms/footer/footer.scss
+++ b/web/themes/custom/drevops/components/03-organisms/footer/footer.scss
@@ -124,7 +124,7 @@
     }
   }
 
-  @media (max-width: 47.99rem) {
+  @media (max-width: 48rem) {
     padding: 3rem 1.5rem 2rem;
 
     &__grid {

--- a/web/themes/custom/drevops/components/03-organisms/footer/footer.scss
+++ b/web/themes/custom/drevops/components/03-organisms/footer/footer.scss
@@ -1,0 +1,141 @@
+//
+// Expanded footer component styles.
+//
+// Ports the redesign footer from static-prototype/ (the `.component-footer-*`
+// blocks). Colours map to the CivicTheme dark palette via ct-color-constant-dark
+// so the values are baked at build time; spacing mirrors the prototype's
+// `--space-*` scale, which is not exposed as theme tokens.
+//
+
+.ct-footer {
+  // Primary step-8 surface, one step lighter than the page canvas (step-9).
+  background-color: ct-color-constant-dark('primary-8');
+  border-top: 0.0625rem solid color-mix(in srgb, #{ct-color-constant-dark('secondary-6')} 20%, transparent);
+  padding: 4.5rem 4rem 2.5rem;
+  color: ct-color-constant-dark('primary-3');
+
+  &__inner {
+    max-width: 75rem;
+    margin: 0 auto;
+  }
+
+  // Four-column grid: a wider brand column, two link columns, a contact column.
+  &__grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 1.2fr;
+    gap: 3rem;
+    margin-bottom: 3.5rem;
+  }
+
+  &__col {
+    // Column heading (the menu block label) rendered as a small uppercase label.
+    .block__title,
+    h2,
+    h3,
+    h4 {
+      margin: 0 0 1.5rem;
+      font-size: 0.6875rem;
+      font-weight: 400;
+      line-height: 1.4;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: ct-color-constant-dark('primary-1');
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    li {
+      margin: 0;
+    }
+
+    // The menus render through CivicTheme's link component in the light scheme;
+    // qualify with .ct-link so the dark-on-dark colours outrank it.
+    a,
+    a.ct-link {
+      font-size: 0.875rem;
+      line-height: 1.4;
+      color: ct-color-constant-dark('primary-3');
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        color: ct-color-constant-dark('secondary-1');
+        text-decoration: none;
+      }
+    }
+
+    // The prototype footer uses plain text links; drop CivicTheme's automatic
+    // external-link icon while keeping the visually-hidden "new tab" hint.
+    .ct-menu__item__link .ct-icon {
+      display: none;
+    }
+  }
+
+  // Brand column: logo above an introductory blurb.
+  &__col--brand {
+    .ct-logo,
+    img {
+      margin-bottom: 1.5rem;
+    }
+
+    p {
+      margin: 0;
+      max-width: 21.25rem;
+      font-size: 0.875rem;
+      line-height: 1.75;
+      color: ct-color-constant-dark('primary-3');
+    }
+  }
+
+  // Bottom bar: copyright on the left, a call-to-action link on the right.
+  &__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-top: 2rem;
+    border-top: 0.0625rem solid color-mix(in srgb, white 6%, transparent);
+    font-size: 0.875rem;
+    color: ct-color-constant-dark('primary-3');
+
+    // The call to action uses the brand interaction teal so it stays legible on
+    // the dark surface (the prototype's muted teal fails contrast here).
+    a,
+    a.ct-link {
+      color: ct-color-constant-dark('secondary-2');
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        color: ct-color-constant-dark('secondary-1');
+        text-decoration: underline;
+      }
+    }
+
+    .ct-menu__item__link .ct-icon {
+      display: none;
+    }
+  }
+
+  @media (max-width: 47.99rem) {
+    padding: 3rem 1.5rem 2rem;
+
+    &__grid {
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+    }
+
+    &__bar {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.75rem;
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/footer/footer.twig
+++ b/web/themes/custom/drevops/components/03-organisms/footer/footer.twig
@@ -19,6 +19,9 @@
  * - content_middle5: Full-width middle slot.
  * - content_bottom1: Bottom bar start - copyright.
  * - content_bottom2: Bottom bar end - call to action.
+ *
+ * The per-slot `ct-footer__<section>__content-<slot>` classes keep each footer
+ * region individually addressable (see the Behat region map).
  */
 #}
 
@@ -36,10 +39,10 @@
       {% if has_top %}
         <div class="ct-footer__top">
           {% if content_top1 is not empty %}
-            <div class="ct-footer__top-item">{{ content_top1 }}</div>
+            <div class="ct-footer__top-item ct-footer__top__content-top1">{{ content_top1 }}</div>
           {% endif %}
           {% if content_top2 is not empty %}
-            <div class="ct-footer__top-item">{{ content_top2 }}</div>
+            <div class="ct-footer__top-item ct-footer__top__content-top2">{{ content_top2 }}</div>
           {% endif %}
         </div>
       {% endif %}
@@ -47,31 +50,31 @@
       {% if has_grid %}
         <div class="ct-footer__grid">
           {% if content_middle1 is not empty %}
-            <div class="ct-footer__col ct-footer__col--brand">{{ content_middle1 }}</div>
+            <div class="ct-footer__col ct-footer__col--brand ct-footer__middle__content-middle1">{{ content_middle1 }}</div>
           {% endif %}
           {% if content_middle2 is not empty %}
-            <div class="ct-footer__col">{{ content_middle2 }}</div>
+            <div class="ct-footer__col ct-footer__middle__content-middle2">{{ content_middle2 }}</div>
           {% endif %}
           {% if content_middle3 is not empty %}
-            <div class="ct-footer__col">{{ content_middle3 }}</div>
+            <div class="ct-footer__col ct-footer__middle__content-middle3">{{ content_middle3 }}</div>
           {% endif %}
           {% if content_middle4 is not empty %}
-            <div class="ct-footer__col">{{ content_middle4 }}</div>
+            <div class="ct-footer__col ct-footer__middle__content-middle4">{{ content_middle4 }}</div>
           {% endif %}
         </div>
       {% endif %}
 
       {% if content_middle5 is not empty %}
-        <div class="ct-footer__wide">{{ content_middle5 }}</div>
+        <div class="ct-footer__wide ct-footer__middle__content-middle5">{{ content_middle5 }}</div>
       {% endif %}
 
       {% if has_bottom %}
         <div class="ct-footer__bar">
           {% if content_bottom1 is not empty %}
-            <div class="ct-footer__bar-start">{{ content_bottom1 }}</div>
+            <div class="ct-footer__bar-start ct-footer__bottom__content-bottom1">{{ content_bottom1 }}</div>
           {% endif %}
           {% if content_bottom2 is not empty %}
-            <div class="ct-footer__bar-end">{{ content_bottom2 }}</div>
+            <div class="ct-footer__bar-end ct-footer__bottom__content-bottom2">{{ content_bottom2 }}</div>
           {% endif %}
         </div>
       {% endif %}

--- a/web/themes/custom/drevops/components/03-organisms/footer/footer.twig
+++ b/web/themes/custom/drevops/components/03-organisms/footer/footer.twig
@@ -1,0 +1,81 @@
+{#
+/**
+ * @file
+ * Expanded footer component.
+ *
+ * Props:
+ * - theme: [string] Theme variation (light or dark).
+ * - background_image: [string] Content background inline image.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
+ * - modifier_class: [string] Additional CSS classes.
+ *
+ * Slots:
+ * - content_top1: Top section first content slot.
+ * - content_top2: Top section second content slot.
+ * - content_middle1: First column - brand logo and blurb.
+ * - content_middle2: Second column - first link menu.
+ * - content_middle3: Third column - second link menu.
+ * - content_middle4: Fourth column - contact menu.
+ * - content_middle5: Full-width middle slot.
+ * - content_bottom1: Bottom bar start - copyright.
+ * - content_bottom2: Bottom bar end - call to action.
+ */
+#}
+
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
+
+{% set has_top = content_top1 is not empty or content_top2 is not empty %}
+{% set has_grid = content_middle1 is not empty or content_middle2 is not empty or content_middle3 is not empty or content_middle4 is not empty %}
+{% set has_bottom = content_bottom1 is not empty or content_bottom2 is not empty %}
+
+{% if has_top or has_grid or content_middle5 is not empty or has_bottom %}
+  <footer class="ct-footer {{ modifier_class -}}" role="contentinfo" data-component-name="ct-footer" {% if background_image %}style="background-image: url('{{ background_image }}')"{% endif %} {% if attributes %}{{ attributes }}{% endif %}>
+    <div class="ct-footer__inner">
+
+      {% if has_top %}
+        <div class="ct-footer__top">
+          {% if content_top1 is not empty %}
+            <div class="ct-footer__top-item">{{ content_top1 }}</div>
+          {% endif %}
+          {% if content_top2 is not empty %}
+            <div class="ct-footer__top-item">{{ content_top2 }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {% if has_grid %}
+        <div class="ct-footer__grid">
+          {% if content_middle1 is not empty %}
+            <div class="ct-footer__col ct-footer__col--brand">{{ content_middle1 }}</div>
+          {% endif %}
+          {% if content_middle2 is not empty %}
+            <div class="ct-footer__col">{{ content_middle2 }}</div>
+          {% endif %}
+          {% if content_middle3 is not empty %}
+            <div class="ct-footer__col">{{ content_middle3 }}</div>
+          {% endif %}
+          {% if content_middle4 is not empty %}
+            <div class="ct-footer__col">{{ content_middle4 }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {% if content_middle5 is not empty %}
+        <div class="ct-footer__wide">{{ content_middle5 }}</div>
+      {% endif %}
+
+      {% if has_bottom %}
+        <div class="ct-footer__bar">
+          {% if content_bottom1 is not empty %}
+            <div class="ct-footer__bar-start">{{ content_bottom1 }}</div>
+          {% endif %}
+          {% if content_bottom2 is not empty %}
+            <div class="ct-footer__bar-end">{{ content_bottom2 }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
+
+    </div>
+  </footer>
+{% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#188] Verb in past tense.`
- [x] Ticket number `#188` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

Closes #188

## Changed

1. Added a `drevops:footer` SDC that replaces `civictheme:footer` via the `replaces:` key. The component ships three files: `footer.component.yml` (slot/prop schema), `footer.twig` (four-column grid + bottom bar), and `footer.scss` (dark surface using `ct-color-constant-dark('primary-8')` = `#2b394d`).
2. Created four Drupal menus (`footer-services`, `footer-company`, `footer-contact`, `footer-cta`) and registered all static links in `do_base.links.menu.yml` using `internal:/` path aliases so links survive content rebuilds.
3. Replaced the four generic `drevops_footer_menu_*` block configs with named blocks (`drevops_footer_services`, `drevops_footer_company`, `drevops_footer_get_in_touch`, `drevops_footer_cta`) wired to the new menus, set depth to 0 (all levels), and made labels visible. Moved the site-branding block from `footer_top_1` to `footer_middle_1`. Disabled the old `drevops_footer_social_links`, `drevops_footer_copyright`, and `drevops_footer_acknowledgment_of_country` blocks.
4. Added two PHP Block plugins (`FooterBrandBlurbBlock`, `FooterCopyrightBlock`) so the fixed brand copy and copyright line are code-defined and consistent across every environment - no content entity dependency.
5. Kept the per-region wrapper classes (`ct-footer__<section>__content-<slot>`) on each slot in `footer.twig` so every footer region stays individually addressable by the Behat region map in `behat.yml`.
6. Added Behat coverage in `tests/behat/features/footer.feature` covering column text, link href resolution, bottom bar content, and the dark `#2b394d` surface via a computed-style assertion.

**Intentional divergences from the prototype:**
- The "Start a conversation" CTA link in the bottom bar uses `ct-color-constant-dark('secondary-2')` (brand interaction teal `#96e7f4`) rather than the prototype's muted `#1e7582`. The prototype value fails WCAG AA contrast on the `#2b394d` dark surface.
- The separate social-icons row has been removed to match the prototype's current state. The GitHub link is preserved inside the "Get in touch" column.
- **Requires human confirmation:** the Acknowledgment of Country block is disabled (`status: false`). Please confirm this is intentional for the new footer design or advise where it should be relocated.

## Screenshots

![Expanded footer](https://raw.githubusercontent.com/drevops/website/ace1924cf2dfa996a48d162656e333eb3102dd1c/feature-188-expanded-footer/d27568a46ce4467ca46796ecb02d9a3c1a8be861.png)

## Before / After

```
BEFORE (default CivicTheme footer)
┌─────────────────────────────────────────────────────────────┐
│  [Logo]                                                     │
│                                                             │
│  [Social links]   [Footer menu 1-4 (generic, disabled)]     │
│                                                             │
│  Acknowledgment of Country (block)                          │
│  Copyright (content block)                                  │
└─────────────────────────────────────────────────────────────┘

AFTER (expanded drevops:footer SDC, dark #2b394d surface)
┌─────────────────────────────────────────────────────────────┐
│                                                             │
│  [Logo]         Services       Company      Get in touch    │
│  A technical    Website        Blog         info@drevops.com│
│  digital        delivery       Responsible  04 3009 3538    │
│  agency...      Ongoing        AI           Open source on  │
│                 support        Contact      GitHub          │
│                 Upgrades &                                  │
│                 migrations                                  │
│                 AI-assisted                                 │
│                 delivery                                    │
│─────────────────────────────────────────────────────────────│
│ DrevOps © 2026 - Melbourne, Australia    Start a conversation│
└─────────────────────────────────────────────────────────────┘
```
