### PR TITLE
[#189] Added Hero component with six contextual variants.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.hero.default.yml
+++ b/config/default/core.entity_form_display.paragraph.hero.default.yml
@@ -1,0 +1,86 @@
+uuid: 8fb7cf72-4bc3-4d99-80ea-aedf63f20ba8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero.field_c_p_image
+    - field.field.paragraph.hero.field_c_p_links
+    - field.field.paragraph.hero.field_c_p_subtitle
+    - field.field.paragraph.hero.field_c_p_summary
+    - field.field.paragraph.hero.field_c_p_theme
+    - field.field.paragraph.hero.field_c_p_title
+    - field.field.paragraph.hero.field_c_p_type
+    - paragraphs.paragraphs_type.hero
+  module:
+    - link
+    - media_library
+id: paragraph.hero.default
+targetEntityType: paragraph
+bundle: hero
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 7
+    region: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_c_p_image:
+    type: media_library_widget
+    weight: 5
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_c_p_links:
+    type: link_default
+    weight: 4
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_c_p_subtitle:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_summary:
+    type: string_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 4
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_theme:
+    type: options_buttons
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_p_title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_type:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 8
+    region: hidden
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/default/core.entity_view_display.paragraph.hero.default.yml
+++ b/config/default/core.entity_view_display.paragraph.hero.default.yml
@@ -1,0 +1,68 @@
+uuid: 8736c3c3-24e3-4abf-8ca9-7cbf5aedfae5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.hero.field_c_p_image
+    - field.field.paragraph.hero.field_c_p_links
+    - field.field.paragraph.hero.field_c_p_subtitle
+    - field.field.paragraph.hero.field_c_p_summary
+    - field.field.paragraph.hero.field_c_p_theme
+    - field.field.paragraph.hero.field_c_p_title
+    - field.field.paragraph.hero.field_c_p_type
+    - paragraphs.paragraphs_type.hero
+  module:
+    - link
+id: paragraph.hero.default
+targetEntityType: paragraph
+bundle: hero
+mode: default
+content:
+  field_c_p_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_c_p_links:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_c_p_subtitle:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_c_p_summary:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_c_p_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  field_c_p_theme: true
+  field_c_p_type: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -14,12 +14,14 @@ dependencies:
     - paragraphs.paragraphs_type.civictheme_iframe
     - paragraphs.paragraphs_type.civictheme_manual_list
     - paragraphs.paragraphs_type.civictheme_map
+    - paragraphs.paragraphs_type.civictheme_message
     - paragraphs.paragraphs_type.civictheme_next_step
     - paragraphs.paragraphs_type.civictheme_promo
     - paragraphs.paragraphs_type.civictheme_slider
     - paragraphs.paragraphs_type.civictheme_webform
     - paragraphs.paragraphs_type.divider
     - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.hero
   module:
     - entity_reference_revisions
 _core:
@@ -54,6 +56,7 @@ settings:
       divider: divider
       from_library: from_library
       civictheme_message: civictheme_message
+      hero: hero
     negate: 0
     target_bundles_drag_drop:
       civictheme_accordion:
@@ -151,5 +154,8 @@ settings:
         enabled: true
       from_library:
         weight: 62
+        enabled: true
+      hero:
+        weight: -60
         enabled: true
 field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.hero.field_c_p_image.yml
+++ b/config/default/field.field.paragraph.hero.field_c_p_image.yml
@@ -1,0 +1,29 @@
+uuid: 77411be8-ac88-463d-ac5e-fc6fa9bf83da
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_image
+    - media.type.civictheme_image
+    - paragraphs.paragraphs_type.hero
+id: paragraph.hero.field_c_p_image
+field_name: field_c_p_image
+entity_type: paragraph
+bundle: hero
+label: 'Background image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      civictheme_image: civictheme_image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.paragraph.hero.field_c_p_links.yml
+++ b/config/default/field.field.paragraph.hero.field_c_p_links.yml
@@ -1,0 +1,23 @@
+uuid: eb134aa7-beb7-43f7-ba9c-c9ca05846cde
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_links
+    - paragraphs.paragraphs_type.hero
+  module:
+    - link
+id: paragraph.hero.field_c_p_links
+field_name: field_c_p_links
+entity_type: paragraph
+bundle: hero
+label: Actions
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/config/default/field.field.paragraph.hero.field_c_p_subtitle.yml
+++ b/config/default/field.field.paragraph.hero.field_c_p_subtitle.yml
@@ -1,0 +1,19 @@
+uuid: c6f7e1c9-92b6-496c-8211-b1bc4e8c6c31
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_subtitle
+    - paragraphs.paragraphs_type.hero
+id: paragraph.hero.field_c_p_subtitle
+field_name: field_c_p_subtitle
+entity_type: paragraph
+bundle: hero
+label: Eyebrow
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.hero.field_c_p_summary.yml
+++ b/config/default/field.field.paragraph.hero.field_c_p_summary.yml
@@ -1,0 +1,19 @@
+uuid: 059f6e55-2f7b-4edc-b83e-67266335edae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_summary
+    - paragraphs.paragraphs_type.hero
+id: paragraph.hero.field_c_p_summary
+field_name: field_c_p_summary
+entity_type: paragraph
+bundle: hero
+label: Lead
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.field.paragraph.hero.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.hero.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: f9e75293-a39a-4d20-8425-cf17687a4644
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.hero
+  module:
+    - options
+id: paragraph.hero.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: hero
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.hero.field_c_p_title.yml
+++ b/config/default/field.field.paragraph.hero.field_c_p_title.yml
@@ -1,0 +1,19 @@
+uuid: 049ad2c2-b5bd-4f7b-9361-937136db34e2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_title
+    - paragraphs.paragraphs_type.hero
+id: paragraph.hero.field_c_p_title
+field_name: field_c_p_title
+entity_type: paragraph
+bundle: hero
+label: Heading
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.hero.field_c_p_type.yml
+++ b/config/default/field.field.paragraph.hero.field_c_p_type.yml
@@ -1,0 +1,21 @@
+uuid: 0da84fa3-c62b-4316-a168-698c00aa707c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_type
+    - paragraphs.paragraphs_type.hero
+  module:
+    - options
+id: paragraph.hero.field_c_p_type
+field_name: field_c_p_type
+entity_type: paragraph
+bundle: hero
+label: Type
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.storage.paragraph.field_c_p_type.yml
+++ b/config/default/field.storage.paragraph.field_c_p_type.yml
@@ -1,0 +1,21 @@
+uuid: eeeaaf97-9a39-4a4e-922a-f3aa61ade837
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_c_p_type
+field_name: field_c_p_type
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values: {  }
+  allowed_values_function: do_base_field_c_p_type_allowed_values
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/paragraphs.paragraphs_type.hero.yml
+++ b/config/default/paragraphs.paragraphs_type.hero.yml
@@ -1,0 +1,10 @@
+uuid: 50e5b3b1-4f13-43b0-a368-5e48a9580278
+langcode: en
+status: true
+dependencies: {  }
+id: hero
+label: Hero
+icon_uuid: null
+icon_default: null
+description: 'A banner or intro that renders one of six variants for its context.'
+behavior_plugins: {  }

--- a/tests/behat/features/paragraph_hero_fields.feature
+++ b/tests/behat/features/paragraph_hero_fields.feature
@@ -1,0 +1,40 @@
+@p1 @civictheme @drevops @hero
+Feature: Hero fields
+
+  As a content editor
+  I want to add a hero to a page and choose its type
+  So that I can open a page or introduce a section in the right context
+
+  @api
+  Scenario: Fields appear as expected and the heading is required
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "node/add/civictheme_page"
+    And I fill in "Title" with "[TEST] Page hero fields"
+    And I press "Add Hero"
+
+    Then I should see the text "Type"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_type]']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_type]'] option[value='home']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_type]'] option[value='inner']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_type]'] option[value='page']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_type]'] option[value='contact']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_type]'] option[value='article']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_type]'] option[value='section']" element
+
+    And I should see the text "Eyebrow"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_subtitle][0][value]']" element
+
+    And I should see the text "Heading"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_title][0][value]']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_title][0][value]'].required" element
+
+    And I should see the text "Lead"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_summary][0][value]']" element
+
+    And I should see the text "Actions"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_links][0][uri]']" element
+
+    And I should see the text "Background image"
+
+    And I should see the text "Theme"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_theme]']" element

