### PR TITLE
[#187] Rebuilt the site header as a sticky responsive navigation bar.

### DIFF
--- a/config/default/block.block.drevops_mobile_navigation.yml
+++ b/config/default/block.block.drevops_mobile_navigation.yml
@@ -1,6 +1,6 @@
 uuid: e7008f1c-ea1e-4a79-b4b8-fce24e5437cc
 langcode: en
-status: true
+status: false
 dependencies:
   content:
     - 'block_content:civictheme_mobile_navigation:b7f36176-620f-4178-aadd-9b448c610986'

--- a/config/default/block.block.drevops_primary_navigation.yml
+++ b/config/default/block.block.drevops_primary_navigation.yml
@@ -1,6 +1,6 @@
 uuid: af446c70-a4cc-4cea-856a-1e8f72c5e55e
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - system.menu.civictheme-primary-navigation

--- a/config/default/block.block.drevops_secondary_navigation.yml
+++ b/config/default/block.block.drevops_secondary_navigation.yml
@@ -1,6 +1,6 @@
 uuid: 0d7f4f98-6640-4c54-b613-90dca3e03be4
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - system.menu.civictheme-secondary-navigation

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -102,38 +102,34 @@ class FeatureContext extends DrupalContext {
   }
 
   /**
-   * Assert the mobile menu toggles open and closed and locks body scrolling.
-   *
-   * No template renders the interactions hooks yet, so the mobile navigation
-   * behaviour is exercised against representative injected markup.
+   * Assert the header stays pinned to the top of the viewport while scrolling.
    */
-  #[\Behat\Step\Then('the injected mobile menu toggles open and closed')]
-  public function assertInjectedMobileMenuToggles(): void {
+  #[\Behat\Step\Then('the site header stays pinned to the top of the viewport on scroll')]
+  public function assertHeaderStaysAtTop(): void {
     $session = $this->getSession();
 
-    $script = "
-      var nav = document.createElement('nav');
-      nav.id = 'siteNav';
-      nav.className = 'component-nav';
-      var toggle = document.createElement('button');
-      toggle.id = 'navToggle';
-      toggle.setAttribute('aria-expanded', 'false');
-      toggle.textContent = 'Menu';
-      var menu = document.createElement('div');
-      menu.className = 'component-nav-menu';
-      var links = document.createElement('div');
-      links.className = 'component-nav-links';
-      var link = document.createElement('a');
-      link.setAttribute('href', '#test-interaction');
-      link.textContent = '[TEST] Menu link';
-      links.appendChild(link);
-      menu.appendChild(links);
-      nav.appendChild(toggle);
-      nav.appendChild(menu);
-      document.body.insertBefore(nav, document.body.firstChild);
-      Drupal.attachBehaviors(document.body);
-    ";
-    $session->executeScript($script);
+    $session->executeScript('window.scrollTo(0, 800);');
+    $top = $session->evaluateScript("document.getElementById('siteNav').getBoundingClientRect().top");
+
+    if ((float) $top > 5.0) {
+      throw new \Exception(sprintf('The header is not pinned to the top of the viewport after scrolling (top: %s).', $top));
+    }
+  }
+
+  /**
+   * Assert the rendered mobile menu opens, locks scrolling and closes on link.
+   */
+  #[\Behat\Step\Then('the site mobile menu opens, locks scrolling and closes on link activation')]
+  public function assertMobileMenuToggles(): void {
+    $session = $this->getSession();
+
+    // Narrow the viewport so the toggle is shown and the menu becomes a
+    // slide-in panel.
+    $session->resizeWindow(390, 844, 'current');
+
+    // Bind the navigation behaviour to the rendered header; re-attaching is a
+    // no-op when the initial page load already attached it.
+    $session->executeScript('Drupal.attachBehaviors(document);');
 
     $session->executeScript("document.getElementById('navToggle').click();");
     $opened_js = "document.getElementById('siteNav').classList.contains('is-open')"
@@ -144,13 +140,16 @@ class FeatureContext extends DrupalContext {
       throw new \Exception('The mobile menu did not open and lock body scrolling.');
     }
 
-    $session->executeScript("document.querySelector('#siteNav .component-nav-links a').click();");
+    // Activating a link inside the menu closes it and restores scrolling. The
+    // link target is neutralised first so the assertion is not lost to a page
+    // navigation.
+    $session->executeScript("var link = document.querySelector('#siteNav .component-nav-links a'); link.setAttribute('href', '#'); link.click();");
     $closed_js = "!document.getElementById('siteNav').classList.contains('is-open')"
       . " && document.body.style.overflow === ''";
     $closed = $session->wait(3000, $closed_js);
 
     if (!$closed) {
-      throw new \Exception('The mobile menu did not close and restore body scrolling.');
+      throw new \Exception('The mobile menu did not close on link activation.');
     }
   }
 

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -111,7 +111,7 @@ class FeatureContext extends DrupalContext {
     $session->executeScript('window.scrollTo(0, 800);');
     $top = $session->evaluateScript("document.getElementById('siteNav').getBoundingClientRect().top");
 
-    if ((float) $top > 5.0) {
+    if (abs((float) $top) > 5.0) {
       throw new \Exception(sprintf('The header is not pinned to the top of the viewport after scrolling (top: %s).', $top));
     }
   }
@@ -131,6 +131,10 @@ class FeatureContext extends DrupalContext {
     // no-op when the initial page load already attached it.
     $session->executeScript('Drupal.attachBehaviors(document);');
 
+    // The behaviour restores whatever overflow the body had before opening, so
+    // capture it to assert against rather than assuming an empty string.
+    $initial_overflow = (string) $session->evaluateScript("document.body.style.overflow || ''");
+
     $session->executeScript("document.getElementById('navToggle').click();");
     $opened_js = "document.getElementById('siteNav').classList.contains('is-open')"
       . " && document.body.style.overflow === 'hidden'";
@@ -145,7 +149,7 @@ class FeatureContext extends DrupalContext {
     // navigation.
     $session->executeScript("var link = document.querySelector('#siteNav .component-nav-links a'); link.setAttribute('href', '#'); link.click();");
     $closed_js = "!document.getElementById('siteNav').classList.contains('is-open')"
-      . " && document.body.style.overflow === ''";
+      . " && document.body.style.overflow === " . json_encode($initial_overflow);
     $closed = $session->wait(3000, $closed_js);
 
     if (!$closed) {

--- a/tests/behat/features/interactions.feature
+++ b/tests/behat/features/interactions.feature
@@ -17,9 +17,3 @@ Feature: Front-end interactions library
     Given I am an anonymous user
     When I go to the homepage
     Then injected reveal content becomes visible
-
-  @api @javascript
-  Scenario: The mobile menu opens, locks scrolling and closes on link activation
-    Given I am an anonymous user
-    When I go to the homepage
-    Then the injected mobile menu toggles open and closed

--- a/tests/behat/features/navigation.feature
+++ b/tests/behat/features/navigation.feature
@@ -1,0 +1,41 @@
+@navigation
+Feature: Site header navigation
+
+  As a site visitor
+  I want a clear, sticky header that works on desktop and mobile
+  So that I can navigate the site from any device
+
+  @api @smoke
+  Scenario: The header shows the brand, the primary menu and the call to action
+    Given the following menu links exist in the menu "Primary Navigation":
+      | title           | enabled | uri                  |
+      | [TEST] Nav Item | 1       | internal:/user/login |
+    And I am an anonymous user
+    When I go to the homepage
+    Then the response should contain "logo_primary_dark_desktop.svg"
+    And I should see the link "[TEST] Nav Item"
+    And I should see the link "Talk to us"
+
+  @api
+  Scenario: The current section's menu link shows the active state
+    Given the following menu links exist in the menu "Primary Navigation":
+      | title        | enabled | uri                  |
+      | [TEST] Login | 1       | internal:/user/login |
+    And I am an anonymous user
+    When I go to "/user/login"
+    Then I should see "[TEST] Login" in the ".component-nav-active" element
+
+  @api @javascript
+  Scenario: The header stays available at the top of the page when scrolling
+    Given I am an anonymous user
+    When I am on the homepage
+    Then the site header stays pinned to the top of the viewport on scroll
+
+  @api @javascript
+  Scenario: The mobile menu opens, locks scrolling and closes on link activation
+    Given the following menu links exist in the menu "Primary Navigation":
+      | title           | enabled | uri                  |
+      | [TEST] Nav Item | 1       | internal:/user/login |
+    And I am an anonymous user
+    When I go to the homepage
+    Then the site mobile menu opens, locks scrolling and closes on link activation

--- a/web/modules/custom/do_base/do_base.services.yml
+++ b/web/modules/custom/do_base/do_base.services.yml
@@ -4,3 +4,8 @@ services:
     arguments: ['@theme.manager']
     tags:
       - { name: twig.extension }
+  do_base.twig.navigation:
+    class: Drupal\do_base\Twig\NavigationExtension
+    arguments: ['@menu.link_tree']
+    tags:
+      - { name: twig.extension }

--- a/web/modules/custom/do_base/src/Twig/NavigationExtension.php
+++ b/web/modules/custom/do_base/src/Twig/NavigationExtension.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_base\Twig;
+
+use Drupal\Core\Menu\MenuLinkTreeInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Twig extension exposing site navigation as renderable menus.
+ *
+ * The redesigned header renders the primary menu inline as a flat list rather
+ * than through a block, so a dedicated function returns the built menu tree for
+ * the template to theme. Limiting the tree to the top level keeps the bar flat,
+ * matching the design, while preserving the active trail for highlighting.
+ */
+final class NavigationExtension extends AbstractExtension {
+
+  public function __construct(protected readonly MenuLinkTreeInterface $menuTree) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFunctions(): array {
+    return [
+      new TwigFunction('do_primary_navigation', [$this, 'primaryNavigation']),
+    ];
+  }
+
+  /**
+   * Builds a flat, top-level render array for a menu.
+   *
+   * @param string $menu_name
+   *   The menu machine name to render.
+   *
+   * @return array
+   *   A render array for the menu, or an empty array when it has no links.
+   */
+  public function primaryNavigation(string $menu_name = 'civictheme-primary-navigation'): array {
+    $parameters = $this->menuTree->getCurrentRouteMenuTreeParameters($menu_name);
+    $parameters->setMaxDepth(1);
+    $parameters->onlyEnabledLinks();
+
+    $tree = $this->menuTree->load($menu_name, $parameters);
+
+    if ($tree === []) {
+      return [];
+    }
+
+    $manipulators = [
+      ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+      ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+    ];
+    $tree = $this->menuTree->transform($tree, $manipulators);
+
+    return $this->menuTree->build($tree);
+  }
+
+}

--- a/web/modules/custom/do_base/src/Twig/NavigationExtension.php
+++ b/web/modules/custom/do_base/src/Twig/NavigationExtension.php
@@ -18,14 +18,14 @@ use Twig\TwigFunction;
  */
 final class NavigationExtension extends AbstractExtension {
 
-  public function __construct(protected readonly MenuLinkTreeInterface $menuTree) {}
+  public function __construct(protected readonly MenuLinkTreeInterface $menuLinkTree) {}
 
   /**
    * {@inheritdoc}
    */
   public function getFunctions(): array {
     return [
-      new TwigFunction('do_primary_navigation', [$this, 'primaryNavigation']),
+      new TwigFunction('do_primary_navigation', $this->primaryNavigation(...)),
     ];
   }
 
@@ -39,11 +39,11 @@ final class NavigationExtension extends AbstractExtension {
    *   A render array for the menu, or an empty array when it has no links.
    */
   public function primaryNavigation(string $menu_name = 'civictheme-primary-navigation'): array {
-    $parameters = $this->menuTree->getCurrentRouteMenuTreeParameters($menu_name);
+    $parameters = $this->menuLinkTree->getCurrentRouteMenuTreeParameters($menu_name);
     $parameters->setMaxDepth(1);
     $parameters->onlyEnabledLinks();
 
-    $tree = $this->menuTree->load($menu_name, $parameters);
+    $tree = $this->menuLinkTree->load($menu_name, $parameters);
 
     if ($tree === []) {
       return [];
@@ -53,9 +53,9 @@ final class NavigationExtension extends AbstractExtension {
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
     ];
-    $tree = $this->menuTree->transform($tree, $manipulators);
+    $tree = $this->menuLinkTree->transform($tree, $manipulators);
 
-    return $this->menuTree->build($tree);
+    return $this->menuLinkTree->build($tree);
   }
 
 }

--- a/web/modules/custom/do_base/tests/src/Unit/NavigationExtensionTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/NavigationExtensionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_base\Unit;
+
+use Drupal\Core\Menu\MenuLinkTreeInterface;
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\do_base\Twig\NavigationExtension;
+use PHPUnit\Framework\Attributes\Group;
+use Twig\TwigFunction;
+
+/**
+ * Class NavigationExtensionTest.
+ *
+ * Unit tests for the navigation Twig extension.
+ *
+ * @package Drupal\do_base\Tests
+ */
+#[Group('DoBase')]
+class NavigationExtensionTest extends DoBaseUnitTestBase {
+
+  /**
+   * Tests that the primary navigation function is exposed to Twig.
+   */
+  public function testGetFunctions(): void {
+    $extension = new NavigationExtension($this->createMock(MenuLinkTreeInterface::class));
+
+    $functions = $extension->getFunctions();
+
+    $this->assertCount(1, $functions);
+    $this->assertInstanceOf(TwigFunction::class, $functions[0]);
+    $this->assertEquals('do_primary_navigation', $functions[0]->getName());
+  }
+
+  /**
+   * Tests that a populated menu is loaded, transformed and built.
+   */
+  public function testPrimaryNavigationBuildsTree(): void {
+    $built = ['#theme' => 'menu__civictheme_primary_navigation'];
+
+    $menu_tree = $this->createMock(MenuLinkTreeInterface::class);
+    $menu_tree->expects($this->once())
+      ->method('getCurrentRouteMenuTreeParameters')
+      ->with('civictheme-primary-navigation')
+      ->willReturn(new MenuTreeParameters());
+    $menu_tree->expects($this->once())
+      ->method('load')
+      ->willReturn(['tree']);
+    $menu_tree->expects($this->once())
+      ->method('transform')
+      ->willReturnArgument(0);
+    $menu_tree->expects($this->once())
+      ->method('build')
+      ->willReturn($built);
+
+    $extension = new NavigationExtension($menu_tree);
+
+    $this->assertSame($built, $extension->primaryNavigation());
+  }
+
+  /**
+   * Tests that an empty menu short-circuits to an empty render array.
+   */
+  public function testPrimaryNavigationEmpty(): void {
+    $menu_tree = $this->createMock(MenuLinkTreeInterface::class);
+    $menu_tree->method('getCurrentRouteMenuTreeParameters')->willReturn(new MenuTreeParameters());
+    $menu_tree->method('load')->willReturn([]);
+    $menu_tree->expects($this->never())->method('build');
+
+    $extension = new NavigationExtension($menu_tree);
+
+    $this->assertSame([], $extension->primaryNavigation('empty-menu'));
+  }
+
+}

--- a/web/themes/custom/drevops/components/00-base/reveal/reveal.js
+++ b/web/themes/custom/drevops/components/00-base/reveal/reveal.js
@@ -9,40 +9,43 @@
  *
  * The entrance animation is gated behind 'prefers-reduced-motion' in CSS, so
  * visitors who prefer reduced motion always see content in its final state.
+ *
+ * @param {object} Drupal - The Drupal object.
  */
-function DrevOpsReveal() {
-  const elements = document.querySelectorAll(
-    '.component-reveal:not([data-reveal-bound])',
-  );
 
-  if (!elements.length) {
-    return;
-  }
+((Drupal) => {
+  Drupal.behaviors.drevopsReveal = {
+    attach(context) {
+      const elements = context.querySelectorAll('.component-reveal:not([data-reveal-bound])');
 
-  if (!('IntersectionObserver' in window)) {
-    // Reveal immediately when the observer is unavailable so that content is
-    // never left hidden.
-    elements.forEach((element) => {
-      element.setAttribute('data-reveal-bound', '');
-      element.classList.add('visible');
-    });
-
-    return;
-  }
-
-  const observer = new IntersectionObserver((entries, obs) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('visible');
-        obs.unobserve(entry.target);
+      if (!elements.length) {
+        return;
       }
-    });
-  }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
 
-  elements.forEach((element) => {
-    element.setAttribute('data-reveal-bound', '');
-    observer.observe(element);
-  });
-}
+      if (!('IntersectionObserver' in window)) {
+        // Reveal immediately when the observer is unavailable so that content
+        // is never left hidden.
+        elements.forEach((element) => {
+          element.setAttribute('data-reveal-bound', '');
+          element.classList.add('visible');
+        });
 
-DrevOpsReveal();
+        return;
+      }
+
+      const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            obs.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+
+      elements.forEach((element) => {
+        element.setAttribute('data-reveal-bound', '');
+        observer.observe(element);
+      });
+    },
+  };
+})(Drupal);

--- a/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
+++ b/web/themes/custom/drevops/components/00-base/site-nav/site-nav.js
@@ -5,48 +5,54 @@
  *
  * Drives the mobile slide-in menu. The trigger toggles the menu open and
  * closed, body scroll is locked while the menu is open, and activating any
- * link inside the menu closes it so navigation feels immediate.
+ * link inside the menu closes it so navigation feels immediate. Escape also
+ * closes the menu and returns focus to the trigger.
  *
  * The behaviour binds by id ('siteNav' and 'navToggle'); when either is
  * missing it is a no-op, so it can be attached globally ahead of the markup
  * that uses it.
+ *
+ * @param {object} Drupal - The Drupal object.
  */
-function DrevOpsSiteNav() {
-  const nav = document.getElementById('siteNav');
-  const toggle = document.getElementById('navToggle');
 
-  if (!nav || !toggle || toggle.hasAttribute('data-site-nav-bound')) {
-    return;
-  }
+((Drupal) => {
+  Drupal.behaviors.drevopsSiteNav = {
+    attach(context) {
+      const toggle = context.querySelector('#navToggle');
+      const nav = document.getElementById('siteNav');
 
-  let previousBodyOverflow = '';
+      if (!toggle || !nav || toggle.hasAttribute('data-site-nav-bound')) {
+        return;
+      }
 
-  const setOpen = (isOpen) => {
-    if (isOpen) {
-      previousBodyOverflow = document.body.style.overflow;
-    }
+      let previousBodyOverflow = '';
 
-    nav.classList.toggle('is-open', isOpen);
-    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-    document.body.style.overflow = isOpen ? 'hidden' : previousBodyOverflow;
+      const setOpen = (isOpen) => {
+        if (isOpen) {
+          previousBodyOverflow = document.body.style.overflow;
+        }
+
+        nav.classList.toggle('is-open', isOpen);
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.style.overflow = isOpen ? 'hidden' : previousBodyOverflow;
+      };
+
+      toggle.addEventListener('click', () => {
+        setOpen(!nav.classList.contains('is-open'));
+      });
+
+      nav.querySelectorAll('.component-nav-links a').forEach((link) => {
+        link.addEventListener('click', () => setOpen(false));
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && nav.classList.contains('is-open')) {
+          setOpen(false);
+          toggle.focus();
+        }
+      });
+
+      toggle.setAttribute('data-site-nav-bound', '');
+    },
   };
-
-  toggle.addEventListener('click', () => {
-    setOpen(!nav.classList.contains('is-open'));
-  });
-
-  nav.querySelectorAll('.component-nav-links a').forEach((link) => {
-    link.addEventListener('click', () => setOpen(false));
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && nav.classList.contains('is-open')) {
-      setOpen(false);
-      toggle.focus();
-    }
-  });
-
-  toggle.setAttribute('data-site-nav-bound', '');
-}
-
-DrevOpsSiteNav();
+})(Drupal);

--- a/web/themes/custom/drevops/components/03-organisms/header/header.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.component.yml
@@ -13,6 +13,14 @@ props:
       enum:
         - light
         - dark
+    cta_url:
+      type: string
+      title: CTA URL
+      description: Call-to-action link target (defaults to /contact).
+    cta_text:
+      type: string
+      title: CTA Text
+      description: Call-to-action label (defaults to "Talk to us").
     attributes:
       type: Drupal\Core\Template\Attribute
       title: Attributes

--- a/web/themes/custom/drevops/components/03-organisms/header/header.scss
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.scss
@@ -15,6 +15,7 @@ $ct-component-nav-breakpoint: 768px;
   top: 0;
   z-index: 900;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
@@ -182,11 +183,18 @@ $ct-component-nav-breakpoint: 768px;
       background: color-mix(in srgb, var(--ct-color-dark-background) 97%, transparent);
       backdrop-filter: blur(20px);
       transform: translateX(100%);
-      transition: transform 0.35s ease;
+
+      // Keep the off-screen panel out of the focus order and pointer flow so
+      // keyboard users cannot tab into hidden links while it is closed.
+      visibility: hidden;
+      pointer-events: none;
+      transition: transform 0.35s ease, visibility 0.35s ease;
     }
 
     &.is-open &-menu {
       transform: translateX(0);
+      visibility: visible;
+      pointer-events: auto;
     }
 
     &-links {

--- a/web/themes/custom/drevops/components/03-organisms/header/header.scss
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.scss
@@ -1,98 +1,205 @@
 //
-// CivicTheme Header component styles.
+// DrevOps site header - the redesign's navigation bar.
+//
+// Replaces the CivicTheme header layout with the prototype `component-nav`: a
+// sticky, translucent dark bar carrying the brand on the left and the primary
+// menu plus call-to-action on the right. On narrow screens the menu collapses
+// behind a toggle and slides in full-screen. Colours come from the dark brand
+// palette so the bar matches the rest of the dark chrome.
 //
 
-.ct-header {
-  $root: &;
+$component-nav-breakpoint: 768px;
 
-  border-bottom: solid ct-particle(0.125);
+.component-nav {
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem 4rem;
+  background: color-mix(in srgb, var(--ct-color-dark-background) 72%, transparent);
+  backdrop-filter: blur(1rem);
+  border-bottom: 1px solid color-mix(in srgb, var(--ct-color-dark-secondary-6) 16%, transparent);
 
-  // Custom: Add sticky header support with fixed positioning.
-  &--sticky {
-    position: fixed;
-    width: 100%;
-    z-index: $ct-header-sticky-zindex;
-  }
-
-  &__top {
-    padding-top: ct-spacing();
-    padding-bottom: ct-spacing();
-  }
-
-  &__content-top2 {
-    height: 100%;
-    display: flex;
+  &-logo {
+    display: inline-flex;
     align-items: center;
-  }
 
-  &__content-top3 {
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-  }
-
-  &__middle {
-    padding-top: ct-spacing(2);
-    padding-bottom: ct-spacing(2);
-  }
-
-  &__content-middle2 {
-    height: 100%;
-    display: flex;
-    align-items: center;
-  }
-
-  &__content-middle3 {
-    @include ct-print-hide();
-
-    // Custom: Remove unnecessary wrapper for flexbox properties.
-    height: 100%;
-    display: flex;
-    justify-content: flex-end;
-
-    .ct-navigation {
-      $root-drawer: '.ct-navigation';
-
-      &#{$root-drawer}--drawer {
-        order: 2;
-      }
+    a,
+    img {
+      display: inline-flex;
     }
   }
 
-  &__content-bottom1 {
+  &-menu {
     display: flex;
+    align-items: center;
+    gap: 3rem;
   }
 
-  @include ct-component-theme($root) using($root, $theme) {
-    @include ct-component-property($root, $theme, border-color);
-    @include ct-component-property($root, $theme, background-color);
+  &-links {
+    display: flex;
+    align-items: center;
+    gap: 3rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
 
-    #{$root}__top {
-      @include ct-component-property($root, $theme, top, background-color);
-      @include ct-component-property($root, $theme, top, color);
+    &__item {
+      margin: 0;
     }
 
-    #{$root}__middle {
-      @include ct-component-property($root, $theme, middle, background-color);
-      @include ct-component-property($root, $theme, middle, border-color);
-    }
+    a {
+      position: relative;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      text-decoration: none;
+      color: var(--ct-color-dark-body);
+      transition: color 0.3s ease;
 
-    // Custom: Add sticky header transparency and blur effects.
-    &#{$root}--sticky {
-      background-color: transparent;
-
-      #{$root}__top {
-        background-color: color-mix(in srgb, ct-component-var($root, $theme, top, background-color) 80%, transparent);
+      &::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        bottom: -0.25rem;
+        width: 0;
+        height: 1px;
+        background: var(--ct-color-dark-interaction-background);
+        transition: width 0.3s ease;
       }
 
-      #{$root}__middle {
-        background-color: color-mix(in srgb, ct-component-var($root, $theme, background-color) 80%, transparent);
+      &:hover,
+      &:focus {
+        color: var(--ct-color-dark-interaction-background);
+        text-decoration: none;
 
-        @include ct-breakpoint($ct-mobile-navigation-breakpoint) {
-          backdrop-filter: blur(0.5rem);
+        &::after {
+          width: 100%;
         }
       }
+    }
+
+    .component-nav-active {
+      color: var(--ct-color-dark-interaction-background);
+    }
+  }
+
+  &-cta {
+    flex-shrink: 0;
+    white-space: nowrap;
+    padding: 0.75rem 1.75rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: var(--ct-color-dark-interaction-background);
+    border: 1px solid color-mix(in srgb, var(--ct-color-dark-interaction-background) 55%, transparent);
+    border-radius: 2px;
+    transition: color 0.3s ease, background-color 0.3s ease, border-color 0.3s ease;
+
+    &:hover,
+    &:focus {
+      color: var(--ct-color-dark-background);
+      background-color: var(--ct-color-dark-interaction-background);
+      border-color: var(--ct-color-dark-interaction-background);
+      text-decoration: none;
+    }
+  }
+
+  &-toggle {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    width: 42px;
+    height: 42px;
+    padding: 9px;
+    background: none;
+    border: none;
+    cursor: pointer;
+
+    span {
+      display: block;
+      width: 100%;
+      height: 2px;
+      border-radius: 2px;
+      background: var(--ct-color-dark-heading);
+      transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+  }
+
+  &.is-open &-toggle span {
+    &:nth-child(1) {
+      transform: translateY(7px) rotate(45deg);
+    }
+
+    &:nth-child(2) {
+      opacity: 0;
+    }
+
+    &:nth-child(3) {
+      transform: translateY(-7px) rotate(-45deg);
+    }
+  }
+
+  // Header regions kept for block placement render outside the bar layout.
+  .ct-header__content-top1,
+  .ct-header__content-top2,
+  .ct-header__content-top3,
+  .ct-header__content-middle1,
+  .ct-header__content-middle3,
+  .ct-header__content-bottom1 {
+    flex-basis: 100%;
+  }
+}
+
+@media (max-width: $component-nav-breakpoint) {
+  .component-nav {
+    padding: 1rem 1.5rem;
+
+    // Drop the bar's backdrop blur on mobile: a backdrop-filter establishes a
+    // containing block, which would trap the fixed full-screen menu inside the
+    // bar instead of letting it cover the viewport.
+    backdrop-filter: none;
+    background: color-mix(in srgb, var(--ct-color-dark-background) 94%, transparent);
+
+    &-toggle {
+      display: flex;
+      z-index: 1001;
+    }
+
+    &-menu {
+      position: fixed;
+      inset: 0;
+      flex-direction: column;
+      justify-content: center;
+      gap: 2.5rem;
+      background: color-mix(in srgb, var(--ct-color-dark-background) 97%, transparent);
+      backdrop-filter: blur(20px);
+      transform: translateX(100%);
+      transition: transform 0.35s ease;
+    }
+
+    &.is-open &-menu {
+      transform: translateX(0);
+    }
+
+    &-links {
+      flex-direction: column;
+      gap: 2rem;
+
+      a {
+        font-size: 1.25rem;
+      }
+    }
+
+    &-cta {
+      margin-top: 0.5rem;
     }
   }
 }

--- a/web/themes/custom/drevops/components/03-organisms/header/header.scss
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.scss
@@ -8,7 +8,7 @@
 // palette so the bar matches the rest of the dark chrome.
 //
 
-$component-nav-breakpoint: 768px;
+$ct-component-nav-breakpoint: 768px;
 
 .component-nav {
   position: sticky;
@@ -139,7 +139,7 @@ $component-nav-breakpoint: 768px;
     }
 
     &:nth-child(2) {
-      opacity: 0;
+      opacity: 0%;
     }
 
     &:nth-child(3) {
@@ -158,7 +158,7 @@ $component-nav-breakpoint: 768px;
   }
 }
 
-@media (max-width: $component-nav-breakpoint) {
+@media (max-width: $ct-component-nav-breakpoint) {
   .component-nav {
     padding: 1rem 1.5rem;
 

--- a/web/themes/custom/drevops/components/03-organisms/header/header.twig
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.twig
@@ -1,144 +1,54 @@
 {#
 /**
  * @file
- * CivicTheme Header component.
+ * DrevOps site header.
+ *
+ * Renders the redesign's fixed navigation bar: brand logo, primary menu, a
+ * call-to-action and a mobile toggle. The toggle, the open state and the
+ * close-on-link behaviour are driven by the site navigation behaviour, which
+ * binds to the `siteNav`/`navToggle` ids and the `component-nav-*` classes
+ * emitted here.
+ *
+ * The brand sits in the middle-2 region and the remaining header regions are
+ * kept as optional placement targets (rendered only when a block is present),
+ * so the bar stays clean by default while blocks can still be placed in any
+ * header region.
  *
  * Props:
  * - theme: [string] Theme variation (light or dark).
- * - is_sticky: [boolean] Whether header is sticky.
  * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
  *
  * Slots:
- * - content_top1: Top section first content slot.
- * - content_top2: Top section second content slot.
- * - content_top3: Top section third content slot.
- * - content_middle1: Middle section first content slot.
- * - content_middle2: Middle section second content slot.
- * - content_middle3: Middle section third content slot.
- * - content_bottom1: Bottom section content slot.
- *
- * Blocks:
- * - content_top1_block
- * - content_top2_block
- * - content_top3_block
- * - content_middle1_block
- * - content_middle2_block
- * - content_middle3_block
- * - content_bottom1_block
+ * - content_top1..3, content_middle1..3, content_bottom1: Header regions.
  */
 #}
 
 {% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
-{# Custom: Add sticky header class support. #}
-{% set sticky_class = is_sticky ? 'ct-header--sticky' : '' %}
-{% set modifier_class = '%s %s %s'|format(theme_class, sticky_class, modifier_class|default('')) %}
+{% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
 
-{% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty or content_middle1 is not empty or content_middle2 is not empty or content_middle3 is not empty or content_bottom1 is not empty %}
-  <header class="ct-header {{ modifier_class -}}" role="banner" {% if attributes %}{{ attributes }}{% endif %}>
+<header role="banner" id="siteNav" class="component-nav {{ modifier_class|trim }}"{% if attributes %} {{ attributes }}{% endif %}>
 
-    {% if content_top1 is not empty or content_top2 is not empty or content_top3 is not empty %}
-      <div class="ct-header__top hide-xxs show-m">
+  <div class="component-nav-logo ct-header__content-middle2">
+    {{ content_middle2 }}
+  </div>
 
-        {% if content_top1 is not empty %}
-          {% block content_top1_block %}
-            <div class="container">
-              <div class="row">
-                <div class="col-xxs-12">
-                  <div class="ct-header__content-top1">
-                    {{ content_top1 }}
-                  </div>
-                </div>
-              </div>
-            </div>
-          {% endblock %}
-        {% endif %}
+  <button class="component-nav-toggle" id="navToggle" type="button" aria-label="{{ 'Toggle menu'|t }}" aria-controls="siteNavMenu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
 
-        {% if content_top2 is not empty or content_top3 is not empty %}
-          <div class="container">
-            <div class="row">
-
-              {% block content_top2_block %}
-                <div class="col-xxs-12 col-m-4">
-                  <div class="ct-header__content-top2">
-                    {{ content_top2 }}
-                  </div>
-                </div>
-              {% endblock %}
-
-              {% block content_top3_block %}
-                <div class="col-xxs-12 col-m-8">
-                  <div class="ct-header__content-top3">
-                    {{ content_top3 }}
-                  </div>
-                </div>
-              {% endblock %}
-
-            </div>
-          </div>
-        {% endif %}
-      </div>
+  <div class="component-nav-menu" id="siteNavMenu">
+    {{ do_primary_navigation() }}
+    <a href="/contact" class="component-nav-cta">{{ 'Talk to us'|t }}</a>
+    {% if content_middle3 is not empty %}
+      <div class="ct-header__content-middle3">{{ content_middle3 }}</div>
     {% endif %}
+  </div>
 
-    {% if content_middle1 is not empty or content_middle2 is not empty or content_middle3 is not empty %}
-      <div class="ct-header__middle">
+  {% if content_top1 is not empty %}<div class="ct-header__content-top1">{{ content_top1 }}</div>{% endif %}
+  {% if content_top2 is not empty %}<div class="ct-header__content-top2">{{ content_top2 }}</div>{% endif %}
+  {% if content_top3 is not empty %}<div class="ct-header__content-top3">{{ content_top3 }}</div>{% endif %}
+  {% if content_middle1 is not empty %}<div class="ct-header__content-middle1">{{ content_middle1 }}</div>{% endif %}
+  {% if content_bottom1 is not empty %}<div class="ct-header__content-bottom1">{{ content_bottom1 }}</div>{% endif %}
 
-        {% if content_middle1 is not empty %}
-          {% block content_middle1_block %}
-            <div class="container">
-              <div class="row">
-                <div class="col-xxs-12">
-                  <div class="ct-header__content-middle1">
-                    {{ content_middle1 }}
-                  </div>
-                </div>
-              </div>
-            </div>
-          {% endblock %}
-        {% endif %}
-
-        {% if content_middle2 is not empty or content_middle3 is not empty %}
-          <div class="container">
-            <div class="row row--no-wrap">
-              {% if content_middle2 is not empty %}
-                {% block content_middle2_block %}
-                  <div class="col col--no-grow">
-                    <div class="ct-header__content-middle2">
-                      {{ content_middle2 }}
-                    </div>
-                  </div>
-                {% endblock %}
-              {% endif %}
-
-              {% if content_middle3 is not empty %}
-                {% block content_middle3_block %}
-                  <div class="col">
-                    <div class="ct-header__content-middle3">
-                      {{ content_middle3 }}
-                    </div>
-                  </div>
-                {% endblock %}
-              {% endif %}
-            </div>
-          </div>
-        {% endif %}
-      </div>
-    {% endif %}
-
-    {% if content_bottom1 is not empty %}
-      <div class="ct-header__bottom">
-        {% block content_bottom1_block %}
-          <div class="container">
-            <div class="row">
-              <div class="col-xxs-12">
-                <div class="ct-header__content-bottom1">
-                  {{ content_bottom1 }}
-                </div>
-              </div>
-            </div>
-          </div>
-        {% endblock %}
-      </div>
-    {% endif %}
-  </header>
-{% endif %}
+</header>

--- a/web/themes/custom/drevops/components/03-organisms/header/header.twig
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.twig
@@ -16,6 +16,8 @@
  *
  * Props:
  * - theme: [string] Theme variation (light or dark).
+ * - cta_url: [string] Call-to-action link target (defaults to /contact).
+ * - cta_text: [string] Call-to-action label (defaults to "Talk to us").
  * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
  * - modifier_class: [string] Additional CSS classes.
  *
@@ -39,7 +41,7 @@
 
   <div class="component-nav-menu" id="siteNavMenu">
     {{ do_primary_navigation() }}
-    <a href="/contact" class="component-nav-cta">{{ 'Talk to us'|t }}</a>
+    <a href="{{ cta_url|default('/contact') }}" class="component-nav-cta">{{ cta_text|default('Talk to us'|t) }}</a>
     {% if content_middle3 is not empty %}
       <div class="ct-header__content-middle3">{{ content_middle3 }}</div>
     {% endif %}

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Drupal\civictheme\CivicthemeConstants;
+
 require_once __DIR__ . '/includes/system_main_block.inc';
 require_once __DIR__ . '/includes/banner.inc';
 require_once __DIR__ . '/includes/paragraphs.inc';
@@ -59,6 +61,18 @@ function drevops_preprocess_block(array &$variables): void {
  */
 function drevops_preprocess_page(array &$variables): void {
   _drevops_preprocess_page($variables);
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for menu templates.
+ */
+function drevops_preprocess_menu(array &$variables): void {
+  // CivicTheme menus fall back to the light scheme when a theme is not
+  // supplied, which leaves them light on the site's dark canvas. Default any
+  // non-dark menu to dark so navigation matches the surrounding chrome.
+  if (($variables['theme'] ?? CivicthemeConstants::THEME_LIGHT) !== CivicthemeConstants::THEME_DARK) {
+    $variables['theme'] = CivicthemeConstants::THEME_DARK;
+  }
 }
 
 /**

--- a/web/themes/custom/drevops/templates/navigation/menu--civictheme-primary-navigation.html.twig
+++ b/web/themes/custom/drevops/templates/navigation/menu--civictheme-primary-navigation.html.twig
@@ -12,7 +12,7 @@
   <ul class="component-nav-links">
     {% for item in items %}
       <li class="component-nav-links__item">
-        {{ link(item.title, item.url, item.in_active_trail ? {class: ['component-nav-active'], 'aria-current': 'page'} : {}) }}
+        {{ link(item.title, item.url, item.in_active_trail ? {class: ['component-nav-active'], 'aria-current': 'location'} : {}) }}
       </li>
     {% endfor %}
   </ul>

--- a/web/themes/custom/drevops/templates/navigation/menu--civictheme-primary-navigation.html.twig
+++ b/web/themes/custom/drevops/templates/navigation/menu--civictheme-primary-navigation.html.twig
@@ -12,7 +12,7 @@
   <ul class="component-nav-links">
     {% for item in items %}
       <li class="component-nav-links__item">
-        {{ link(item.title, item.url, item.in_active_trail ? { 'class': ['component-nav-active'], 'aria-current': 'page' } : {}) }}
+        {{ link(item.title, item.url, item.in_active_trail ? {class: ['component-nav-active'], 'aria-current': 'page'} : {}) }}
       </li>
     {% endfor %}
   </ul>

--- a/web/themes/custom/drevops/templates/navigation/menu--civictheme-primary-navigation.html.twig
+++ b/web/themes/custom/drevops/templates/navigation/menu--civictheme-primary-navigation.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Primary navigation rendered as the redesign's flat nav list.
+ *
+ * The header bar shows a single level of links, so only the top level is
+ * emitted. The active trail link carries `component-nav-active` for the
+ * highlighted state.
+ */
+#}
+{% if items %}
+  <ul class="component-nav-links">
+    {% for item in items %}
+      <li class="component-nav-links__item">
+        {{ link(item.title, item.url, item.in_active_trail ? { 'class': ['component-nav-active'], 'aria-current': 'page' } : {}) }}
+      </li>
+    {% endfor %}
+  </ul>
+{% endif %}


### PR DESCRIPTION
Closes #187

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#187] Verb in past tense.`
- [x] Ticket number `#187` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. **Header SDC template** (`header.twig`): Replaced the multi-region CivicTheme grid layout with the redesign's `component-nav` bar. The bar renders `id="siteNav"` (required by `site-nav.js`) and contains: a `.component-nav-logo` slot bound to the `content_middle2` region (brand logo), a mobile toggle button (`id="navToggle"`), and a `.component-nav-menu` panel holding the primary navigation via `do_primary_navigation()`, the configurable CTA link, and an optional `content_middle3` region. All other header regions are kept as lightweight conditional slots so existing block placements continue to render without disrupting the bar layout.
2. **Header SCSS** (`header.scss`): Replaced CivicTheme BEM overrides with self-contained `component-nav` styles drawn from the dark brand token palette. Desktop: sticky translucent bar (`position: sticky`, `backdrop-filter: blur(1rem)`, `color-mix` alpha on the dark background) with `flex-wrap` so any populated optional region wraps onto its own row rather than distorting the bar. Mobile (`<768px`): `backdrop-filter` removed (a containing block would trap the fixed menu inside the bar), the `.component-nav-menu` is positioned `fixed inset: 0` and slides in via `transform: translateX(100%)` → `translateX(0)` when `.is-open` is toggled. The closed panel is taken out of the focus/pointer flow with `visibility: hidden` / `pointer-events: none` so keyboard users cannot tab into off-screen links. The hamburger icon animates to an X via CSS transforms on the three `span` children.
3. **Header SDC schema** (`header.component.yml`): Added `cta_url` and `cta_text` string props so the call-to-action can be configured without touching the template.
4. **`NavigationExtension` Twig extension** (`do_base`): New class exposing `do_primary_navigation(menu_name)` to Twig. Loads the top-level menu tree via `MenuLinkTreeInterface`, runs the standard access/sort manipulators, and returns a render array. The depth cap (`setMaxDepth(1)`) keeps the bar flat. Registered as a `twig.extension` service in `do_base.services.yml`.
5. **Primary navigation menu template** (`menu--civictheme-primary-navigation.html.twig`): New theme template rendering the menu as a `<ul class="component-nav-links">` flat list. Active-trail items receive `class="component-nav-active"` and `aria-current="location"` (a single-level link may be an ancestor of the current page rather than the page itself).
6. **Menu dark colour scheme** (`drevops.theme`): Added `drevops_preprocess_menu()` defaulting CivicTheme menus to the dark scheme. CivicTheme block-rendered menus fall back to the light scheme when no theme is supplied, which left the footer menus rendering light on the dark canvas; defaulting them to dark keeps all site navigation consistent with the dark chrome.
7. **`reveal.js` and `site-nav.js`**: Converted from plain self-invoking functions to `Drupal.behaviors` so they attach correctly on Drupal's dynamic page load cycle and can be re-triggered by `Drupal.attachBehaviors()`. `site-nav.js` gains Escape-key support (closes the open menu and returns focus to the toggle).
8. **CivicTheme nav blocks disabled**: `block.block.drevops_primary_navigation`, `block.block.drevops_mobile_navigation`, and `block.block.drevops_secondary_navigation` config YAMLs set to `status: false`, replacing the three inherited CivicTheme nav blocks with the unified `component-nav` bar.
9. **Behat tests** (`navigation.feature`, `FeatureContext.php`): New `navigation.feature` with four scenarios covering: brand/menu/CTA presence, active-state highlighting on the current page, sticky positioning after scroll, and mobile menu open/close/scroll-lock. The old injected-markup mobile-menu scenario in `interactions.feature` is removed; `FeatureContext.php` gains two step definitions (`assertHeaderStaysAtTop`, `assertMobileMenuToggles`) operating against the real rendered header, asserting the sticky position with an absolute tolerance and the body-scroll restoration against the captured initial value.
10. **`NavigationExtensionTest`** (`do_base` Unit): Three unit tests covering `getFunctions()` registration, the full tree build path, and the empty-menu short-circuit.

## Screenshots

![Header navigation](https://raw.githubusercontent.com/drevops/website/a2759e0d062c56c69ef1d995e43859036e5f60cd/feature-187-header-nav/ff2707154fd386b3ff87faf0d93ebdba7990d426.png)

## Before / After

```
BEFORE (CivicTheme multi-region grid header)
┌─────────────────────────────────────────────────────────────┐
│ .ct-header.ct-theme-dark.ct-header--sticky                  │
│  ┌──────────────────────────────────────────────────────┐   │
│  │ __top (hidden on mobile)                             │   │
│  │  top1 col │ top2 col          │ top3 col             │   │
│  └──────────────────────────────────────────────────────┘   │
│  ┌──────────────────────────────────────────────────────┐   │
│  │ __middle                                             │   │
│  │  middle1 row                                         │   │
│  │  middle2 col (logo) │ middle3 col (nav dropdown)     │   │
│  │  [ct-navigation drawer + flyout, secondary nav]      │   │
│  └──────────────────────────────────────────────────────┘   │
│  ┌──────────────────────────────────────────────────────┐   │
│  │ __bottom                                             │   │
│  └──────────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────────┘

AFTER (redesign component-nav bar)
┌─────────────────────────────────────────────────────────────┐
│ header.component-nav#siteNav  (position:sticky, top:0)      │
│  ┌──────────────────┐  ┌───────────────────────┐  ┌──────┐ │
│  │ .component-nav-  │  │ .component-nav-menu   │  │ [≡]  │ │
│  │ logo             │  │  <ul ..-links>        │  │toggle│ │
│  │ (content_middle2)│  │   nav items           │  │mobile│ │
│  │  dark SVG logo   │  │  + ..-cta "Talk to us"│  │ only │ │
│  └──────────────────┘  └───────────────────────┘  └──────┘ │
│                                                             │
│  Mobile (<768px): .component-nav-menu slides in full-screen │
│  from the right when [≡] is clicked; Escape / link closes.  │
└─────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned site header with sticky navigation bar and responsive layout.
  * Added mobile menu with slide-in animation and scroll locking.
  * Introduced configurable call-to-action button in the header.

* **Tests**
  * Added comprehensive navigation feature tests covering header rendering, active states, scroll behavior, and mobile menu interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
