### PR TITLE
[#191] Added the animated stat counter paragraph components.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.stat.default.yml
+++ b/config/default/core.entity_form_display.paragraph.stat.default.yml
@@ -1,0 +1,51 @@
+uuid: f77c8386-f475-4c0a-addd-a538fa3e6508
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stat.field_c_p_theme
+    - field.field.paragraph.stat.field_items
+    - field.field.paragraph.stat.field_subtitle
+    - paragraphs.paragraphs_type.stat
+  module:
+    - paragraphs
+id: paragraph.stat.default
+targetEntityType: paragraph
+bundle: stat
+mode: default
+content:
+  field_c_p_theme:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_items:
+    type: paragraphs
+    weight: 2
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_subtitle:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_form_display.paragraph.stat_item.default.yml
+++ b/config/default/core.entity_form_display.paragraph.stat_item.default.yml
@@ -1,0 +1,41 @@
+uuid: 4273b7d2-d34e-4e92-8349-5366d486da16
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stat_item.field_stat_label
+    - field.field.paragraph.stat_item.field_stat_suffix
+    - field.field.paragraph.stat_item.field_stat_value
+    - paragraphs.paragraphs_type.stat_item
+id: paragraph.stat_item.default
+targetEntityType: paragraph
+bundle: stat_item
+mode: default
+content:
+  field_stat_label:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_stat_suffix:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_stat_value:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_view_display.paragraph.stat.default.yml
+++ b/config/default/core.entity_view_display.paragraph.stat.default.yml
@@ -1,0 +1,29 @@
+uuid: 58edac6f-d860-4cc4-9bcb-87553b622076
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stat.field_c_p_theme
+    - field.field.paragraph.stat.field_items
+    - field.field.paragraph.stat.field_subtitle
+    - paragraphs.paragraphs_type.stat
+  module:
+    - entity_reference_revisions
+id: paragraph.stat.default
+targetEntityType: paragraph
+bundle: stat
+mode: default
+content:
+  field_items:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_c_p_theme: true
+  field_subtitle: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.stat_item.default.yml
+++ b/config/default/core.entity_view_display.paragraph.stat_item.default.yml
@@ -1,0 +1,19 @@
+uuid: be0936f1-c395-4377-90c2-747da9115e78
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stat_item.field_stat_label
+    - field.field.paragraph.stat_item.field_stat_suffix
+    - field.field.paragraph.stat_item.field_stat_value
+    - paragraphs.paragraphs_type.stat_item
+id: paragraph.stat_item.default
+targetEntityType: paragraph
+bundle: stat_item
+mode: default
+content: {  }
+hidden:
+  field_stat_label: true
+  field_stat_suffix: true
+  field_stat_value: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -24,6 +24,7 @@ dependencies:
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.hero
     - paragraphs.paragraphs_type.service_detail
+    - paragraphs.paragraphs_type.stat
   module:
     - entity_reference_revisions
 _core:
@@ -61,6 +62,7 @@ settings:
       hero: hero
       campaign: campaign
       service_detail: service_detail
+      stat: stat
     negate: 0
     target_bundles_drag_drop:
       campaign:
@@ -167,5 +169,8 @@ settings:
         enabled: true
       service_detail:
         weight: -49
+        enabled: true
+      stat:
+        weight: 61
         enabled: true
 field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.stat.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.stat.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: b22d35c6-0d10-4ab7-8489-0bc81cff53c1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.stat
+  module:
+    - options
+id: paragraph.stat.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: stat
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.stat.field_items.yml
+++ b/config/default/field.field.paragraph.stat.field_items.yml
@@ -1,0 +1,31 @@
+uuid: 383bb889-1485-480a-a1fb-313dfc86a1fa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_items
+    - paragraphs.paragraphs_type.stat
+    - paragraphs.paragraphs_type.stat_item
+  module:
+    - entity_reference_revisions
+id: paragraph.stat.field_items
+field_name: field_items
+entity_type: paragraph
+bundle: stat
+label: Items
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      stat_item: stat_item
+    negate: 0
+    target_bundles_drag_drop:
+      stat_item:
+        weight: 0
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.stat.field_subtitle.yml
+++ b/config/default/field.field.paragraph.stat.field_subtitle.yml
@@ -1,0 +1,19 @@
+uuid: 0181b4a7-ad52-4145-897e-572143ddc1f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_subtitle
+    - paragraphs.paragraphs_type.stat
+id: paragraph.stat.field_subtitle
+field_name: field_subtitle
+entity_type: paragraph
+bundle: stat
+label: 'Section label'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.stat_item.field_stat_label.yml
+++ b/config/default/field.field.paragraph.stat_item.field_stat_label.yml
@@ -1,0 +1,19 @@
+uuid: a9064079-1daa-4f72-bc79-0d0aa491c20c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_stat_label
+    - paragraphs.paragraphs_type.stat_item
+id: paragraph.stat_item.field_stat_label
+field_name: field_stat_label
+entity_type: paragraph
+bundle: stat_item
+label: Label
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.stat_item.field_stat_suffix.yml
+++ b/config/default/field.field.paragraph.stat_item.field_stat_suffix.yml
@@ -1,0 +1,19 @@
+uuid: ca610995-c298-40b9-bcb6-56ca6c5d320d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_stat_suffix
+    - paragraphs.paragraphs_type.stat_item
+id: paragraph.stat_item.field_stat_suffix
+field_name: field_stat_suffix
+entity_type: paragraph
+bundle: stat_item
+label: Suffix
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.stat_item.field_stat_value.yml
+++ b/config/default/field.field.paragraph.stat_item.field_stat_value.yml
@@ -1,0 +1,19 @@
+uuid: 435003f9-c8a1-4aec-bec4-b9cc993786d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_stat_value
+    - paragraphs.paragraphs_type.stat_item
+id: paragraph.stat_item.field_stat_value
+field_name: field_stat_value
+entity_type: paragraph
+bundle: stat_item
+label: Value
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.paragraph.field_items.yml
+++ b/config/default/field.storage.paragraph.field_items.yml
@@ -1,0 +1,20 @@
+uuid: c27eddf7-4fa6-4e61-89ae-24fab24acf9d
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_items
+field_name: field_items
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_stat_label.yml
+++ b/config/default/field.storage.paragraph.field_stat_label.yml
@@ -1,0 +1,21 @@
+uuid: 971ded2e-1b3d-451f-bc31-832594dae92a
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_stat_label
+field_name: field_stat_label
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_stat_suffix.yml
+++ b/config/default/field.storage.paragraph.field_stat_suffix.yml
@@ -1,0 +1,21 @@
+uuid: fad6489c-0330-4991-b25f-226d7c3abb4e
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_stat_suffix
+field_name: field_stat_suffix
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_stat_value.yml
+++ b/config/default/field.storage.paragraph.field_stat_value.yml
@@ -1,0 +1,21 @@
+uuid: 072bc2d1-d11c-483c-be34-6ef5a1d47235
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_stat_value
+field_name: field_stat_value
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/paragraphs.paragraphs_type.stat.yml
+++ b/config/default/paragraphs.paragraphs_type.stat.yml
@@ -1,0 +1,10 @@
+uuid: bd7828b7-4260-49ea-a9dd-7ee7c2919efa
+langcode: en
+status: true
+dependencies: {  }
+id: stat
+label: 'Stat grid'
+icon_uuid: null
+icon_default: null
+description: 'A grid of statistics that count up when scrolled into view.'
+behavior_plugins: {  }

--- a/config/default/paragraphs.paragraphs_type.stat_item.yml
+++ b/config/default/paragraphs.paragraphs_type.stat_item.yml
@@ -1,0 +1,10 @@
+uuid: 9f368484-e142-455b-9db4-85d50e95be66
+langcode: en
+status: true
+dependencies: {  }
+id: stat_item
+label: 'Stat item'
+icon_uuid: null
+icon_default: null
+description: 'A single statistic: a value, an optional suffix and a label.'
+behavior_plugins: {  }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -158,6 +158,29 @@ class FeatureContext extends DrupalContext {
   }
 
   /**
+   * Assert that every stat counter animates up to its target value.
+   */
+  #[\Behat\Step\Then('the stat counters reach their target values')]
+  public function assertStatCountersReachTargets(): void {
+    $session = $this->getSession();
+
+    $script = "(function () {"
+      . " var counters = document.querySelectorAll('.ct-stat-item__count[data-target]');"
+      . " if (!counters.length) { return false; }"
+      . " for (var i = 0; i < counters.length; i++) {"
+      . " if (counters[i].textContent.trim() !== counters[i].getAttribute('data-target')) { return false; }"
+      . " }"
+      . " return true;"
+      . " })()";
+
+    $reached = $session->wait(5000, $script);
+
+    if (!$reached) {
+      throw new \Exception('The stat counters did not reach their target values.');
+    }
+  }
+
+  /**
    * Asserts that an element's computed CSS property resolves to a colour.
    *
    * Works for colour properties (returned by the browser as rgb/rgba) and for

--- a/tests/behat/features/stat.feature
+++ b/tests/behat/features/stat.feature
@@ -1,0 +1,87 @@
+@p1 @drevops @stat
+Feature: Stat grid
+
+  As a content editor
+  I want a grid of statistics that count up as they come into view
+  So that I can present key numbers in a way that draws attention
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                 | status |
+      | [TEST] Page Stat test | 1      |
+
+  @api
+  Scenario: The stat grid renders its items with values, suffixes and labels
+    Given I am an anonymous user
+    And the following fields for the paragraph "stat" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Stat test":
+      | field_subtitle  | [TEST] The essentials |
+      | field_c_p_theme | dark                  |
+    And the following fields for the paragraph "stat_item" exist in the field "field_items" within the "stat" "paragraph" identified by the field "field_subtitle" and the value "[TEST] The essentials":
+      | field_stat_value  | 1                            |
+      | field_stat_suffix | day                          |
+      | field_stat_label  | [TEST] To set up CI/CD       |
+    And the following fields for the paragraph "stat_item" exist in the field "field_items" within the "stat" "paragraph" identified by the field "field_subtitle" and the value "[TEST] The essentials":
+      | field_stat_value  | 10                           |
+      | field_stat_suffix | yrs                          |
+      | field_stat_label  | [TEST] Delivering platforms  |
+    And the following fields for the paragraph "stat_item" exist in the field "field_items" within the "stat" "paragraph" identified by the field "field_subtitle" and the value "[TEST] The essentials":
+      | field_stat_value  | 40                           |
+      | field_stat_suffix | +                            |
+      | field_stat_label  | [TEST] Open-source tools     |
+    And the following fields for the paragraph "stat_item" exist in the field "field_items" within the "stat" "paragraph" identified by the field "field_subtitle" and the value "[TEST] The essentials":
+      | field_stat_value  | 100                          |
+      | field_stat_suffix | %                            |
+      | field_stat_label  | [TEST] Automated tests       |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Stat test"
+    Then I should see an "article .ct-stat" element
+    And I should see an "article .ct-stat.ct-theme-dark" element
+    And I should see 4 ".ct-stat-item" elements
+    And I should see the text "[TEST] The essentials"
+    And I should see the text "[TEST] To set up CI/CD"
+    And I should see the text "[TEST] Delivering platforms"
+    And I should see the text "[TEST] Open-source tools"
+    And I should see the text "[TEST] Automated tests"
+    And I should see the text "yrs"
+    And the response should contain "data-target=\"1\""
+    And the response should contain "data-target=\"10\""
+    And the response should contain "data-target=\"40\""
+    And the response should contain "data-target=\"100\""
+    And the response should contain "ct-stat-item__suffix"
+    And save screenshot
+
+  @api @javascript
+  Scenario: The numbers count up to their target values when scrolled into view
+    Given I am an anonymous user
+    And the following fields for the paragraph "stat" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Stat test":
+      | field_subtitle  | [TEST] The essentials |
+      | field_c_p_theme | dark                  |
+    And the following fields for the paragraph "stat_item" exist in the field "field_items" within the "stat" "paragraph" identified by the field "field_subtitle" and the value "[TEST] The essentials":
+      | field_stat_value  | 40                       |
+      | field_stat_suffix | +                        |
+      | field_stat_label  | [TEST] Open-source tools |
+    And the following fields for the paragraph "stat_item" exist in the field "field_items" within the "stat" "paragraph" identified by the field "field_subtitle" and the value "[TEST] The essentials":
+      | field_stat_value  | 100                    |
+      | field_stat_suffix | %                      |
+      | field_stat_label  | [TEST] Automated tests |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Stat test"
+    Then the stat counters reach their target values
+    And save screenshot
+
+  @api
+  Scenario: A content editor can add a stat grid and a stat item
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "node/add/civictheme_page"
+    And I fill in "Title" with "[TEST] Page stat fields"
+    And I press "Add Stat grid"
+
+    Then I should see the text "Section label"
+    And should see a "[name='field_c_n_components[0][subform][field_subtitle][0][value]']" element
+    And should see a "[name='field_c_n_components_0_subform_field_items_stat_item_add_more']" element
+
+    When I press "Add Stat item"
+    Then I should see the text "Value"
+    And should see a "[name='field_c_n_components[0][subform][field_items][0][subform][field_stat_value][0][value]']" element
+    And should see a "[name='field_c_n_components[0][subform][field_items][0][subform][field_stat_suffix][0][value]']" element
+    And should see a "[name='field_c_n_components[0][subform][field_items][0][subform][field_stat_label][0][value]']" element

--- a/web/themes/custom/drevops/components/00-base/stat-counter/stat-counter.js
+++ b/web/themes/custom/drevops/components/00-base/stat-counter/stat-counter.js
@@ -3,11 +3,11 @@
  * @file
  * Stat count-up behaviour.
  *
- * Animates each '.ct-stat-item__count' from zero to its 'data-target' value when
- * the stat grid scrolls into view, using an easeOut curve. Visitors who prefer
- * reduced motion, and anyone without IntersectionObserver, keep the final value
- * the template already renders. Each element is animated once and ignored on
- * subsequent attaches.
+ * Animates each '.ct-stat-item__count' from zero to its 'data-target' value
+ * when the stat grid scrolls into view, using an easeOut curve. Visitors who
+ * prefer reduced motion, and anyone without IntersectionObserver, keep the
+ * final value the template already renders. Each element is animated once and
+ * ignored on subsequent attaches.
  */
 function DrevOpsStatCounter() {
   const counters = document.querySelectorAll(
@@ -71,7 +71,8 @@ function DrevOpsStatCounter() {
       return;
     }
 
-    // Without motion or an observer, keep the final value the template rendered.
+    // Without motion or an observer, keep the final value the template
+    // already rendered.
     if (reduceMotion || target === 0 || !observer) {
       element.textContent = String(target);
 

--- a/web/themes/custom/drevops/components/00-base/stat-counter/stat-counter.js
+++ b/web/themes/custom/drevops/components/00-base/stat-counter/stat-counter.js
@@ -24,6 +24,10 @@ function DrevOpsStatCounter() {
   const easeOut = (t) => 1 - ((1 - t) ** 3);
 
   const countUp = (element, target) => {
+    if (!Number.isFinite(target)) {
+      return;
+    }
+
     const duration = target < 20 ? 1200 : 2000;
     let start = null;
 
@@ -63,13 +67,13 @@ function DrevOpsStatCounter() {
 
     const target = parseInt(element.getAttribute('data-target'), 10);
 
-    if (Number.isNaN(target)) {
+    if (Number.isNaN(target) || target < 0) {
       return;
     }
 
     // Without motion or an observer, keep the final value the template rendered.
     if (reduceMotion || target === 0 || !observer) {
-      element.textContent = target;
+      element.textContent = String(target);
 
       return;
     }

--- a/web/themes/custom/drevops/components/00-base/stat-counter/stat-counter.js
+++ b/web/themes/custom/drevops/components/00-base/stat-counter/stat-counter.js
@@ -1,0 +1,84 @@
+// phpcs:ignoreFile
+/**
+ * @file
+ * Stat count-up behaviour.
+ *
+ * Animates each '.ct-stat-item__count' from zero to its 'data-target' value when
+ * the stat grid scrolls into view, using an easeOut curve. Visitors who prefer
+ * reduced motion, and anyone without IntersectionObserver, keep the final value
+ * the template already renders. Each element is animated once and ignored on
+ * subsequent attaches.
+ */
+function DrevOpsStatCounter() {
+  const counters = document.querySelectorAll(
+    '.ct-stat-item__count[data-target]:not([data-stat-bound])',
+  );
+
+  if (!counters.length) {
+    return;
+  }
+
+  const reduceMotion = window.matchMedia
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const easeOut = (t) => 1 - ((1 - t) ** 3);
+
+  const countUp = (element, target) => {
+    const duration = target < 20 ? 1200 : 2000;
+    let start = null;
+
+    const step = (timestamp) => {
+      if (start === null) {
+        start = timestamp;
+      }
+
+      const progress = Math.min((timestamp - start) / duration, 1);
+      element.textContent = Math.round(easeOut(progress) * target);
+
+      if (progress < 1) {
+        window.requestAnimationFrame(step);
+      } else {
+        element.textContent = target;
+      }
+    };
+
+    window.requestAnimationFrame(step);
+  };
+
+  let observer = null;
+  if ('IntersectionObserver' in window) {
+    observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const target = parseInt(entry.target.getAttribute('data-target'), 10);
+          countUp(entry.target, target);
+          obs.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.4 });
+  }
+
+  counters.forEach((element) => {
+    element.setAttribute('data-stat-bound', '');
+
+    const target = parseInt(element.getAttribute('data-target'), 10);
+
+    if (Number.isNaN(target)) {
+      return;
+    }
+
+    // Without motion or an observer, keep the final value the template rendered.
+    if (reduceMotion || target === 0 || !observer) {
+      element.textContent = target;
+
+      return;
+    }
+
+    // Reset to zero now, not on intersect, so the final value never flashes
+    // before the grid scrolls into view.
+    element.textContent = '0';
+    observer.observe(element);
+  });
+}
+
+DrevOpsStatCounter();

--- a/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.component.yml
+++ b/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.component.yml
@@ -1,0 +1,34 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Stat item
+status: stable
+description: A single statistic - a value that counts up, an optional suffix and a label.
+props:
+  type: object
+  properties:
+    value:
+      type: string
+      title: Value
+      description: The target number the statistic counts up to.
+    suffix:
+      type: string
+      title: Suffix
+      description: Short text shown beside the value (for example %, +, yrs).
+    label:
+      type: string
+      title: Label
+      description: Caption describing the statistic.
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier Class
+      description: Additional CSS classes.

--- a/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.scss
+++ b/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.scss
@@ -1,0 +1,49 @@
+//
+// Stat item component.
+//
+// One cell of the stat grid: a large count-up number with an optional suffix
+// above an uppercase label. Ported from static-prototype/ (the `components/stat.css`
+// cell rules). Colours map to the CivicTheme dark palette via ct-color-constant-dark
+// so the values are baked at build time; spacing mirrors the prototype's `--space-*`
+// scale, which is not exposed as theme tokens.
+//
+
+.ct-stat-item {
+  padding: 4.5rem 3.5rem;
+
+  &__number {
+    display: flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    margin-bottom: 1rem;
+
+    // The display number uses the brand primary face (Plus Jakarta Sans); body
+    // copy is Outfit, so the family is set explicitly rather than inherited.
+    font-family: 'Plus Jakarta Sans', sans-serif;
+    font-size: clamp(4.5rem, 8vw, 6.75rem);
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: -0.03em;
+    color: ct-color-constant-dark('secondary-6');
+  }
+
+  &__suffix {
+    font-size: 0.45em;
+    font-weight: 400;
+    letter-spacing: 0;
+    opacity: 0.8;
+  }
+
+  &__label {
+    margin: 0;
+    font-size: 0.6875rem;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: ct-color-constant-dark('primary-1');
+  }
+
+  @media (max-width: 48rem) {
+    padding: 3rem 2rem;
+  }
+}

--- a/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.scss
+++ b/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.scss
@@ -31,7 +31,7 @@
     font-size: 0.45em;
     font-weight: 400;
     letter-spacing: 0;
-    opacity: 0.8;
+    opacity: 80%;
   }
 
   &__label {

--- a/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.twig
+++ b/web/themes/custom/drevops/components/02-molecules/stat-item/stat-item.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * @file
+ * Stat item component.
+ *
+ * Props:
+ * - value: [string] The target number the statistic counts up to.
+ * - suffix: [string] Short text shown beside the value (for example %, +, yrs).
+ * - label: [string] Caption describing the statistic.
+ * - theme: [string] Theme variation (light or dark).
+ * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
+ * - modifier_class: [string] Additional CSS classes.
+ *
+ * The count starts rendered at its final value so it is correct without
+ * JavaScript and for reduced-motion visitors; stat-counter.js resets it to zero
+ * and animates up only when motion is allowed.
+ #}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set modifier_class = '%s component-reveal %s'|format(theme_class, modifier_class|default('')) %}
+
+<div class="ct-stat-item {{ modifier_class -}}" {% if attributes %}{{ attributes }}{% endif %}>
+  <div class="ct-stat-item__number">
+    <span class="ct-stat-item__count" data-target="{{ value }}">{{ value }}</span>
+    {%- if suffix is not empty %}<span class="ct-stat-item__suffix">{{ suffix }}</span>{% endif -%}
+  </div>
+  {% if label is not empty %}
+    <p class="ct-stat-item__label">{{ label }}</p>
+  {% endif %}
+</div>

--- a/web/themes/custom/drevops/components/03-organisms/stat/stat.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/stat/stat.component.yml
@@ -1,0 +1,30 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Stat
+status: stable
+description: A grid of statistics that count up when scrolled into view.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+    subtitle:
+      type: string
+      title: Section label
+      description: Small label shown above the grid.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier Class
+      description: Additional CSS classes.
+slots:
+  items:
+    title: Items
+    description: The rendered stat item components.

--- a/web/themes/custom/drevops/components/03-organisms/stat/stat.scss
+++ b/web/themes/custom/drevops/components/03-organisms/stat/stat.scss
@@ -1,0 +1,107 @@
+//
+// Stat grid component.
+//
+// Ports the redesign stats section from static-prototype/ (the `components/stat.css`
+// block and the `#stats` markup). Colours map to the CivicTheme dark palette via
+// ct-color-constant-dark so the values are baked at build time; spacing mirrors the
+// prototype's `--space-*` scale, which is not exposed as theme tokens.
+//
+
+// The hairline that frames the grid and divides its cells.
+$ct-stat-border: 0.0625rem solid color-mix(in srgb, #{ct-color-constant-dark('secondary-6')} 18%, transparent);
+
+.ct-stat {
+  position: relative;
+  overflow: hidden;
+  padding: 8.75rem 0;
+  background-color: color-mix(in srgb, white 6%, #{ct-color-constant-dark('primary-9')});
+
+  // Soft brand glow anchored off the bottom-right corner.
+  &::before {
+    content: '';
+    position: absolute;
+    right: -12.5rem;
+    bottom: -12.5rem;
+    width: 37.5rem;
+    height: 37.5rem;
+    background: radial-gradient(ellipse, color-mix(in srgb, #{ct-color-constant-dark('secondary-6')} 7%, transparent) 0%, transparent 65%);
+    pointer-events: none;
+  }
+
+  &__inner {
+    position: relative;
+    z-index: 1;
+    max-width: 75rem;
+    margin: 0 auto;
+    padding: 0 4rem;
+  }
+
+  &__subtitle {
+    margin: 0 0 3rem;
+    font-size: 0.6875rem;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: ct-color-constant-dark('primary-3');
+  }
+
+  // A 2x2 grid framed by a hairline, with interior dividers drawn on the first
+  // three cells (right border on the left column, bottom border on the top row).
+  &__grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    border: $ct-stat-border;
+  }
+
+  &__grid .ct-stat-item {
+    &:nth-child(1) {
+      border-right: $ct-stat-border;
+      border-bottom: $ct-stat-border;
+    }
+
+    &:nth-child(2) {
+      border-bottom: $ct-stat-border;
+    }
+
+    &:nth-child(3) {
+      border-right: $ct-stat-border;
+    }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    &__grid .ct-stat-item {
+      &:nth-child(2) {
+        transition-delay: 0.1s;
+      }
+
+      &:nth-child(3) {
+        transition-delay: 0.2s;
+      }
+
+      &:nth-child(4) {
+        transition-delay: 0.3s;
+      }
+    }
+  }
+
+  @media (max-width: 48rem) {
+    padding: 6.25rem 0;
+
+    &__inner {
+      padding: 0 1.5rem;
+    }
+
+    &__grid {
+      grid-template-columns: 1fr;
+    }
+
+    &__grid .ct-stat-item {
+      &:nth-child(1),
+      &:nth-child(2),
+      &:nth-child(3) {
+        border-right: none;
+        border-bottom: $ct-stat-border;
+      }
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/stat/stat.twig
+++ b/web/themes/custom/drevops/components/03-organisms/stat/stat.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * @file
+ * Stat grid component.
+ *
+ * Props:
+ * - theme: [string] Theme variation (light or dark).
+ * - subtitle: [string] Small label shown above the grid.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
+ * - modifier_class: [string] Additional CSS classes.
+ *
+ * Slots:
+ * - items: The rendered stat item components.
+ #}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
+
+{% if items is not empty %}
+  <div class="ct-stat {{ modifier_class -}}" data-component-name="ct-stat" {% if attributes %}{{ attributes }}{% endif %}>
+    <div class="ct-stat__inner">
+      {% if subtitle is not empty %}
+        <p class="ct-stat__subtitle component-reveal">{{ subtitle }}</p>
+      {% endif %}
+      <div class="ct-stat__grid">
+        {{ items }}
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -16,6 +16,7 @@ require_once __DIR__ . '/includes/divider.inc';
 require_once __DIR__ . '/includes/hero.inc';
 require_once __DIR__ . '/includes/service_detail.inc';
 require_once __DIR__ . '/includes/manual_list.inc';
+require_once __DIR__ . '/includes/stat.inc';
 require_once __DIR__ . '/includes/page.inc';
 require_once __DIR__ . '/includes/node.inc';
 require_once __DIR__ . '/includes/cards.inc';

--- a/web/themes/custom/drevops/includes/stat.inc
+++ b/web/themes/custom/drevops/includes/stat.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * DrevOps Stat grid paragraph components.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__stat(array &$variables): void {
+  _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
+  $variables['subtitle'] = civictheme_get_field_value($variables['paragraph'], 'field_subtitle', TRUE);
+}
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__stat_item(array &$variables): void {
+  $variables['value'] = civictheme_get_field_value($variables['paragraph'], 'field_stat_value', TRUE);
+  $variables['suffix'] = civictheme_get_field_value($variables['paragraph'], 'field_stat_suffix', TRUE);
+  $variables['label'] = civictheme_get_field_value($variables['paragraph'], 'field_stat_label', TRUE);
+}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--stat-item.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--stat-item.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Stat item component.
+ *
+ * Rendered through the SDC component id so Drupal attaches the component's
+ * library (stat-item.css) when it is placed.
+ */
+#}
+{{ include('drevops:stat-item', {
+  value: value,
+  suffix: suffix,
+  label: label,
+  attributes: component_attributes,
+}, with_context = false) }}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--stat-item.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--stat-item.html.twig
@@ -12,4 +12,4 @@
   suffix: suffix,
   label: label,
   attributes: component_attributes,
-}, with_context = false) }}
+}, with_context: false) }}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--stat.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--stat.html.twig
@@ -12,4 +12,4 @@
   subtitle: subtitle,
   items: content.field_items,
   attributes: component_attributes,
-}, with_context = false) }}
+}, with_context: false) }}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--stat.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--stat.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Stat grid component.
+ *
+ * Rendered through the SDC component id so Drupal attaches the component's
+ * library (stat.css and the shared count-up behaviour) when it is placed.
+ */
+#}
+{{ include('drevops:stat', {
+  theme: theme,
+  subtitle: subtitle,
+  items: content.field_items,
+  attributes: component_attributes,
+}, with_context = false) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#191] Verb in past tense.`
- [x] Ticket number `#191` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

Closes #191

## Changed

1. Added two new paragraph types: `stat` (Stat grid wrapper with `field_subtitle`, `field_items`, and `field_c_p_theme` fields) and `stat_item` (individual statistic with `field_stat_value`, `field_stat_suffix`, and `field_stat_label` fields).
2. Added two SDC components - `03-organisms/stat` (grid wrapper with a 2x2 hairline-bordered grid, brand radial glow, and staggered reveal) and `02-molecules/stat-item` (individual count-up cell using `Plus Jakarta Sans` at `clamp(4.5rem, 8vw, 6.75rem)`), both ported from `static-prototype/`.
3. Added `00-base/stat-counter/stat-counter.js` - a Drupal behaviour that resets each `.ct-stat-item__count[data-target]` to zero and animates it up using an `easeOut` curve via `IntersectionObserver`; visitors who prefer reduced motion or whose browser lacks `IntersectionObserver` keep the server-rendered final value.
4. Added preprocess hook `drevops_preprocess_paragraph__stat` and `drevops_preprocess_paragraph__stat_item` in `includes/stat.inc` and wired up two paragraph Twig templates to delegate rendering to the SDC components.
5. Registered `stat` as an allowed paragraph type on `field_c_n_components` for `civictheme_page` nodes.
6. Added Behat coverage in `tests/behat/features/stat.feature` (three scenarios: rendering with values/suffixes/labels, count-up animation reaching target values, and content-editor form fields) with a custom `assertStatCountersReachTargets` step in `FeatureContext.php`.

## Screenshots

![Stat grid](https://raw.githubusercontent.com/drevops/website/fb8a913b095a22cdfb8183992400b35a697ece21/feature-191-stat-counter/3afade1cb205d0d26c927c3f3b9b8d03fdc11142.png)

## Before / After

```
BEFORE
┌──────────────────────────────────────────────────┐
│  civictheme_page  (field_c_n_components)         │
│  Available paragraph types:                       │
│  - civictheme_accordion, civictheme_banner, ...  │
│  (no stat grid paragraph)                        │
└──────────────────────────────────────────────────┘

AFTER
┌──────────────────────────────────────────────────┐
│  civictheme_page  (field_c_n_components)         │
│  + stat  ──────────────────────────────────────► │
│    ┌──────────────────────────────────────┐       │
│    │  .ct-stat  (dark theme, brand glow) │       │
│    │  ┌──────────┬──────────┐            │       │
│    │  │ stat_item│ stat_item│            │       │
│    │  │  1  day  │ 10  yrs  │  count-up  │       │
│    │  ├──────────┼──────────┤  via       │       │
│    │  │ stat_item│ stat_item│  IntersecObs│      │
│    │  │  40+     │ 100%     │            │       │
│    │  └──────────┴──────────┘            │       │
│    └──────────────────────────────────────┘       │
└──────────────────────────────────────────────────┘
```