--- a/tests/behat/features/paragraph_hero_fields.feature
+++ b/tests/behat/features/paragraph_hero_fields.feature
@@ -35,6 +35,7 @@ Feature: Hero fields
     And should see a "[name='field_c_n_components[0][subform][field_c_p_links][0][uri]']" element
 
     And I should see the text "Background image"
+    And should see a ".field--name-field-c-p-image" element
 
     And I should see the text "Theme"
     And should see a "[name='field_c_n_components[0][subform][field_c_p_theme]']" element

--- a/tests/behat/features/paragraph_hero_render.feature
+++ b/tests/behat/features/paragraph_hero_render.feature
@@ -1,0 +1,75 @@
+@p1 @civictheme @drevops @hero
+Feature: Hero render
+
+  As a site visitor
+  I want each hero variant to render in its intended treatment
+  So that pages and sections open in the right context
+
+  Background:
+    Given the following managed files:
+      | path      | uri                        | status |
+      | image.jpg | public://do_test/image.jpg | 1      |
+
+    And the following media "civictheme_image" exist:
+      | name            | field_c_m_image |
+      | [TEST] DO Image | image.jpg       |
+
+    And the following "civictheme_page" content:
+      | title                    | status |
+      | [TEST] Page Hero home    | 1      |
+      | [TEST] Page Hero section | 1      |
+      | [TEST] Page Hero article | 1      |
+
+  @api @javascript
+  Scenario: The home hero opens with a full banner, scroll indicator and content
+    Given I am an anonymous user
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Hero home":
+      | field_c_p_type     | home                  |
+      | field_c_p_theme    | dark                  |
+      | field_c_p_subtitle | [TEST] Hero eyebrow   |
+      | field_c_p_title    | [TEST] Hero home lead |
+      | field_c_p_summary  | [TEST] Hero home body |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Hero home"
+    Then I should see an "article .component-hero.component-hero--home" element
+    And I should see an "article .component-hero--home.ct-theme-dark" element
+    And I should see an "article .component-hero--home .component-hero-eyebrow" element
+    And I should see an "article .component-hero--home .component-hero-title" element
+    And I should see an "article .component-hero--home .component-hero-lead" element
+    And I should see an "article .component-hero--home .component-scroll-indicator" element
+    And I should see the text "[TEST] Hero home lead"
+    And save screenshot
+
+  @api @javascript
+  Scenario: The section hero renders a centred band with no scroll indicator
+    Given I am an anonymous user
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Hero section":
+      | field_c_p_type     | section                  |
+      | field_c_p_theme    | dark                     |
+      | field_c_p_subtitle | [TEST] Hero section label |
+      | field_c_p_title    | [TEST] Hero section lead |
+      | field_c_p_summary  | [TEST] Hero section body |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Hero section"
+    Then I should see an "article .component-hero.component-hero--section" element
+    And I should see an "article .component-hero--section .component-hero-title" element
+    And I should not see an "article .component-hero--section .component-scroll-indicator" element
+    And I should see the text "[TEST] Hero section lead"
+    And save screenshot
+
+  @api @javascript
+  Scenario: The article hero renders the background image behind an overlay
+    Given I am an anonymous user
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Hero article":
+      | field_c_p_type  | article                  |
+      | field_c_p_theme | dark                     |
+      | field_c_p_title | [TEST] Hero article lead |
+      | field_c_p_image | [TEST] DO Image          |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Hero article"
+    Then I should see an "article .component-hero.component-hero--article" element
+    And I should see an "article .component-hero--article .component-hero__image img" element
+    And I should see an "article .component-hero--article .component-hero__overlay" element
+    And I should see an "article .component-hero--article .component-hero__title" element
+    And I should see the text "[TEST] Hero article lead"
+    And save screenshot

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
-use Drupal\csp\Csp;
 use Drupal\Core\Site\Settings;
