### PR TITLE
[#193] Added the Contact detail component with email and phone links.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.contact_detail.default.yml
+++ b/config/default/core.entity_form_display.paragraph.contact_detail.default.yml
@@ -1,0 +1,50 @@
+uuid: 3af51954-f3a4-4cdb-a249-ecc5a0bc5813
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.contact_detail.field_c_p_content
+    - field.field.paragraph.contact_detail.field_c_p_subtitle
+    - field.field.paragraph.contact_detail.field_c_p_summary
+    - field.field.paragraph.contact_detail.field_c_p_theme
+    - paragraphs.paragraphs_type.contact_detail
+  module:
+    - text
+id: paragraph.contact_detail.default
+targetEntityType: paragraph
+bundle: contact_detail
+mode: default
+content:
+  field_c_p_content:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_subtitle:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_summary:
+    type: string_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_theme:
+    type: options_buttons
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_view_display.paragraph.contact_detail.default.yml
+++ b/config/default/core.entity_view_display.paragraph.contact_detail.default.yml
@@ -1,0 +1,42 @@
+uuid: bc81021c-d744-424e-b34e-89ac2c1a289a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.contact_detail.field_c_p_content
+    - field.field.paragraph.contact_detail.field_c_p_subtitle
+    - field.field.paragraph.contact_detail.field_c_p_summary
+    - field.field.paragraph.contact_detail.field_c_p_theme
+    - paragraphs.paragraphs_type.contact_detail
+  module:
+    - text
+id: paragraph.contact_detail.default
+targetEntityType: paragraph
+bundle: contact_detail
+mode: default
+content:
+  field_c_p_content:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_c_p_subtitle:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_c_p_summary:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  field_c_p_theme: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -20,6 +20,7 @@ dependencies:
     - paragraphs.paragraphs_type.civictheme_promo
     - paragraphs.paragraphs_type.civictheme_slider
     - paragraphs.paragraphs_type.civictheme_webform
+    - paragraphs.paragraphs_type.contact_detail
     - paragraphs.paragraphs_type.divider
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.hero
@@ -63,6 +64,7 @@ settings:
       campaign: campaign
       service_detail: service_detail
       stat: stat
+      contact_detail: contact_detail
     negate: 0
     target_bundles_drag_drop:
       campaign:
@@ -157,6 +159,9 @@ settings:
         enabled: false
       civictheme_webform:
         weight: -46
+        enabled: true
+      contact_detail:
+        weight: 61
         enabled: true
       divider:
         weight: 60

--- a/config/default/field.field.paragraph.contact_detail.field_c_p_content.yml
+++ b/config/default/field.field.paragraph.contact_detail.field_c_p_content.yml
@@ -1,0 +1,22 @@
+uuid: 2f6c4b09-e264-4b1b-ab9b-cf8e592a0cb3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_content
+    - paragraphs.paragraphs_type.contact_detail
+  module:
+    - text
+id: paragraph.contact_detail.field_c_p_content
+field_name: field_c_p_content
+entity_type: paragraph
+bundle: contact_detail
+label: Value
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/default/field.field.paragraph.contact_detail.field_c_p_content.yml
+++ b/config/default/field.field.paragraph.contact_detail.field_c_p_content.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_c_p_content
+    - filter.format.plain_text
     - paragraphs.paragraphs_type.contact_detail
   module:
     - text
@@ -18,5 +19,6 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  allowed_formats: {  }
+  allowed_formats:
+    - plain_text
 field_type: text_long

--- a/config/default/field.field.paragraph.contact_detail.field_c_p_subtitle.yml
+++ b/config/default/field.field.paragraph.contact_detail.field_c_p_subtitle.yml
@@ -1,0 +1,19 @@
+uuid: a3ca2c8b-146b-45a1-a56d-c3a9862581ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_subtitle
+    - paragraphs.paragraphs_type.contact_detail
+id: paragraph.contact_detail.field_c_p_subtitle
+field_name: field_c_p_subtitle
+entity_type: paragraph
+bundle: contact_detail
+label: Label
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.contact_detail.field_c_p_summary.yml
+++ b/config/default/field.field.paragraph.contact_detail.field_c_p_summary.yml
@@ -1,0 +1,19 @@
+uuid: c24aa9e1-8c0f-4bcd-b571-2814de7f727f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_summary
+    - paragraphs.paragraphs_type.contact_detail
+id: paragraph.contact_detail.field_c_p_summary
+field_name: field_c_p_summary
+entity_type: paragraph
+bundle: contact_detail
+label: Note
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.field.paragraph.contact_detail.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.contact_detail.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: 53ded269-1ebc-435c-bae3-87da703d896f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.contact_detail
+  module:
+    - options
+id: paragraph.contact_detail.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: contact_detail
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/paragraphs.paragraphs_type.contact_detail.yml
+++ b/config/default/paragraphs.paragraphs_type.contact_detail.yml
@@ -1,0 +1,10 @@
+uuid: 5dfe18e3-5538-4ab9-9954-40499f521b2d
+langcode: en
+status: true
+dependencies: {  }
+id: contact_detail
+label: 'Contact detail'
+icon_uuid: null
+icon_default: null
+description: 'A single contact method - a label, a value, and a note. Email and phone values render as actionable links.'
+behavior_plugins: {  }

--- a/tests/behat/features/paragraph_contact_detail_fields.feature
+++ b/tests/behat/features/paragraph_contact_detail_fields.feature
@@ -18,6 +18,7 @@ Feature: Contact detail fields
 
     And I should see the text "Value"
     And should see a "[name='field_c_n_components[0][subform][field_c_p_content][0][value]']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_content][0][value]'].required" element
 
     And I should see the text "Note"
     And should see a "[name='field_c_n_components[0][subform][field_c_p_summary][0][value]']" element

--- a/tests/behat/features/paragraph_contact_detail_fields.feature
+++ b/tests/behat/features/paragraph_contact_detail_fields.feature
@@ -1,0 +1,26 @@
+@p1 @civictheme @drevops @contact_detail
+Feature: Contact detail fields
+
+  As a content editor
+  I want to add a contact detail to a page with a label, value and note
+  So that I can build the contact information column from structured pieces
+
+  @api
+  Scenario: The form exposes label, value and note, with the label required
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "node/add/civictheme_page"
+    And I fill in "Title" with "[TEST] Page contact detail fields"
+    And I press "Add Contact detail"
+
+    Then I should see the text "Label"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_subtitle][0][value]']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_subtitle][0][value]'].required" element
+
+    And I should see the text "Value"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_content][0][value]']" element
+
+    And I should see the text "Note"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_summary][0][value]']" element
+
+    And I should see the text "Theme"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_theme]']" element

