### PR TITLE
[#190] Added the featured campaign card component.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.campaign.default.yml
+++ b/config/default/core.entity_form_display.paragraph.campaign.default.yml
@@ -1,0 +1,60 @@
+uuid: 6e657307-cdde-4710-bd50-7fbb26987c7f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.campaign.field_c_p_theme
+    - field.field.paragraph.campaign.field_content
+    - field.field.paragraph.campaign.field_link
+    - field.field.paragraph.campaign.field_subtitle
+    - field.field.paragraph.campaign.field_title
+    - paragraphs.paragraphs_type.campaign
+  module:
+    - link
+    - text
+id: paragraph.campaign.default
+targetEntityType: paragraph
+bundle: campaign
+mode: default
+content:
+  field_c_p_theme:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_content:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_link:
+    type: link_default
+    weight: 4
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_subtitle:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_view_display.paragraph.campaign.default.yml
+++ b/config/default/core.entity_view_display.paragraph.campaign.default.yml
@@ -1,0 +1,31 @@
+uuid: d8da9cd0-f389-4962-bcce-15f24257c573
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.campaign.field_c_p_theme
+    - field.field.paragraph.campaign.field_content
+    - field.field.paragraph.campaign.field_link
+    - field.field.paragraph.campaign.field_subtitle
+    - field.field.paragraph.campaign.field_title
+    - paragraphs.paragraphs_type.campaign
+  module:
+    - text
+id: paragraph.campaign.default
+targetEntityType: paragraph
+bundle: campaign
+mode: default
+content:
+  field_content:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_c_p_theme: true
+  field_link: true
+  field_subtitle: true
+  field_title: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_c_n_components
     - node.type.civictheme_page
+    - paragraphs.paragraphs_type.campaign
     - paragraphs.paragraphs_type.civictheme_accordion
     - paragraphs.paragraphs_type.civictheme_attachment
     - paragraphs.paragraphs_type.civictheme_automated_list
@@ -57,8 +58,12 @@ settings:
       from_library: from_library
       civictheme_message: civictheme_message
       hero: hero
+      campaign: campaign
     negate: 0
     target_bundles_drag_drop:
+      campaign:
+        weight: 61
+        enabled: true
       civictheme_accordion:
         weight: -58
         enabled: true

--- a/config/default/field.field.paragraph.campaign.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.campaign.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: 92a47c55-bfb4-4a1f-868d-e81b084d25db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.campaign
+  module:
+    - options
+id: paragraph.campaign.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: campaign
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.campaign.field_content.yml
+++ b/config/default/field.field.paragraph.campaign.field_content.yml
@@ -1,0 +1,22 @@
+uuid: a823814e-cf52-4d63-abe2-056dc9bee306
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_content
+    - paragraphs.paragraphs_type.campaign
+  module:
+    - text
+id: paragraph.campaign.field_content
+field_name: field_content
+entity_type: paragraph
+bundle: campaign
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/default/field.field.paragraph.campaign.field_link.yml
+++ b/config/default/field.field.paragraph.campaign.field_link.yml
@@ -1,0 +1,23 @@
+uuid: 7b875d6e-099c-4fda-a0b9-024157b208ba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.campaign
+  module:
+    - link
+id: paragraph.campaign.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: campaign
+label: Actions
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/config/default/field.field.paragraph.campaign.field_subtitle.yml
+++ b/config/default/field.field.paragraph.campaign.field_subtitle.yml
@@ -1,0 +1,19 @@
+uuid: 1d6d76f1-bfec-465c-a799-7c7e277fceea
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_subtitle
+    - paragraphs.paragraphs_type.campaign
+id: paragraph.campaign.field_subtitle
+field_name: field_subtitle
+entity_type: paragraph
+bundle: campaign
+label: Label
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.campaign.field_title.yml
+++ b/config/default/field.field.paragraph.campaign.field_title.yml
@@ -1,0 +1,19 @@
+uuid: da3de285-7ada-4a5a-8c3c-a90da623a404
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.campaign
+id: paragraph.campaign.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: campaign
+label: Heading
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.paragraph.field_content.yml
+++ b/config/default/field.storage.paragraph.field_content.yml
@@ -1,0 +1,19 @@
+uuid: e6607b5b-cbe5-4887-ba01-9086cb320f43
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_content
+field_name: field_content
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_link.yml
+++ b/config/default/field.storage.paragraph.field_link.yml
@@ -1,0 +1,19 @@
+uuid: 41046985-8beb-4d1f-87dd-ce0b0080e07a
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_link
+field_name: field_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 2
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_subtitle.yml
+++ b/config/default/field.storage.paragraph.field_subtitle.yml
@@ -1,0 +1,21 @@
+uuid: 6c80a97e-6f97-4a10-8410-7a7866e693aa
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_subtitle
+field_name: field_subtitle
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_title.yml
+++ b/config/default/field.storage.paragraph.field_title.yml
@@ -1,0 +1,21 @@
+uuid: ab48768e-54db-4cdf-9a4f-5033c3a2b81b
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_title
+field_name: field_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/paragraphs.paragraphs_type.campaign.yml
+++ b/config/default/paragraphs.paragraphs_type.campaign.yml
@@ -1,0 +1,10 @@
+uuid: 79b306cb-fcd9-43e0-b95a-034f777ab0a3
+langcode: en
+status: true
+dependencies: {  }
+id: campaign
+label: Campaign
+icon_uuid: null
+icon_default: null
+description: 'A featured campaign card with a label, heading, body and up to two action links.'
+behavior_plugins: {  }

--- a/tests/behat/features/paragraph_campaign.feature
+++ b/tests/behat/features/paragraph_campaign.feature
@@ -1,0 +1,53 @@
+@p1 @civictheme @drevops @campaign
+Feature: Campaign card
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                        | status |
+      | [TEST] Page Campaign two     | 1      |
+      | [TEST] Page Campaign one     | 1      |
+
+  @api
+  Scenario: Anonymous user sees a campaign card with label, heading, body and two actions
+    Given I am an anonymous user
+    And the following fields for the paragraph "campaign" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Campaign two":
+      | field_subtitle   | For teams already on Drupal                       |
+      | field_title      | Curious what your next project would cost          |
+      | field_content    | Send us a recent quote and we will show the cost.  |
+      | field_c_p_theme  | dark                                               |
+      | field_link:title | See the cost, See how we work                      |
+      | field_link:uri   | https://example.com/cost, https://example.com/work |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Campaign two"
+    Then I should see an "article .ct-campaign-card" element
+    And I should see an "article .ct-campaign-card.ct-theme-dark" element
+    And I should see the text "For teams already on Drupal"
+    And I should see the text "Curious what your next project would cost"
+    And I should see the text "Send us a recent quote and we will show the cost."
+    And I should see the link "See the cost"
+    And I should see the link "See how we work"
+    And I should see an "article .ct-campaign-card__action--secondary" element
+    And I should see an "article .ct-campaign-card__action--primary" element
+    And save screenshot
+
+  @api
+  Scenario: A single action renders one primary button and keeps the layout intact
+    Given I am an anonymous user
+    And the following fields for the paragraph "campaign" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Campaign one":
+      | field_title      | A single call to action      |
+      | field_c_p_theme  | dark                         |
+      | field_link:title | Get in touch                 |
+      | field_link:uri   | https://example.com/contact  |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Campaign one"
+    Then I should see an "article .ct-campaign-card" element
+    And I should see the link "Get in touch"
+    And I should see 1 "article .ct-campaign-card__action" element
+    And I should see an "article .ct-campaign-card__action--primary" element
+    And I should not see an "article .ct-campaign-card__action--secondary" element
+
+  @api
+  Scenario: A content editor is offered the campaign component on a page
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "node/add/civictheme_page"
+    Then the response should contain "Add Campaign"

--- a/tests/behat/features/paragraph_campaign.feature
+++ b/tests/behat/features/paragraph_campaign.feature
@@ -6,6 +6,7 @@ Feature: Campaign card
       | title                        | status |
       | [TEST] Page Campaign two     | 1      |
       | [TEST] Page Campaign one     | 1      |
+      | [TEST] Page Campaign light   | 1      |
 
   @api
   Scenario: Anonymous user sees a campaign card with label, heading, body and two actions
@@ -31,7 +32,7 @@ Feature: Campaign card
     And save screenshot
 
   @api
-  Scenario: A single action renders one primary button and keeps the layout intact
+  Scenario: A single action renders only a primary button
     Given I am an anonymous user
     And the following fields for the paragraph "campaign" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Campaign one":
       | field_title      | A single call to action      |
@@ -51,3 +52,17 @@ Feature: Campaign card
     Given I am logged in as a user with the "Site Administrator" role
     When I visit "node/add/civictheme_page"
     Then the response should contain "Add Campaign"
+
+  @api
+  Scenario: A campaign card honours the light theme
+    Given I am an anonymous user
+    And the following fields for the paragraph "campaign" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Campaign light":
+      | field_title      | A light scheme campaign      |
+      | field_c_p_theme  | light                        |
+      | field_link:title | Get in touch                 |
+      | field_link:uri   | https://example.com/contact  |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Campaign light"
+    Then I should see an "article .ct-campaign-card.ct-theme-light" element
+    And I should not see an "article .ct-campaign-card.ct-theme-dark" element
+    And I should see the link "Get in touch"

--- a/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.component.yml
@@ -25,6 +25,7 @@ props:
       type: array
       title: Actions
       description: Up to two action links. The last action renders as the primary button, the rest as secondary.
+      maxItems: 2
       items:
         type: object
         properties:

--- a/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.component.yml
@@ -1,0 +1,50 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Campaign Card
+status: stable
+description: A centred, bordered featured-campaign card with an accent label, heading, body and up to two action buttons.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: dark
+    label:
+      type: string
+      title: Label
+      description: Short accent label shown above the heading.
+    heading:
+      type: string
+      title: Heading
+      description: Campaign heading.
+    actions:
+      type: array
+      title: Actions
+      description: Up to two action links. The last action renders as the primary button, the rest as secondary.
+      items:
+        type: object
+        properties:
+          url:
+            type: string
+            title: URL
+            description: Action URL.
+          title:
+            type: string
+            title: Title
+            description: Action label.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier class
+      description: Additional CSS classes.
+slots:
+  body:
+    title: Body
+    description: Campaign body content.

--- a/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.scss
+++ b/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.scss
@@ -1,0 +1,163 @@
+//
+// Campaign Card component.
+//
+// A centred, bordered featured-campaign card with a soft corner glow, an accent
+// label, a heading, a body and up to two action buttons. The look is ported from
+// the static prototype's featured-campaign section; colours and typography use
+// CivicTheme's brand-mapped `--ct-*` tokens, spacing uses the prototype's rem
+// scale (CivicTheme exposes no global spacing tokens).
+//
+
+.ct-campaign-card {
+  position: relative;
+  overflow: hidden;
+  padding: 8.75rem 0;
+
+  // Soft corner glow in the brand accent.
+  &::before {
+    content: '';
+    position: absolute;
+    top: -160px;
+    left: -160px;
+    width: 520px;
+    height: 520px;
+    background: radial-gradient(ellipse, color-mix(in srgb, var(--ct-color-dark-interaction-background) 12%, transparent) 0%, transparent 65%);
+    pointer-events: none;
+  }
+
+  &__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 4rem;
+
+    @media (max-width: 768px) {
+      padding: 0 1.5rem;
+    }
+  }
+
+  &__card {
+    position: relative;
+    z-index: 2;
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 4.5rem 3.5rem;
+    text-align: center;
+    background: var(--ct-color-dark-background-light);
+    border: 1px solid var(--ct-color-dark-border);
+    border-radius: 1rem;
+
+    @media (max-width: 768px) {
+      padding: 3rem 1.5rem;
+    }
+  }
+
+  &__label {
+    margin: 0;
+    font-family: var(--ct-typography-label-regular-font-name);
+    font-size: var(--ct-typography-label-regular-font-size);
+    font-weight: var(--ct-typography-label-regular-font-weight);
+    line-height: var(--ct-typography-label-regular-line-height);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ct-color-dark-interaction-background);
+  }
+
+  &__title {
+    margin: 1.5rem 0;
+    font-family: var(--ct-typography-display-font-name);
+    font-size: var(--ct-typography-display-font-size);
+    font-weight: var(--ct-typography-display-font-weight);
+    line-height: 1.1;
+    letter-spacing: var(--ct-typography-display-letter-spacing);
+    color: var(--ct-color-dark-heading);
+  }
+
+  &__content {
+    max-width: 640px;
+    margin: 0 auto 3rem;
+    font-size: var(--ct-typography-text-large-font-size);
+    line-height: 1.6;
+    color: var(--ct-color-dark-body);
+
+    p {
+      margin: 0;
+
+      & + p {
+        margin-top: 1.5rem;
+      }
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__action {
+    display: inline-block;
+    position: relative;
+    overflow: hidden;
+    padding: 1rem 2rem;
+    font-family: var(--ct-typography-label-regular-font-name);
+    font-size: 0.875rem;
+    font-weight: var(--ct-typography-label-regular-font-weight);
+    line-height: 1;
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: color 0.4s ease, border-color 0.4s ease;
+
+    // Hover fill: a faint tint that wipes in from the left.
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 0.4s ease;
+    }
+
+    &:hover {
+      text-decoration: none;
+
+      &::before {
+        transform: scaleX(1);
+      }
+    }
+
+    // The last action is the primary CTA: brand accent outline.
+    &--primary {
+      color: var(--ct-color-dark-interaction-background);
+      border-color: color-mix(in srgb, var(--ct-color-dark-interaction-background) 40%, transparent);
+
+      &::before {
+        background: color-mix(in srgb, var(--ct-color-dark-interaction-background) 8%, transparent);
+      }
+
+      &:hover {
+        color: var(--ct-color-dark-interaction-hover-background);
+        border-color: var(--ct-color-dark-interaction-background);
+      }
+    }
+
+    // Earlier actions are secondary: neutral outline.
+    &--secondary {
+      color: var(--ct-color-dark-heading);
+      border-color: color-mix(in srgb, var(--ct-color-dark-heading) 30%, transparent);
+
+      &::before {
+        background: color-mix(in srgb, var(--ct-color-dark-heading) 8%, transparent);
+      }
+
+      &:hover {
+        color: var(--ct-color-dark-heading);
+        border-color: var(--ct-color-dark-heading);
+      }
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.scss
+++ b/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.scss
@@ -3,15 +3,33 @@
 //
 // A centred, bordered featured-campaign card with a soft corner glow, an accent
 // label, a heading, a body and up to two action buttons. The look is ported from
-// the static prototype's featured-campaign section; colours and typography use
-// CivicTheme's brand-mapped `--ct-*` tokens, spacing uses the prototype's rem
-// scale (CivicTheme exposes no global spacing tokens).
+// the static prototype's featured-campaign section. Colours resolve through
+// per-theme local variables (dark by default, light when ct-theme-light is set)
+// so the card renders correctly in either CivicTheme scheme; spacing uses the
+// prototype's rem scale (CivicTheme exposes no global spacing tokens).
 //
 
 .ct-campaign-card {
+  // Dark scheme is the default; ct-theme-light overrides below.
+  --ct-campaign-card-surface-color: var(--ct-color-dark-background-light);
+  --ct-campaign-card-border-color: var(--ct-color-dark-border);
+  --ct-campaign-card-heading-color: var(--ct-color-dark-heading);
+  --ct-campaign-card-body-color: var(--ct-color-dark-body);
+  --ct-campaign-card-accent-color: var(--ct-color-dark-interaction-background);
+  --ct-campaign-card-accent-hover-color: var(--ct-color-dark-interaction-hover-background);
+
   position: relative;
   overflow: hidden;
   padding: 8.75rem 0;
+
+  &.ct-theme-light {
+    --ct-campaign-card-surface-color: var(--ct-color-light-background-light);
+    --ct-campaign-card-border-color: var(--ct-color-light-border);
+    --ct-campaign-card-heading-color: var(--ct-color-light-heading);
+    --ct-campaign-card-body-color: var(--ct-color-light-body);
+    --ct-campaign-card-accent-color: var(--ct-color-light-interaction-background);
+    --ct-campaign-card-accent-hover-color: var(--ct-color-light-interaction-hover-background);
+  }
 
   // Soft corner glow in the brand accent.
   &::before {
@@ -21,7 +39,7 @@
     left: -160px;
     width: 520px;
     height: 520px;
-    background: radial-gradient(ellipse, color-mix(in srgb, var(--ct-color-dark-interaction-background) 12%, transparent) 0%, transparent 65%);
+    background: radial-gradient(ellipse, color-mix(in srgb, var(--ct-campaign-card-accent-color) 12%, transparent) 0%, transparent 65%);
     pointer-events: none;
   }
 
@@ -30,7 +48,7 @@
     margin: 0 auto;
     padding: 0 4rem;
 
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
       padding: 0 1.5rem;
     }
   }
@@ -42,11 +60,11 @@
     margin: 0 auto;
     padding: 4.5rem 3.5rem;
     text-align: center;
-    background: var(--ct-color-dark-background-light);
-    border: 1px solid var(--ct-color-dark-border);
+    background: var(--ct-campaign-card-surface-color);
+    border: 1px solid var(--ct-campaign-card-border-color);
     border-radius: 1rem;
 
-    @media (max-width: 768px) {
+    @media (width <= 768px) {
       padding: 3rem 1.5rem;
     }
   }
@@ -59,7 +77,7 @@
     line-height: var(--ct-typography-label-regular-line-height);
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: var(--ct-color-dark-interaction-background);
+    color: var(--ct-campaign-card-accent-color);
   }
 
   &__title {
@@ -69,7 +87,7 @@
     font-weight: var(--ct-typography-display-font-weight);
     line-height: 1.1;
     letter-spacing: var(--ct-typography-display-letter-spacing);
-    color: var(--ct-color-dark-heading);
+    color: var(--ct-campaign-card-heading-color);
   }
 
   &__content {
@@ -77,7 +95,7 @@
     margin: 0 auto 3rem;
     font-size: var(--ct-typography-text-large-font-size);
     line-height: 1.6;
-    color: var(--ct-color-dark-body);
+    color: var(--ct-campaign-card-body-color);
 
     p {
       margin: 0;
@@ -132,31 +150,31 @@
 
     // The last action is the primary CTA: brand accent outline.
     &--primary {
-      color: var(--ct-color-dark-interaction-background);
-      border-color: color-mix(in srgb, var(--ct-color-dark-interaction-background) 40%, transparent);
+      color: var(--ct-campaign-card-accent-color);
+      border-color: color-mix(in srgb, var(--ct-campaign-card-accent-color) 40%, transparent);
 
       &::before {
-        background: color-mix(in srgb, var(--ct-color-dark-interaction-background) 8%, transparent);
+        background: color-mix(in srgb, var(--ct-campaign-card-accent-color) 8%, transparent);
       }
 
       &:hover {
-        color: var(--ct-color-dark-interaction-hover-background);
-        border-color: var(--ct-color-dark-interaction-background);
+        color: var(--ct-campaign-card-accent-hover-color);
+        border-color: var(--ct-campaign-card-accent-color);
       }
     }
 
     // Earlier actions are secondary: neutral outline.
     &--secondary {
-      color: var(--ct-color-dark-heading);
-      border-color: color-mix(in srgb, var(--ct-color-dark-heading) 30%, transparent);
+      color: var(--ct-campaign-card-heading-color);
+      border-color: color-mix(in srgb, var(--ct-campaign-card-heading-color) 30%, transparent);
 
       &::before {
-        background: color-mix(in srgb, var(--ct-color-dark-heading) 8%, transparent);
+        background: color-mix(in srgb, var(--ct-campaign-card-heading-color) 8%, transparent);
       }
 
       &:hover {
-        color: var(--ct-color-dark-heading);
-        border-color: var(--ct-color-dark-heading);
+        color: var(--ct-campaign-card-heading-color);
+        border-color: var(--ct-campaign-card-heading-color);
       }
     }
   }

--- a/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.twig
+++ b/web/themes/custom/drevops/components/03-organisms/campaign-card/campaign-card.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @file
+ * Campaign Card component.
+ *
+ * Variables:
+ * - theme: [string] Theme variation: light, dark.
+ * - label: [string] Short accent label shown above the heading.
+ * - heading: [string] Campaign heading.
+ * - actions: [array] Up to two action links; the last renders as primary:
+ *   - url: [string] Action URL.
+ *   - title: [string] Action label.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ *
+ * Slots:
+ * - body: Campaign body content.
+ */
+#}
+
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set modifier_class = '%s %s'|format(theme_class, modifier_class|default(''))|trim %}
+
+{% if heading is not empty %}
+  <div class="ct-campaign-card {{ modifier_class }}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="ct-campaign-card__inner">
+      <div class="ct-campaign-card__card component-reveal">
+        {% if label is not empty %}
+          <p class="ct-campaign-card__label">{{ label }}</p>
+        {% endif %}
+
+        <h2 class="ct-campaign-card__title">{{ heading }}</h2>
+
+        {% if body is not empty %}
+          <div class="ct-campaign-card__content">{{ body }}</div>
+        {% endif %}
+
+        {% if actions is not empty %}
+          <div class="ct-campaign-card__actions">
+            {% for action in actions %}
+              {% if action.url is not empty and action.title is not empty %}
+                <a href="{{ action.url }}" class="ct-campaign-card__action ct-campaign-card__action--{{ loop.last ? 'primary' : 'secondary' }}">{{ action.title }}</a>
+              {% endif %}
+            {% endfor %}
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--campaign.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--campaign.html.twig
@@ -8,7 +8,7 @@
 {% for item in paragraph.field_link %}
   {% if item.uri is not empty %}
     {% set campaign_actions = campaign_actions|merge([{
-      url: item.url.toString,
+      url: item.url.toString(),
       title: item.title,
     }]) %}
   {% endif %}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--campaign.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--campaign.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Campaign paragraph.
+ */
+#}
+{% set campaign_actions = [] %}
+{% for item in paragraph.field_link %}
+  {% if item.uri is not empty %}
+    {% set campaign_actions = campaign_actions|merge([{
+      url: item.url.toString,
+      title: item.title,
+    }]) %}
+  {% endif %}
+{% endfor %}
+
+{{ include('drevops:campaign-card', {
+  theme: paragraph.field_c_p_theme.value|default('dark'),
+  label: paragraph.field_subtitle.value,
+  heading: paragraph.field_title.value,
+  body: content.field_content,
+  actions: campaign_actions,
+  attributes: component_attributes,
+}) }}


### PR DESCRIPTION
Closes #190

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#190] Verb in past tense.`
- [x] Ticket number `#190` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added a `campaign` paragraph type with fields: `field_subtitle` (Label), `field_title` (Heading, required), `field_content` (Body), `field_link` (Actions, cardinality 2), and `field_c_p_theme` (Theme, defaulting to `dark`). All field storage configs are new - none reuse existing paragraph field storage.
2. Added the `drevops:campaign-card` SDC at `03-organisms/campaign-card/` - a centred, bordered card with a soft corner glow, accent label, heading, body slot, and up to two action buttons. The last action renders as the primary CTA (brand accent outline); any earlier action renders as secondary (neutral outline). Colours are driven by per-component CSS custom properties that resolve against the active CivicTheme `--ct-*` brand tokens, supporting both `ct-theme-dark` and `ct-theme-light`.
3. Added `paragraph--campaign.html.twig` to wire the paragraph entity to the SDC: iterates `field_link` items to build the `actions` array, passes `field_subtitle`, `field_title`, `field_content`, and `field_c_p_theme` through to the component.
4. Enabled the `campaign` bundle on `field_c_n_components` for `civictheme_page` nodes so editors can add a Campaign card from the page component field.
5. Added Behat coverage in `paragraph_campaign.feature` with four scenarios: full two-action dark card, single-action (primary only), editor component picker, and light-theme rendering.

## Screenshots

![Featured campaign card](https://raw.githubusercontent.com/drevops/website/957869a290c1a3135f0fb403f9eb3efc229a4745/feature-190-campaign-card/1668d819ce0a0d56ba5fb6b0334a5629e159e06d.png)

## Before / After

```
BEFORE                                    AFTER
┌─────────────────────────────────┐       ┌─────────────────────────────────┐
│ civictheme_page                 │       │ civictheme_page                 │
│  field_c_n_components           │       │  field_c_n_components           │
│  ┌──────────────────────────┐   │       │  ┌──────────────────────────┐   │
│  │ Existing CivicTheme      │   │       │  │ Existing CivicTheme      │   │
│  │ paragraph types          │   │       │  │ paragraph types          │   │
│  └──────────────────────────┘   │       │  └──────────────────────────┘   │
│  (no campaign bundle)           │       │  ┌──────────────────────────┐   │
│                                 │       │  │ campaign (NEW)           │   │
│                                 │       │  │  label · heading · body  │   │
│                                 │       │  │  actions (up to 2)       │   │
│                                 │       │  │  theme: dark / light     │   │
└─────────────────────────────────┘       │  └──────────────────────────┘   │
                                          │  rendered via drevops:campaign-  │
                                          │  card SDC (03-organisms)         │
                                          └─────────────────────────────────┘
```