+use Drupal\csp\Csp;
 
 /**
  * Allowed values for the shared paragraph component "type" selector.

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -7,8 +7,44 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\csp\Csp;
 use Drupal\Core\Site\Settings;
+
+/**
+ * Allowed values for the shared paragraph component "type" selector.
+ *
+ * A single field storage backs the variant selector across several paragraph
+ * bundles, each offering its own set of variants, so the options are resolved
+ * from the host bundle rather than fixed on the storage. Without bundle context
+ * (settings forms, validation of already-stored values) every bundle's options
+ * are exposed so stored values stay valid.
+ */
+function do_base_field_c_p_type_allowed_values(FieldStorageDefinitionInterface $definition, ?FieldableEntityInterface $entity = NULL): array {
+  $bundle_values = [
+    'hero' => [
+      'home' => 'Home',
+      'inner' => 'Inner',
+      'page' => 'Page',
+      'contact' => 'Contact',
+      'article' => 'Article',
+      'section' => 'Section',
+    ],
+  ];
+
+  $bundle = $entity?->bundle();
+  if ($bundle !== NULL && isset($bundle_values[$bundle])) {
+    return $bundle_values[$bundle];
+  }
+
+  $all = [];
+  foreach ($bundle_values as $values) {
+    $all += $values;
+  }
+
+  return $all;
+}
 
 /**
  * Implements hook_mail_alter().

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -39,8 +39,8 @@ function do_base_field_c_p_type_allowed_values(FieldStorageDefinitionInterface $
   }
 
   $all = [];
-  foreach ($bundle_values as $values) {
-    $all += $values;
+  foreach ($bundle_values as $bundle_value) {
+    $all += $bundle_value;
   }
 
   return $all;

--- a/web/themes/custom/drevops/assets/sass/base/_infrastructure.scss
+++ b/web/themes/custom/drevops/assets/sass/base/_infrastructure.scss
@@ -2,8 +2,16 @@
 // Site infrastructure styles.
 //
 // Site-wide presentation that sits outside any single component: the global
-// grain overlay and smooth in-page scrolling.
+// grain overlay, horizontal-overflow clipping and smooth in-page scrolling.
 //
+
+// Full-bleed sections (such as the hero) span the viewport width by breaking
+// out of the constrained content column. Clipping horizontal overflow on the
+// root keeps that viewport-wide width from adding a horizontal scrollbar while
+// leaving vertical scrolling untouched.
+html {
+  overflow-x: clip;
+}
 
 // Grain overlay.
 //

--- a/web/themes/custom/drevops/components/03-organisms/hero/hero.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/hero/hero.component.yml
@@ -42,6 +42,7 @@ props:
       type: array
       title: Actions
       description: Up to two call-to-action links.
+      maxItems: 2
       items:
         type: object
         properties:

--- a/web/themes/custom/drevops/components/03-organisms/hero/hero.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/hero/hero.component.yml
@@ -1,0 +1,91 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Hero
+status: stable
+description: Page or section opener that renders one of six contextual variants.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: dark
+    type:
+      type: string
+      title: Type
+      description: Variant that sets the hero treatment for its context.
+      enum:
+        - home
+        - inner
+        - page
+        - contact
+        - article
+        - section
+      default: home
+    background_image:
+      type: object
+      title: Background image
+      description: Image shown behind the overlay for the article variant.
+      properties:
+        url:
+          type: string
+          title: URL
+          description: Image source URL.
+        alt:
+          type: string
+          title: Alt text
+          description: Image alt text.
+    actions:
+      type: array
+      title: Actions
+      description: Up to two call-to-action links.
+      items:
+        type: object
+        properties:
+          text:
+            type: string
+            title: Text
+            description: Link text.
+          url:
+            type: string
+            title: URL
+            description: Link URL.
+          type:
+            type: string
+            title: Type
+            description: Button style (primary, secondary, tertiary).
+          is_external:
+            type: boolean
+            title: External
+            description: Whether the link is external.
+          is_new_window:
+            type: boolean
+            title: New window
+            description: Whether to open the link in a new window.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier class
+      description: Additional CSS classes.
+slots:
+  eyebrow:
+    title: Eyebrow
+    description: Short label above the heading.
+  heading:
+    title: Heading
+    description: Main hero heading.
+  lead:
+    title: Lead
+    description: Supporting lead paragraph.
+  meta:
+    title: Meta
+    description: Article meta such as date and read time.
+  tags:
+    title: Tags
+    description: Article tags.

--- a/web/themes/custom/drevops/components/03-organisms/hero/hero.scss
+++ b/web/themes/custom/drevops/components/03-organisms/hero/hero.scss
@@ -9,13 +9,13 @@
 // continuous glow and scroll-pulse are gated behind prefers-reduced-motion.
 //
 
-$hero-bg: ct-color-constant-dark('primary-9');
-$hero-bg-contact: ct-color-constant-dark('primary-8');
-$hero-teal: ct-color-constant-dark('secondary-6');
-$hero-accent: ct-color-constant-dark('tertiary-3');
-$hero-text: ct-color-constant-dark('neutral-1');
-$hero-text-subtle: ct-color-constant-dark('primary-1');
-$hero-text-muted: ct-color-constant-dark('primary-3');
+$_hero-bg: ct-color-constant-dark('primary-9');
+$_hero-bg-contact: ct-color-constant-dark('primary-8');
+$_hero-teal: ct-color-constant-dark('secondary-6');
+$_hero-accent: ct-color-constant-dark('tertiary-3');
+$_hero-text: ct-color-constant-dark('neutral-1');
+$_hero-text-subtle: ct-color-constant-dark('primary-1');
+$_hero-text-muted: ct-color-constant-dark('primary-3');
 
 .component-hero {
   $root: &;
@@ -30,7 +30,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     min-height: 100vh;
     padding: 8.75rem ct-particle(8) ct-particle(10);
     overflow: hidden;
-    background: $hero-bg;
+    background: $_hero-bg;
     text-align: center;
 
     // The hero is a full-width opener, so it breaks out of CivicTheme's
@@ -51,7 +51,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     width: ct-particle(100);
     height: ct-particle(75);
     transform: translate(-50%, -55%);
-    background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 12%, transparent) 0%, color-mix(in srgb, #{$hero-teal} 4%, transparent) 40%, transparent 70%);
+    background: radial-gradient(ellipse at center, color-mix(in srgb, #{$_hero-teal} 12%, transparent) 0%, color-mix(in srgb, #{$_hero-teal} 4%, transparent) 40%, transparent 70%);
     pointer-events: none;
   }
 
@@ -76,7 +76,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     font-weight: 400;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: $hero-teal;
+    color: $_hero-teal;
   }
 
   #{$root}-title {
@@ -85,7 +85,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     & {
       position: relative;
       margin: 0;
-      color: $hero-text;
+      color: $_hero-text;
     }
   }
 
@@ -94,7 +94,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     width: ct-particle(10);
     height: 3px;
     margin: ct-particle(3) auto 0;
-    background: linear-gradient(90deg, #{$hero-teal}, #{$hero-accent});
+    background: linear-gradient(90deg, #{$_hero-teal}, #{$_hero-accent});
     border-radius: 2px;
   }
 
@@ -104,7 +104,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     font-size: 1.25rem;
     line-height: 1.6;
     letter-spacing: 0.02em;
-    color: $hero-text-subtle;
+    color: $_hero-text-subtle;
   }
 
   #{$root}-actions {
@@ -122,7 +122,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     bottom: 8.75rem;
     left: 0;
     height: 1px;
-    background: linear-gradient(90deg, transparent 0%, color-mix(in srgb, #{$hero-teal} 40%, transparent) 20%, color-mix(in srgb, #{$hero-teal} 60%, transparent) 50%, color-mix(in srgb, #{$hero-teal} 40%, transparent) 80%, transparent 100%);
+    background: linear-gradient(90deg, transparent 0%, color-mix(in srgb, #{$_hero-teal} 40%, transparent) 20%, color-mix(in srgb, #{$_hero-teal} 60%, transparent) 50%, color-mix(in srgb, #{$_hero-teal} 40%, transparent) 80%, transparent 100%);
   }
 
   #{$root} .component-scroll-indicator {
@@ -140,7 +140,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(ellipse at center, transparent 40%, color-mix(in srgb, #{$hero-bg} 60%, transparent) 100%);
+    background: radial-gradient(ellipse at center, transparent 40%, color-mix(in srgb, #{$_hero-bg} 60%, transparent) 100%);
     pointer-events: none;
   }
 
@@ -150,7 +150,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     padding: ct-particle(20) ct-particle(8) ct-particle(10);
 
     &::before {
-      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 10%, transparent) 0%, color-mix(in srgb, #{$hero-teal} 3%, transparent) 40%, transparent 70%);
+      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$_hero-teal} 10%, transparent) 0%, color-mix(in srgb, #{$_hero-teal} 3%, transparent) 40%, transparent 70%);
     }
   }
 
@@ -162,7 +162,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
 
     &::before {
       width: ct-particle(112);
-      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 8%, transparent) 0%, transparent 65%);
+      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$_hero-teal} 8%, transparent) 0%, transparent 65%);
     }
 
     #{$root}-title {
@@ -177,12 +177,12 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
 
   // Contact: darker surface, narrow column.
   &#{$root}--contact {
-    background: $hero-bg-contact;
+    background: $_hero-bg-contact;
     min-height: auto;
     padding: ct-particle(25) 0 ct-particle(12);
 
     &::before {
-      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 12%, transparent) 0%, color-mix(in srgb, #{$hero-teal} 3%, transparent) 40%, transparent 70%);
+      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$_hero-teal} 12%, transparent) 0%, color-mix(in srgb, #{$_hero-teal} 3%, transparent) 40%, transparent 70%);
     }
   }
 
@@ -209,7 +209,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
   #{$root}__overlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(to bottom, color-mix(in srgb, #{$hero-bg} 40%, transparent) 0%, color-mix(in srgb, #{$hero-bg} 70%, transparent) 40%, #{$hero-bg} 100%);
+    background: linear-gradient(to bottom, color-mix(in srgb, #{$_hero-bg} 40%, transparent) 0%, color-mix(in srgb, #{$_hero-bg} 70%, transparent) 40%, #{$_hero-bg} 100%);
   }
 
   #{$root}__content {
@@ -228,7 +228,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
     font-size: 0.75rem;
     letter-spacing: 0.15em;
     text-transform: uppercase;
-    color: $hero-text-muted;
+    color: $_hero-text-muted;
   }
 
   #{$root}__title {
@@ -238,7 +238,7 @@ $hero-text-muted: ct-color-constant-dark('primary-3');
       max-width: ct-particle(100);
       margin: 0 0 ct-particle(3);
       font-size: var(--ct-typography-display-font-size);
-      color: $hero-text;
+      color: $_hero-text;
     }
   }
 

--- a/web/themes/custom/drevops/components/03-organisms/hero/hero.scss
+++ b/web/themes/custom/drevops/components/03-organisms/hero/hero.scss
@@ -1,0 +1,327 @@
+//
+// Hero component styles.
+//
+// Ported from static-prototype (homepage, services, blog, blog-post, contact).
+// Brand colours are read from the dark palette as flat values so gradients and
+// color-mix resolve directly; the redesign uses identical brand anchors across
+// schemes, so the hero renders the same dark treatment whichever theme it
+// requests. Entrance motion reuses the shared .component-reveal library; the
+// continuous glow and scroll-pulse are gated behind prefers-reduced-motion.
+//
+
+$hero-bg: ct-color-constant-dark('primary-9');
+$hero-bg-contact: ct-color-constant-dark('primary-8');
+$hero-teal: ct-color-constant-dark('secondary-6');
+$hero-accent: ct-color-constant-dark('tertiary-3');
+$hero-text: ct-color-constant-dark('neutral-1');
+$hero-text-subtle: ct-color-constant-dark('primary-1');
+$hero-text-muted: ct-color-constant-dark('primary-3');
+
+.component-hero {
+  $root: &;
+
+  & {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    min-height: 100vh;
+    padding: 8.75rem ct-particle(8) ct-particle(10);
+    overflow: hidden;
+    background: $hero-bg;
+    text-align: center;
+
+    // The hero is a full-width opener, so it breaks out of CivicTheme's
+    // constrained content column to span the viewport. The root clips
+    // horizontal overflow (see base/_infrastructure), so the viewport-wide
+    // width never adds a horizontal scrollbar.
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: calc(50% - 50vw);
+  }
+
+  // Teal glow.
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: ct-particle(100);
+    height: ct-particle(75);
+    transform: translate(-50%, -55%);
+    background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 12%, transparent) 0%, color-mix(in srgb, #{$hero-teal} 4%, transparent) 40%, transparent 70%);
+    pointer-events: none;
+  }
+
+  #{$root}-inner {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: ct-particle(4);
+    max-width: ct-particle(112);
+    margin: 0 auto;
+  }
+
+  #{$root}-inner--narrow {
+    max-width: ct-particle(88);
+  }
+
+  #{$root}-eyebrow {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: $hero-teal;
+  }
+
+  #{$root}-title {
+    @include ct-typography('display-large');
+
+    & {
+      position: relative;
+      margin: 0;
+      color: $hero-text;
+    }
+  }
+
+  #{$root}-title__accent {
+    display: block;
+    width: ct-particle(10);
+    height: 3px;
+    margin: ct-particle(3) auto 0;
+    background: linear-gradient(90deg, #{$hero-teal}, #{$hero-accent});
+    border-radius: 2px;
+  }
+
+  #{$root}-lead {
+    max-width: ct-particle(90);
+    margin: 0 auto;
+    font-size: 1.25rem;
+    line-height: 1.6;
+    letter-spacing: 0.02em;
+    color: $hero-text-subtle;
+  }
+
+  #{$root}-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: ct-particle(2);
+    margin-top: ct-particle(2);
+  }
+
+  // Decorative separator and scroll indicator (home only).
+  #{$root}-rule {
+    position: absolute;
+    right: 0;
+    bottom: 8.75rem;
+    left: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, color-mix(in srgb, #{$hero-teal} 40%, transparent) 20%, color-mix(in srgb, #{$hero-teal} 60%, transparent) 50%, color-mix(in srgb, #{$hero-teal} 40%, transparent) 80%, transparent 100%);
+  }
+
+  #{$root} .component-scroll-indicator {
+    position: absolute;
+    bottom: ct-particle(5);
+    left: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transform: translateX(-50%);
+  }
+
+  // Home: deep vignette over the glow.
+  &#{$root}--home::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse at center, transparent 40%, color-mix(in srgb, #{$hero-bg} 60%, transparent) 100%);
+    pointer-events: none;
+  }
+
+  // Inner: shorter, dimmer glow, no scroll indicator.
+  &#{$root}--inner {
+    min-height: 70vh;
+    padding: ct-particle(20) ct-particle(8) ct-particle(10);
+
+    &::before {
+      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 10%, transparent) 0%, color-mix(in srgb, #{$hero-teal} 3%, transparent) 40%, transparent 70%);
+    }
+  }
+
+  // Page and section: centred band, auto height, faded static glow, medium title.
+  &#{$root}--page,
+  &#{$root}--section {
+    min-height: auto;
+    padding: ct-particle(25) 0 ct-particle(10);
+
+    &::before {
+      width: ct-particle(112);
+      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 8%, transparent) 0%, transparent 65%);
+    }
+
+    #{$root}-title {
+      font-size: var(--ct-typography-display-font-size);
+    }
+  }
+
+  // Section sits inside the page flow, so it needs less top offset.
+  &#{$root}--section {
+    padding: ct-particle(12) 0;
+  }
+
+  // Contact: darker surface, narrow column.
+  &#{$root}--contact {
+    background: $hero-bg-contact;
+    min-height: auto;
+    padding: ct-particle(25) 0 ct-particle(12);
+
+    &::before {
+      background: radial-gradient(ellipse at center, color-mix(in srgb, #{$hero-teal} 12%, transparent) 0%, color-mix(in srgb, #{$hero-teal} 3%, transparent) 40%, transparent 70%);
+    }
+  }
+
+  // Article: image-backed header with overlay.
+  &#{$root}--article {
+    display: block;
+    min-height: ct-particle(65);
+    padding: 0;
+    text-align: left;
+  }
+
+  #{$root}__image {
+    position: absolute;
+    inset: 0;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+  }
+
+  #{$root}__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to bottom, color-mix(in srgb, #{$hero-bg} 40%, transparent) 0%, color-mix(in srgb, #{$hero-bg} 70%, transparent) 40%, #{$hero-bg} 100%);
+  }
+
+  #{$root}__content {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
+    max-width: ct-particle(137);
+    margin: 0 auto;
+    padding: 0 ct-particle(8) ct-particle(8);
+  }
+
+  #{$root}__meta {
+    margin-bottom: ct-particle(3);
+    font-size: 0.75rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: $hero-text-muted;
+  }
+
+  #{$root}__title {
+    @include ct-typography('display-large');
+
+    & {
+      max-width: ct-particle(100);
+      margin: 0 0 ct-particle(3);
+      font-size: var(--ct-typography-display-font-size);
+      color: $hero-text;
+    }
+  }
+
+  #{$root}__tags {
+    margin-top: ct-particle(3);
+  }
+
+  // Continuous motion - gated so reduced-motion visitors get a still hero.
+  @media (prefers-reduced-motion: no-preference) {
+    &::before {
+      animation: component-hero-glow 8s ease-in-out infinite;
+    }
+
+    &#{$root}--page::before,
+    &#{$root}--section::before,
+    &#{$root}--contact::before {
+      animation: none;
+    }
+
+    #{$root} .component-scroll-line {
+      animation: component-hero-scroll-pulse 2s ease-in-out infinite;
+    }
+  }
+
+  @include ct-breakpoint-upto('m') {
+    & {
+      padding: ct-particle(13) ct-particle(3) ct-particle(10);
+    }
+
+    &#{$root}--inner {
+      min-height: 50vh;
+      padding: ct-particle(17) ct-particle(3) ct-particle(8);
+    }
+
+    &#{$root}--page,
+    &#{$root}--section,
+    &#{$root}--contact {
+      padding: ct-particle(17) ct-particle(3) ct-particle(5);
+    }
+
+    &#{$root}--article {
+      min-height: ct-particle(50);
+    }
+
+    #{$root}__content {
+      padding: 0 ct-particle(3) ct-particle(5);
+    }
+
+    #{$root}-lead {
+      font-size: 1.125rem;
+    }
+  }
+}
+
+// Scroll indicator line (home).
+.component-scroll-line {
+  width: 1px;
+  height: ct-particle(6);
+  background: linear-gradient(to bottom, ct-color-constant-dark('secondary-6'), transparent);
+}
+
+@keyframes component-hero-glow {
+  0%,
+  100% {
+    opacity: 70%;
+    transform: translate(-50%, -55%) scale(1);
+  }
+
+  50% {
+    opacity: 100%;
+    transform: translate(-50%, -55%) scale(1.08);
+  }
+}
+
+@keyframes component-hero-scroll-pulse {
+  0%,
+  100% {
+    opacity: 30%;
+    transform: scaleY(1);
+  }
+
+  50% {
+    opacity: 90%;
+    transform: scaleY(1.15);
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/hero/hero.twig
+++ b/web/themes/custom/drevops/components/03-organisms/hero/hero.twig
@@ -30,7 +30,7 @@
 {% set has_scroll = type == 'home' %}
 
 {% if type == 'article' %}
-  <header class="component-hero component-hero--article {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+  <header class="component-hero {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     {% if background_image.url is not empty %}
       <div class="component-hero__image">
         {{ include('civictheme:image', {

--- a/web/themes/custom/drevops/components/03-organisms/hero/hero.twig
+++ b/web/themes/custom/drevops/components/03-organisms/hero/hero.twig
@@ -1,0 +1,101 @@
+{#
+/**
+ * @file
+ * Hero component.
+ *
+ * Props:
+ * - theme: [string] Theme variation (light or dark).
+ * - type: [string] Variant: home, inner, page, contact, article, section.
+ * - background_image: [object] Image for the article variant (url, alt).
+ * - actions: [array] Up to two call-to-action links (text, url, type,
+ *   is_external, is_new_window).
+ * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
+ * - modifier_class: [string] Additional CSS classes.
+ *
+ * Slots:
+ * - eyebrow: Short label above the heading.
+ * - heading: Main hero heading.
+ * - lead: Supporting lead paragraph.
+ * - meta: Article meta such as date and read time.
+ * - tags: Article tags.
+ */
+#}
+
+{% set type = type in ['home', 'inner', 'page', 'contact', 'article', 'section'] ? type : 'home' %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set type_class = 'component-hero--%s'|format(type) %}
+{% set modifier_class = '%s %s %s'|format(theme_class, type_class, modifier_class|default('')) %}
+
+{% set has_accent = type in ['home', 'contact'] %}
+{% set has_scroll = type == 'home' %}
+
+{% if type == 'article' %}
+  <header class="component-hero component-hero--article {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    {% if background_image.url is not empty %}
+      <div class="component-hero__image">
+        {{ include('civictheme:image', {
+          theme: theme,
+          url: background_image.url,
+          alt: background_image.alt,
+        }, false) }}
+        <div class="component-hero__overlay"></div>
+      </div>
+    {% endif %}
+
+    <div class="component-hero__content">
+      {% if meta is not empty %}
+        <div class="component-hero__meta">{{ meta }}</div>
+      {% endif %}
+
+      {% if heading is not empty %}
+        <h1 class="component-hero__title">{{ heading }}</h1>
+      {% endif %}
+
+      {% if tags is not empty %}
+        <div class="component-hero__tags">{{ tags }}</div>
+      {% endif %}
+    </div>
+  </header>
+{% else %}
+  <section class="component-hero {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="component-hero-inner {{ type == 'contact' ? 'component-hero-inner--narrow' }}">
+      {% if eyebrow is not empty %}
+        <p class="component-hero-eyebrow component-reveal">{{ eyebrow }}</p>
+      {% endif %}
+
+      {% if heading is not empty %}
+        <h1 class="component-hero-title component-reveal component-reveal-d1">
+          {{ heading }}
+          {% if has_accent %}<span class="component-hero-title__accent" aria-hidden="true"></span>{% endif %}
+        </h1>
+      {% endif %}
+
+      {% if lead is not empty %}
+        <p class="component-hero-lead component-reveal component-reveal-d2">{{ lead }}</p>
+      {% endif %}
+
+      {% if actions is not empty %}
+        <div class="component-hero-actions component-reveal component-reveal-d3">
+          {% for action in actions %}
+            {{ include('civictheme:button', {
+              theme: theme,
+              kind: 'link',
+              type: action.type|default('secondary'),
+              text: action.text,
+              url: action.url,
+              is_external: action.is_external,
+              is_new_window: action.is_new_window,
+            }, false) }}
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+
+    {% if has_scroll %}
+      <div class="component-hero-rule" aria-hidden="true"></div>
+      <div class="component-scroll-indicator" aria-hidden="true">
+        <div class="component-scroll-line"></div>
+      </div>
+    {% endif %}
+  </section>
+{% endif %}

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -11,6 +11,7 @@ require_once __DIR__ . '/includes/system_main_block.inc';
 require_once __DIR__ . '/includes/banner.inc';
 require_once __DIR__ . '/includes/paragraphs.inc';
 require_once __DIR__ . '/includes/divider.inc';