--- a/tests/behat/features/paragraph_contact_detail_render.feature
+++ b/tests/behat/features/paragraph_contact_detail_render.feature
@@ -1,0 +1,46 @@
+@p1 @civictheme @drevops @contact_detail
+Feature: Contact detail render
+
+  As a site visitor
+  I want each contact method to show its label, value and note
+  So that I can reach the team through the right channel
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                      | status |
+      | [TEST] Page Contact detail | 1      |
+
+  @api @javascript
+  Scenario: Contact details stack with actionable email and phone links
+    Given I am an anonymous user
+    And the following fields for the paragraph "contact_detail" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Contact detail":
+      | field_c_p_subtitle       | Email us directly                  |
+      | field_c_p_content:value  | info@drevops.com                   |
+      | field_c_p_content:format | basic_html                         |
+      | field_c_p_summary        | We typically respond within a day. |
+      | field_c_p_theme          | dark                               |
+    And the following fields for the paragraph "contact_detail" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Contact detail":
+      | field_c_p_subtitle       | Call us                             |
+      | field_c_p_content:value  | 04 3009 3538                        |
+      | field_c_p_content:format | basic_html                          |
+      | field_c_p_summary        | Available weekdays, Melbourne time. |
+      | field_c_p_theme          | dark                                |
+    And the following fields for the paragraph "contact_detail" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Contact detail":
+      | field_c_p_subtitle       | Based in                         |
+      | field_c_p_content:value  | Melbourne, Australia             |
+      | field_c_p_content:format | basic_html                       |
+      | field_c_p_summary        | We work across Australia and NZ. |
+      | field_c_p_theme          | dark                             |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Contact detail"
+    Then I should see an "article .component-contact-detail.ct-theme-dark" element
+    And I should see an "article .component-contact-detail .component-contact-detail__label" element
+    And I should see an "article .component-contact-detail .component-contact-detail__note" element
+    And I should see an "article a.component-contact-detail__value--email[href='mailto:info@drevops.com']" element
+    And I should see an "article a.component-contact-detail__value[href='tel:0430093538']" element
+    And I should see an "article p.component-contact-detail__value" element
+    And I should see the text "Email us directly"
+    And I should see the text "info@drevops.com"
+    And I should see the text "04 3009 3538"
+    And I should see the text "Melbourne, Australia"
+    And save screenshot

--- a/tests/behat/features/paragraph_contact_detail_render.feature
+++ b/tests/behat/features/paragraph_contact_detail_render.feature
@@ -5,14 +5,12 @@ Feature: Contact detail render
   I want each contact method to show its label, value and note
   So that I can reach the team through the right channel
 
-  Background:
+  @api @javascript
+  Scenario: Contact details stack with actionable email and phone links
     Given the following "civictheme_page" content:
       | title                      | status |
       | [TEST] Page Contact detail | 1      |
-
-  @api @javascript
-  Scenario: Contact details stack with actionable email and phone links
-    Given I am an anonymous user
+    And I am an anonymous user
     And the following fields for the paragraph "contact_detail" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Contact detail":
       | field_c_p_subtitle       | Email us directly                  |
       | field_c_p_content:value  | info@drevops.com                   |

--- a/tests/behat/features/paragraph_contact_detail_render.feature
+++ b/tests/behat/features/paragraph_contact_detail_render.feature
@@ -16,19 +16,19 @@ Feature: Contact detail render
     And the following fields for the paragraph "contact_detail" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Contact detail":
       | field_c_p_subtitle       | Email us directly                  |
       | field_c_p_content:value  | info@drevops.com                   |
-      | field_c_p_content:format | basic_html                         |
+      | field_c_p_content:format | plain_text                         |
       | field_c_p_summary        | We typically respond within a day. |
       | field_c_p_theme          | dark                               |
     And the following fields for the paragraph "contact_detail" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Contact detail":
       | field_c_p_subtitle       | Call us                             |
       | field_c_p_content:value  | 04 3009 3538                        |
-      | field_c_p_content:format | basic_html                          |
+      | field_c_p_content:format | plain_text                          |
       | field_c_p_summary        | Available weekdays, Melbourne time. |
       | field_c_p_theme          | dark                                |
     And the following fields for the paragraph "contact_detail" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Contact detail":
       | field_c_p_subtitle       | Based in                         |
       | field_c_p_content:value  | Melbourne, Australia             |
-      | field_c_p_content:format | basic_html                       |
+      | field_c_p_content:format | plain_text                       |
       | field_c_p_summary        | We work across Australia and NZ. |
       | field_c_p_theme          | dark                             |
 

--- a/web/themes/custom/drevops/components/02-molecules/contact-detail/contact-detail.component.yml
+++ b/web/themes/custom/drevops/components/02-molecules/contact-detail/contact-detail.component.yml
@@ -1,0 +1,48 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Contact detail
+status: stable
+description: A single contact method - a label, a value, and a supporting note. Email and phone values render as actionable links.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: dark
+    label:
+      type: string
+      title: Label
+      description: Short label naming the contact method.
+    value:
+      type: object
+      title: Value
+      description: The contact value and, for email or phone, the link that opens it.
+      properties:
+        text:
+          type: string
+          title: Text
+          description: The value shown to the visitor.
+        url:
+          type: string
+          title: URL
+          description: The mailto or tel link, when the value is actionable.
+        is_email:
+          type: boolean
+          title: Is email
+          description: Whether the value is an email address (drives the underline treatment).
+    note:
+      type: string
+      title: Note
+      description: Supporting note shown beneath the value.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier class
+      description: Additional CSS classes.