+require_once __DIR__ . '/includes/hero.inc';
 require_once __DIR__ . '/includes/manual_list.inc';
 require_once __DIR__ . '/includes/page.inc';
 require_once __DIR__ . '/includes/node.inc';

--- a/web/themes/custom/drevops/includes/hero.inc
+++ b/web/themes/custom/drevops/includes/hero.inc
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file
+ * DrevOps Hero paragraph component.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__hero(array &$variables): void {
+  _civictheme_preprocess_paragraph__paragraph_field__title($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__image($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__links($variables);
+
+  _drevops_preprocess_paragraph__hero_field__type($variables);
+  _drevops_preprocess_paragraph__hero_field__eyebrow($variables);
+  _drevops_preprocess_paragraph__hero_field__lead($variables);
+  _drevops_preprocess_paragraph__hero_field__actions($variables);
+
+  // CivicTheme's image helper exposes the media as 'image'; the hero renders it
+  // as the article variant's full-bleed background.
+  if (!empty($variables['image'])) {
+    $variables['background_image'] = $variables['image'];
+  }
+}
+
+/**
+ * Pre-process for Hero type field.
+ */
+function _drevops_preprocess_paragraph__hero_field__type(array &$variables): void {
+  $variables['type'] = civictheme_get_field_value($variables['paragraph'], 'field_c_p_type') ?? 'home';
+}
+
+/**
+ * Pre-process for Hero eyebrow field.
+ */
+function _drevops_preprocess_paragraph__hero_field__eyebrow(array &$variables): void {
+  $variables['eyebrow'] = civictheme_get_field_value($variables['paragraph'], 'field_c_p_subtitle');
+}
+
+/**
+ * Pre-process for Hero lead field.
+ */
+function _drevops_preprocess_paragraph__hero_field__lead(array &$variables): void {
+  $variables['lead'] = civictheme_get_field_value($variables['paragraph'], 'field_c_p_summary');
+}
+
+/**
+ * Pre-process for Hero action buttons.
+ */
+function _drevops_preprocess_paragraph__hero_field__actions(array &$variables): void {
+  if (empty($variables['links'])) {
+    return;
+  }
+
+  // The first action leads as a secondary button and the second as tertiary,
+  // matching the prototype's call-to-action hierarchy; at most two render.
+  $styles = ['secondary', 'tertiary'];
+  $actions = [];
+
+  foreach (array_slice($variables['links'], 0, 2) as $index => $link) {
+    $actions[] = $link + ['type' => $styles[$index]];
+  }
+
+  $variables['actions'] = $actions;
+}

--- a/web/themes/custom/drevops/includes/hero.inc
+++ b/web/themes/custom/drevops/includes/hero.inc
@@ -63,7 +63,7 @@ function _drevops_preprocess_paragraph__hero_field__actions(array &$variables): 
   $actions = [];
 
   foreach (array_slice($variables['links'], 0, 2) as $index => $link) {
-    $actions[] = $link + ['type' => $styles[$index]];
+    $actions[] = array_merge($link, ['type' => $styles[$index]]);
   }
 
   $variables['actions'] = $actions;

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
@@ -13,4 +13,4 @@
   heading: title,
   lead: lead,
   attributes: component_attributes,
-}, with_context = false) }}
+}, with_context: false) }}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Hero component.
+ */
+#}
+{{ include('drevops:hero', {
+  theme: theme,
+  type: type,
+  background_image: background_image,
+  actions: actions,
+  eyebrow: eyebrow,
+  heading: title,
+  lead: lead,
+  attributes: component_attributes,
+}, with_context = false) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#189] Verb in past tense.`
- [x] Ticket number `#189` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally.

Closes #189

## Changed

1. Added a `hero` paragraph type with six variants (`home`, `inner`, `page`, `contact`, `article`, `section`) driven by a shared `field_c_p_type` list-string field whose allowed values are resolved per bundle via `do_base_field_c_p_type_allowed_values` in `do_base.module`.
2. Created the `drevops:hero` Single Directory Component (`hero.component.yml`, `hero.twig`, `hero.scss`) implementing the full-bleed viewport-wide opener with per-variant layout rules, teal glow, decorative rule, scroll indicator (home only), article image overlay, and entrance-reveal motion gated behind `prefers-reduced-motion`.
3. Wired the paragraph to the SDC via `drevops_preprocess_paragraph__hero` in `includes/hero.inc` (delegates to CivicTheme helpers for title, theme, image, links; adds eyebrow, lead, and action-style mapping) and `templates/paragraphs/paragraph--hero.html.twig`.
4. Added `overflow-x: clip` on the `html` element in `base/_infrastructure.scss` so the hero's `100vw` width and negative left margin do not introduce a horizontal scrollbar.
5. Enabled the hero paragraph type on `field_c_n_components` for `civictheme_page` nodes (weight -60 so it sorts first).
6. Added Behat feature files `paragraph_hero_fields.feature` (field presence and all six type options) and `paragraph_hero_render.feature` (home, section, and article variant rendering with screenshot assertions).

## Screenshots

![Home hero](https://raw.githubusercontent.com/drevops/website/890cea6b82e3a3dad7b8230a12e77473a96e057f/feature-189-hero-component/709a6f5cbe27e722815f3ba2e6480cead51c76a5.png)

## Before / After

```
Before                                    After
──────────────────────────────────────    ──────────────────────────────────────
Page loads; no hero paragraph type        hero paragraph type available
available on civictheme_page nodes.       on civictheme_page nodes.

┌─────────────────────────────────┐       ┌─────────────────────────────────┐
│  [Header]                       │       │  [Header]                       │
│  ─────────────────────────────  │       │  ╔═════════════════════════════╗ │
│                                 │       │  ║  HERO (100vw, 100vh)        ║ │
│  [Page body starts here]        │       │  ║  Eyebrow · Heading · Lead   ║ │
│                                 │       │  ║  [CTA1]  [CTA2]             ║ │
│                                 │       │  ║  ─── scroll indicator ───   ║ │
│                                 │       │  ╚═════════════════════════════╝ │
│                                 │       │  [Page body starts here]        │
└─────────────────────────────────┘       └─────────────────────────────────┘

Variants: none                            Variants: home | inner | page |
                                                    contact | article | section
field_c_p_type: does not exist            field_c_p_type: shared storage,
                                          bundle-scoped allowed values
```