--- a/web/themes/custom/drevops/components/02-molecules/contact-detail/contact-detail.scss
+++ b/web/themes/custom/drevops/components/02-molecules/contact-detail/contact-detail.scss
@@ -1,0 +1,77 @@
+//
+// Contact detail component styles.
+//
+// Ported from static-prototype (contact, the direct-contact column). Brand
+// colours are read from the dark palette as flat values so the contact detail
+// renders the same dark treatment whichever theme it requests, matching the
+// rest of the redesign. Email values carry an animated underline; phone values
+// are plain tel links; non-actionable values render as static text.
+//
+
+$_contact-detail-text: ct-color-constant-dark('neutral-1');
+$_contact-detail-muted: ct-color-constant-dark('primary-3');
+$_contact-detail-accent: ct-color-constant-dark('tertiary-3');
+$_contact-detail-teal: ct-color-constant-dark('secondary-6');
+
+.component-contact-detail {
+  $root: &;
+
+  & {
+    margin-bottom: ct-particle(5);
+  }
+
+  #{$root}__label {
+    margin: 0 0 ct-particle(1);
+    font-size: 0.6875rem;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: $_contact-detail-accent;
+  }
+
+  #{$root}__value {
+    display: block;
+    margin: 0 0 ct-particle(1);
+    font-size: 1.5rem;
+    font-weight: 400;
+    color: $_contact-detail-text;
+    text-decoration: none;
+  }
+
+  a#{$root}__value {
+    transition: color 0.3s ease;
+
+    &:hover {
+      color: $_contact-detail-teal;
+      text-decoration: none;
+    }
+  }
+
+  #{$root}__value--email {
+    position: relative;
+    display: inline-block;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: -2px;
+      left: 0;
+      width: 0;
+      height: 1px;
+      background: $_contact-detail-teal;
+      transition: width 0.4s ease;
+    }
+
+    &:hover::after {
+      width: 100%;
+    }
+  }
+
+  #{$root}__note {
+    margin: 0;
+    font-size: 0.875rem;
+    font-weight: 200;
+    line-height: 1.5;
+    color: $_contact-detail-muted;
+  }
+}

--- a/web/themes/custom/drevops/components/02-molecules/contact-detail/contact-detail.twig
+++ b/web/themes/custom/drevops/components/02-molecules/contact-detail/contact-detail.twig
@@ -1,0 +1,35 @@
+{#
+/**
+ * @file
+ * Contact detail component.
+ *
+ * Props:
+ * - theme: [string] Theme variation (light or dark).
+ * - label: [string] Short label naming the contact method.
+ * - value: [object] The contact value (text, url, is_email).
+ * - note: [string] Supporting note shown beneath the value.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
+ * - modifier_class: [string] Additional CSS classes.
+ */
+#}
+
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
+
+<div class="component-contact-detail {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+  {% if label is not empty %}
+    <p class="component-contact-detail__label">{{ label }}</p>
+  {% endif %}
+
+  {% if value.text is not empty %}
+    {% if value.url is not empty %}
+      <a href="{{ value.url }}" class="component-contact-detail__value{{ value.is_email ? ' component-contact-detail__value--email' }}">{{ value.text }}</a>
+    {% else %}
+      <p class="component-contact-detail__value">{{ value.text }}</p>
+    {% endif %}
+  {% endif %}
+
+  {% if note is not empty %}
+    <p class="component-contact-detail__note">{{ note }}</p>
+  {% endif %}
+</div>

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -12,6 +12,7 @@ use Drupal\civictheme\CivicthemeConstants;
 require_once __DIR__ . '/includes/system_main_block.inc';
 require_once __DIR__ . '/includes/banner.inc';
 require_once __DIR__ . '/includes/paragraphs.inc';
+require_once __DIR__ . '/includes/contact_detail.inc';
 require_once __DIR__ . '/includes/divider.inc';
 require_once __DIR__ . '/includes/hero.inc';
 require_once __DIR__ . '/includes/service_detail.inc';

--- a/web/themes/custom/drevops/includes/contact_detail.inc
+++ b/web/themes/custom/drevops/includes/contact_detail.inc
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file
+ * DrevOps Contact detail paragraph component.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__contact_detail(array &$variables): void {
+  _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
+
+  _drevops_preprocess_paragraph__contact_detail_field__label($variables);
+  _drevops_preprocess_paragraph__contact_detail_field__value($variables);
+  _drevops_preprocess_paragraph__contact_detail_field__note($variables);
+}
+
+/**
+ * Pre-process for the Contact detail label field.
+ */
+function _drevops_preprocess_paragraph__contact_detail_field__label(array &$variables): void {
+  $variables['label'] = civictheme_get_field_value($variables['paragraph'], 'field_c_p_subtitle');
+}
+
+/**
+ * Pre-process for the Contact detail value field.
+ */
+function _drevops_preprocess_paragraph__contact_detail_field__value(array &$variables): void {
+  // Read the raw stored text rather than the rendered field: an email becomes a
+  // mailto link and a phone number a tel link so the value is actionable, while
+  // anything else stays plain text.
+  $raw = $variables['paragraph']->get('field_c_p_content')->value ?? '';
+  $text = trim(html_entity_decode(strip_tags((string) $raw), ENT_QUOTES));
+
+  $value = ['text' => $text, 'url' => '', 'is_email' => FALSE];
+
+  if ($text !== '') {
+    if (filter_var($text, FILTER_VALIDATE_EMAIL)) {
+      $value['url'] = 'mailto:' . $text;
+      $value['is_email'] = TRUE;
+    }
+    elseif (preg_match('/^\+?[0-9 ()-]{6,}$/', $text)) {
+      $digits = preg_replace('/[^0-9]/', '', $text);
+      $value['url'] = 'tel:' . (str_starts_with($text, '+') ? '+' : '') . $digits;
+    }
+  }
+
+  $variables['value'] = $value;
+}
+
+/**
+ * Pre-process for the Contact detail note field.
+ */
+function _drevops_preprocess_paragraph__contact_detail_field__note(array &$variables): void {
+  $variables['note'] = civictheme_get_field_value($variables['paragraph'], 'field_c_p_summary');
+}

--- a/web/themes/custom/drevops/includes/contact_detail.inc
+++ b/web/themes/custom/drevops/includes/contact_detail.inc
@@ -44,7 +44,10 @@ function _drevops_preprocess_paragraph__contact_detail_field__value(array &$vari
     }
     elseif (preg_match('/^\+?[0-9 ()-]{6,}$/', $text)) {
       $digits = preg_replace('/[^0-9]/', '', $text);
-      $value['url'] = 'tel:' . (str_starts_with($text, '+') ? '+' : '') . $digits;
+
+      if ($digits !== '') {
+        $value['url'] = 'tel:' . (str_starts_with($text, '+') ? '+' : '') . $digits;
+      }
     }
   }
 

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--contact-detail.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--contact-detail.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Contact detail component.
+ */
+#}
+{{ include('drevops:contact-detail', {
+  theme: theme,
+  label: label,
+  value: value,
+  note: note,
+  attributes: component_attributes,
+}, with_context: false) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#193] Verb in past tense.`
- [x] Ticket number `#193` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

Closes #193

## Changed

1. Added the `contact_detail` Drupal paragraph type (config, form/view display) reusing shared CivicTheme `field_c_p_*` field storages: `field_c_p_subtitle` (Label, required), `field_c_p_content` (Value, restricted to `plain_text`, required), `field_c_p_summary` (Note, optional), `field_c_p_theme` (Theme, defaults to `dark`).
2. Added the `contact-detail` SDC component at `web/themes/custom/drevops/components/02-molecules/contact-detail/` with Twig template, SCSS styles ported from the static prototype, and a component YAML schema.
3. Added `includes/contact_detail.inc` with a preprocess function that detects the value type - valid email addresses become `mailto:` links with an animated underline treatment, phone numbers (6+ digits, optional `+` prefix, spaces, brackets, hyphens) become `tel:` links with the non-digit characters stripped, and anything else renders as plain text.
4. Added the paragraph Twig template at `templates/paragraphs/paragraph--contact-detail.html.twig` which delegates to the SDC component via `include`.
5. Enabled the `contact_detail` bundle on the `civictheme_page` `field_c_n_components` field.
6. Added Behat coverage: `paragraph_contact_detail_fields.feature` (form structure and required fields) and `paragraph_contact_detail_render.feature` (rendered email link, phone `tel:` link, and plain-text value).

## Screenshots

![Contact detail component](https://raw.githubusercontent.com/drevops/website/2a0075b1cb9f93fd067f39159061bcedcf2a5c29/feature-193-contact-detail/02a5473c4f3f61f0ece72513c3b33a5524e0f34a.png)

## Before / After

```
┌─────────────────────────────────────────────────────────────────────┐
│ BEFORE                          │ AFTER                             │
├─────────────────────────────────┼───────────────────────────────────┤
│ No Contact detail paragraph     │ Contact detail paragraph type     │
│ type existed. Contact info had  │ available in page builder.        │
│ to be hand-coded in markup or   │                                   │
│ stored in unstructured text.    │ Label (e.g. "Email us directly")  │
│                                 │   CONTACT@EXAMPLE.COM  <-- link   │
│                                 │   We respond within a day.        │
│                                 │                                   │
│                                 │   CALL US                         │
│                                 │   04 3009 3538  <-- tel: link     │
│                                 │   Available weekdays, Melb time.  │
│                                 │                                   │
│                                 │   BASED IN                        │
│                                 │   Melbourne, Australia  (plain)   │
│                                 │   We work across AU and NZ.       │
└─────────────────────────────────┴───────────────────────────────────┘
```
