### PR TITLE
[#194] Added card paragraph with number, dot and icon markers.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.card.default.yml
+++ b/config/default/core.entity_form_display.paragraph.card.default.yml
@@ -1,0 +1,56 @@
+uuid: 83af51a9-7e41-4d48-94b5-f9a6c7dde1f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.card.field_c_p_icon
+    - field.field.paragraph.card.field_c_p_summary
+    - field.field.paragraph.card.field_c_p_theme
+    - field.field.paragraph.card.field_c_p_title
+    - field.field.paragraph.card.field_c_p_type
+    - paragraphs.paragraphs_type.card
+  module:
+    - media_library
+id: paragraph.card.default
+targetEntityType: paragraph
+bundle: card
+mode: default
+content:
+  field_c_p_icon:
+    type: media_library_widget
+    weight: 3
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_c_p_summary:
+    type: string_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_theme:
+    type: options_buttons
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_p_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_type:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_form_display.paragraph.card_group.default.yml
+++ b/config/default/core.entity_form_display.paragraph.card_group.default.yml
@@ -1,0 +1,49 @@
+uuid: d037e315-c83b-44f7-8b16-e331e0711dad
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.card_group.field_c_p_list_column_count
+    - field.field.paragraph.card_group.field_c_p_list_items
+    - field.field.paragraph.card_group.field_c_p_theme
+    - paragraphs.paragraphs_type.card_group
+  module:
+    - paragraphs
+id: paragraph.card_group.default
+targetEntityType: paragraph
+bundle: card_group
+mode: default
+content:
+  field_c_p_list_column_count:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_p_list_items:
+    type: paragraphs
+    weight: 0
+    region: content
+    settings:
+      title: Card
+      title_plural: Cards
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_c_p_theme:
+    type: options_buttons
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_view_display.paragraph.card.default.yml
+++ b/config/default/core.entity_view_display.paragraph.card.default.yml
@@ -1,0 +1,23 @@
+uuid: 63939959-e408-44a1-a2c6-f5f4bb3aebc6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.card.field_c_p_icon
+    - field.field.paragraph.card.field_c_p_summary
+    - field.field.paragraph.card.field_c_p_theme
+    - field.field.paragraph.card.field_c_p_title
+    - field.field.paragraph.card.field_c_p_type
+    - paragraphs.paragraphs_type.card
+id: paragraph.card.default
+targetEntityType: paragraph
+bundle: card
+mode: default
+content: {  }
+hidden:
+  field_c_p_icon: true
+  field_c_p_summary: true
+  field_c_p_theme: true
+  field_c_p_title: true
+  field_c_p_type: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.card_group.default.yml
+++ b/config/default/core.entity_view_display.paragraph.card_group.default.yml
@@ -1,0 +1,19 @@
+uuid: 11f24c40-6237-4bc9-a205-118296964bde
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.card_group.field_c_p_list_column_count
+    - field.field.paragraph.card_group.field_c_p_list_items
+    - field.field.paragraph.card_group.field_c_p_theme
+    - paragraphs.paragraphs_type.card_group
+id: paragraph.card_group.default
+targetEntityType: paragraph
+bundle: card_group
+mode: default
+content: {  }
+hidden:
+  field_c_p_list_column_count: true
+  field_c_p_list_items: true
+  field_c_p_theme: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_c_n_components
     - node.type.civictheme_page
     - paragraphs.paragraphs_type.campaign
+    - paragraphs.paragraphs_type.card_group
     - paragraphs.paragraphs_type.civictheme_accordion
     - paragraphs.paragraphs_type.civictheme_attachment
     - paragraphs.paragraphs_type.civictheme_automated_list
@@ -65,10 +66,14 @@ settings:
       service_detail: service_detail
       stat: stat
       contact_detail: contact_detail
+      card_group: card_group
     negate: 0
     target_bundles_drag_drop:
       campaign:
         weight: 61
+        enabled: true
+      card_group:
+        weight: 63
         enabled: true
       civictheme_accordion:
         weight: -58

--- a/config/default/field.field.paragraph.card.field_c_p_icon.yml
+++ b/config/default/field.field.paragraph.card.field_c_p_icon.yml
@@ -1,0 +1,24 @@
+uuid: 79a54b66-c5a3-4599-8d55-253e7dad1d31
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_icon
+    - media.type.civictheme_icon
+    - paragraphs.paragraphs_type.card
+id: paragraph.card.field_c_p_icon
+field_name: field_c_p_icon
+entity_type: paragraph
+bundle: card
+label: Icon
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      civictheme_icon: civictheme_icon
+field_type: entity_reference

--- a/config/default/field.field.paragraph.card.field_c_p_summary.yml
+++ b/config/default/field.field.paragraph.card.field_c_p_summary.yml
@@ -1,0 +1,19 @@
+uuid: a603727d-8f30-4547-985d-9851f198469f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_summary
+    - paragraphs.paragraphs_type.card
+id: paragraph.card.field_c_p_summary
+field_name: field_c_p_summary
+entity_type: paragraph
+bundle: card
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.field.paragraph.card.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.card.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: bd3224b9-1384-4c3d-a942-04b555fd053c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.card
+  module:
+    - options
+id: paragraph.card.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: card
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.card.field_c_p_title.yml
+++ b/config/default/field.field.paragraph.card.field_c_p_title.yml
@@ -1,0 +1,19 @@
+uuid: a9b5eb14-826b-4c76-a2a3-3b3ba35e4511
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_title
+    - paragraphs.paragraphs_type.card
+id: paragraph.card.field_c_p_title
+field_name: field_c_p_title
+entity_type: paragraph
+bundle: card
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.card.field_c_p_type.yml
+++ b/config/default/field.field.paragraph.card.field_c_p_type.yml
@@ -1,0 +1,21 @@
+uuid: 1723f408-9e4b-4bdd-b2bf-4b9166c4ef2b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_type
+    - paragraphs.paragraphs_type.card
+  module:
+    - options
+id: paragraph.card.field_c_p_type
+field_name: field_c_p_type
+entity_type: paragraph
+bundle: card
+label: Type
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.card_group.field_c_p_list_column_count.yml
+++ b/config/default/field.field.paragraph.card_group.field_c_p_list_column_count.yml
@@ -1,0 +1,23 @@
+uuid: 42d3ced7-096e-42df-a395-d759f913ec7c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_list_column_count
+    - paragraphs.paragraphs_type.card_group
+  module:
+    - options
+id: paragraph.card_group.field_c_p_list_column_count
+field_name: field_c_p_list_column_count
+entity_type: paragraph
+bundle: card_group
+label: Columns
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings: {  }
+field_type: list_integer

--- a/config/default/field.field.paragraph.card_group.field_c_p_list_items.yml
+++ b/config/default/field.field.paragraph.card_group.field_c_p_list_items.yml
@@ -1,0 +1,31 @@
+uuid: ecf2a5a3-dfce-4c4b-ac90-ab817c5450f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_list_items
+    - paragraphs.paragraphs_type.card
+    - paragraphs.paragraphs_type.card_group
+  module:
+    - entity_reference_revisions
+id: paragraph.card_group.field_c_p_list_items
+field_name: field_c_p_list_items
+entity_type: paragraph
+bundle: card_group
+label: Cards
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      card: card
+    negate: 0
+    target_bundles_drag_drop:
+      card:
+        weight: 0
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.card_group.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.card_group.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: 5a3e6c20-3e26-4f25-b063-7382380c05eb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.card_group
+  module:
+    - options
+id: paragraph.card_group.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: card_group
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/paragraphs.paragraphs_type.card.yml
+++ b/config/default/paragraphs.paragraphs_type.card.yml
@@ -1,0 +1,10 @@
+uuid: bf6b7c84-230b-429c-a622-4c0d6fc2ad2f
+langcode: en
+status: true
+dependencies: {  }
+id: card
+label: Card
+icon_uuid: null
+icon_default: null
+description: 'A single card that leads with a number, a dot or an icon.'
+behavior_plugins: {  }

--- a/config/default/paragraphs.paragraphs_type.card_group.yml
+++ b/config/default/paragraphs.paragraphs_type.card_group.yml
@@ -6,5 +6,5 @@ id: card_group
 label: 'Card group'
 icon_uuid: null
 icon_default: null
-description: 'A group of cards laid out in one, two or four columns.'
+description: 'A group of cards laid out in one, two, three or four columns.'
 behavior_plugins: {  }

--- a/config/default/paragraphs.paragraphs_type.card_group.yml
+++ b/config/default/paragraphs.paragraphs_type.card_group.yml
@@ -1,0 +1,10 @@
+uuid: b774b652-3814-4e81-8517-54164302bece
+langcode: en
+status: true
+dependencies: {  }
+id: card_group
+label: 'Card group'
+icon_uuid: null
+icon_default: null
+description: 'A group of cards laid out in one, two or four columns.'
+behavior_plugins: {  }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -50,3 +50,8 @@ parameters:
         - web/themes/custom/*/tests/*
         - tests/phpunit/*
       reportUnmatched: false
+    - # Behat step definitions cannot use constructor injection, so \Drupal::
+      # static calls are the correct pattern in this context.
+      message: '#\\\Drupal calls should be avoided in classes, use dependency injection instead#'
+      paths:
+        - tests/behat/bootstrap/*

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -36,8 +36,11 @@ use DrevOps\BehatSteps\LinkTrait;
 use DrevOps\BehatSteps\PathTrait;
 use DrevOps\BehatSteps\ResponseTrait;
 use DrevOps\BehatSteps\WaitTrait;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Step\Given;
 use Behat\Step\Then;
 use Drupal\DrupalExtension\Context\DrupalContext;
+use Drupal\paragraphs\Entity\Paragraph;
 
 /**
  * Defines application features from the specific context.
@@ -244,6 +247,73 @@ class FeatureContext extends DrupalContext {
     }
 
     return $color;
+  }
+
+  /**
+   * Create a card group with nested cards on a civictheme_page node.
+   *
+   * The library's ParagraphsTrait attaches only a single, flat paragraph, so a
+   * card group (which references child card paragraphs) needs a dedicated step.
+   *
+   * @code
+   * Given a card group with 2 columns and the following cards on the "[TEST] Page" page:
+   *   | type   | title         | description       | icon           |
+   *   | number | [TEST] First  | [TEST] First body |                |
+   *   | icon   | [TEST] Second | [TEST] Body two   | [TEST] DO Icon |
+   * @endcode
+   */
+  #[Given('a card group with :columns columns and the following cards on the :node_title page:')]
+  public function cardGroupCreateWithCards(string $columns, string $node_title, TableNode $cards): void {
+    $node = $this->paragraphsFindEntity('node', 'civictheme_page', 'title', $node_title);
+
+    if (!$node) {
+      throw new \RuntimeException(sprintf('The civictheme_page node with the title "%s" was not found.', $node_title));
+    }
+
+    $card_refs = [];
+
+    foreach ($cards->getHash() as $row) {
+      $values = [
+        'type' => 'card',
+        'field_c_p_type' => $row['type'],
+        'field_c_p_title' => $row['title'],
+        'field_c_p_summary' => $row['description'] ?? '',
+        'field_c_p_theme' => 'dark',
+      ];
+
+      if (!empty($row['icon'])) {
+        $icon_ids = \Drupal::entityQuery('media')
+          ->accessCheck(FALSE)
+          ->condition('bundle', 'civictheme_icon')
+          ->condition('name', $row['icon'])
+          ->range(0, 1)
+          ->execute();
+
+        if ($icon_ids) {
+          $values['field_c_p_icon'] = ['target_id' => reset($icon_ids)];
+        }
+      }
+
+      $card = Paragraph::create($values);
+      $card->save();
+      static::$paragraphEntities[] = $card;
+
+      $card_refs[] = ['target_id' => $card->id(), 'target_revision_id' => $card->getRevisionId()];
+    }
+
+    $group = Paragraph::create([
+      'type' => 'card_group',
+      'field_c_p_list_column_count' => (int) $columns,
+      'field_c_p_theme' => 'dark',
+      'field_c_p_list_items' => $card_refs,
+    ]);
+    $group->save();
+    static::$paragraphEntities[] = $group;
+
+    $components = $node->get('field_c_n_components')->getValue();
+    $components[] = ['target_id' => $group->id(), 'target_revision_id' => $group->getRevisionId()];
+    $node->set('field_c_n_components', $components);
+    $node->save();
   }
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -39,6 +39,7 @@ use DrevOps\BehatSteps\WaitTrait;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\DrupalExtension\Context\DrupalContext;
 use Drupal\paragraphs\Entity\Paragraph;
 
@@ -266,7 +267,7 @@ class FeatureContext extends DrupalContext {
   public function cardGroupCreateWithCards(string $columns, string $node_title, TableNode $cards): void {
     $node = $this->paragraphsFindEntity('node', 'civictheme_page', 'title', $node_title);
 
-    if (!$node) {
+    if (!$node instanceof ContentEntityInterface) {
       throw new \RuntimeException(sprintf('The civictheme_page node with the title "%s" was not found.', $node_title));
     }
 

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -289,9 +289,11 @@ class FeatureContext extends DrupalContext {
           ->range(0, 1)
           ->execute();
 
-        if ($icon_ids) {
-          $values['field_c_p_icon'] = ['target_id' => reset($icon_ids)];
+        if (!$icon_ids) {
+          throw new \RuntimeException(sprintf('The civictheme_icon media "%s" was not found.', $row['icon']));
         }
+
+        $values['field_c_p_icon'] = ['target_id' => reset($icon_ids)];
       }
 
       $card = Paragraph::create($values);

--- a/tests/behat/features/paragraph_card.feature
+++ b/tests/behat/features/paragraph_card.feature
@@ -1,0 +1,77 @@
+@p1 @civictheme @drevops @card
+Feature: Card markers
+
+  As a content editor
+  I want one card that can lead with a number, a dot or an icon
+  So that I can build numbered lists, feature lists and icon grids without separate components
+
+  Background:
+    Given the following managed files:
+      | path     | uri                       | status |
+      | icon.svg | public://do_test/icon.svg | 1      |
+
+    And the following media "civictheme_icon" exist:
+      | name           | field_c_m_icon |
+      | [TEST] DO Icon | icon.svg       |
+
+    And the following "civictheme_page" content:
+      | title                      | status |
+      | [TEST] Page Cards numbered | 1      |
+      | [TEST] Page Cards markers  | 1      |
+      | [TEST] Page Cards columns  | 1      |
+
+  @api
+  Scenario: A content editor is offered the card group component on a page
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "node/add/civictheme_page"
+    Then the response should contain "Add Card group"
+
+  @api
+  Scenario: Number cards lead with a sequential index reflecting their order
+    Given I am an anonymous user
+    And a card group with 1 columns and the following cards on the "[TEST] Page Cards numbered" page:
+      | type   | title            | description             |
+      | number | [TEST] Discovery | [TEST] We map the work. |
+      | number | [TEST] Delivery  | [TEST] We build it.     |
+      | number | [TEST] Support   | [TEST] We maintain it.  |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Cards numbered"
+    Then I should see an "article .ct-card-group.ct-card-group--cols-1" element
+    And I should see 3 ".ct-card--number" elements
+    And I should see "01" in the ".ct-card:nth-child(1) .ct-card__number" element
+    And I should see "02" in the ".ct-card:nth-child(2) .ct-card__number" element
+    And I should see "03" in the ".ct-card:nth-child(3) .ct-card__number" element
+    And I should see the text "[TEST] Discovery"
+    And I should see the text "[TEST] We map the work."
+    And save screenshot
+
+  @api
+  Scenario: Dot and icon cards lead with their markers
+    Given I am an anonymous user
+    And a card group with 1 columns and the following cards on the "[TEST] Page Cards markers" page:
+      | type | title         | description      | icon           |
+      | dot  | [TEST] Tested | [TEST] Covered.  |                |
+      | icon | [TEST] Secure | [TEST] Hardened. | [TEST] DO Icon |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Cards markers"
+    Then I should see a ".ct-card--dot .ct-card__dot" element
+    And I should see a ".ct-card--icon .ct-card__icon svg" element
+    And I should see the text "[TEST] Tested"
+    And I should see the text "[TEST] Secure"
+
+  @api
+  Scenario Outline: Card groups render in the configured column count
+    Given I am an anonymous user
+    And a card group with <columns> columns and the following cards on the "[TEST] Page Cards columns" page:
+      | type | title           | description      |
+      | dot  | [TEST] Item one | [TEST] Body one. |
+      | dot  | [TEST] Item two | [TEST] Body two. |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Cards columns"
+    Then I should see an "article .ct-card-group--cols-<columns>" element
+
+    Examples:
+      | columns |
+      | 1       |
+      | 2       |
+      | 4       |

--- a/tests/behat/fixtures/icon.svg
+++ b/tests/behat/fixtures/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -31,6 +31,11 @@ function do_base_field_c_p_type_allowed_values(FieldStorageDefinitionInterface $
       'article' => 'Article',
       'section' => 'Section',
     ],
+    'card' => [
+      'number' => 'Number',
+      'dot' => 'Dot',
+      'icon' => 'Icon',
+    ],
   ];
 
   $bundle = $entity?->bundle();

--- a/web/themes/custom/drevops/components/02-molecules/card/card.component.yml
+++ b/web/themes/custom/drevops/components/02-molecules/card/card.component.yml
@@ -1,0 +1,44 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Card
+status: stable
+description: A single card that leads with a number, a dot or an icon marker, followed by a title and description.
+props:
+  type: object
+  properties:
+    type:
+      type: string
+      title: Marker type
+      description: Which marker leads the card.
+      enum:
+        - number
+        - dot
+        - icon
+      default: dot
+    index:
+      type: integer
+      title: Index
+      description: 1-based position within the group; shown as the number marker and used for the staggered reveal delay.
+    title:
+      type: string
+      title: Title
+    description:
+      type: string
+      title: Description
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: dark
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+    modifier_class:
+      type: string
+      title: Modifier class
+slots:
+  icon:
+    title: Icon
+    description: Inline SVG markup for the icon marker.

--- a/web/themes/custom/drevops/components/02-molecules/card/card.scss
+++ b/web/themes/custom/drevops/components/02-molecules/card/card.scss
@@ -1,0 +1,78 @@
+//
+// Card component.
+//
+// A single card that leads with a number, a dot or an icon marker, followed by
+// a title and description. Ported from the static prototype's service list, dot
+// list and trust grid. Colours resolve through per-theme local variables (dark
+// by default, light when ct-theme-light is set); spacing uses the prototype's
+// rem scale (CivicTheme exposes no global spacing tokens). The marker leads
+// beside the body by default; the card group stacks it above the body in
+// multi-column layouts.
+//
+
+.ct-card {
+  --ct-card-marker-color: var(--ct-color-dark-interaction-background);
+  --ct-card-title-color: var(--ct-color-dark-heading);
+  --ct-card-body-color: var(--ct-color-dark-body);
+
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.5rem;
+  align-items: start;
+
+  &.ct-theme-light {
+    --ct-card-marker-color: var(--ct-color-light-interaction-background);
+    --ct-card-title-color: var(--ct-color-light-heading);
+    --ct-card-body-color: var(--ct-color-light-body);
+  }
+
+  &__marker {
+    display: flex;
+    align-items: flex-start;
+    color: var(--ct-card-marker-color);
+  }
+
+  &__number {
+    font-family: var(--ct-typography-display-font-name);
+    font-size: 3.5rem;
+    font-weight: var(--ct-typography-display-font-weight);
+    line-height: 1;
+    letter-spacing: -0.04em;
+    opacity: 40%;
+    user-select: none;
+  }
+
+  &__dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    margin-top: 0.625rem;
+    border-radius: 50%;
+    background: var(--ct-card-marker-color);
+  }
+
+  &__icon {
+    display: inline-flex;
+
+    svg {
+      width: 1.75rem;
+      height: 1.75rem;
+    }
+  }
+
+  &__title {
+    margin: 0;
+    font-family: var(--ct-typography-heading-4-font-name);
+    font-size: var(--ct-typography-heading-4-font-size);
+    font-weight: var(--ct-typography-heading-4-font-weight);
+    line-height: var(--ct-typography-heading-4-line-height);
+    letter-spacing: var(--ct-typography-heading-4-letter-spacing);
+    color: var(--ct-card-title-color);
+  }
+
+  &__description {
+    margin: 0.5rem 0 0;
+    font-size: var(--ct-typography-text-small-font-size);
+    line-height: 1.6;
+    color: var(--ct-card-body-color);
+  }
+}

--- a/web/themes/custom/drevops/components/02-molecules/card/card.twig
+++ b/web/themes/custom/drevops/components/02-molecules/card/card.twig
@@ -1,0 +1,47 @@
+{#
+/**
+ * @file
+ * Card component.
+ *
+ * Variables:
+ * - type: [string] Marker type: number, dot, icon.
+ * - index: [integer] 1-based position; shown as the number marker and drives
+ *   the staggered reveal delay.
+ * - title: [string] Card title.
+ * - description: [string] Card description.
+ * - theme: [string] Theme variation: light, dark.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ *
+ * Slots:
+ * - icon: Inline SVG markup for the icon marker.
+ */
+#}
+
+{% set index = index|default(0) %}
+{% set type = type in ['number', 'dot', 'icon'] ? type : 'dot' %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set delay_class = index > 0 ? 'component-reveal-d%d'|format(min(index, 6)) : '' %}
+{% set modifier_class = 'ct-card ct-card--%s %s component-reveal %s %s'|format(type, theme_class, delay_class, modifier_class|default(''))|trim %}
+
+{% if title is not empty %}
+  <div class="{{ modifier_class }}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="ct-card__marker" aria-hidden="true">
+      {% if type == 'number' %}
+        <span class="ct-card__number">{{ index > 0 ? (index < 10 ? '0' ~ index : index) }}</span>
+      {% elseif type == 'icon' %}
+        <span class="ct-card__icon">{{ icon }}</span>
+      {% else %}
+        <span class="ct-card__dot"></span>
+      {% endif %}
+    </div>
+
+    <div class="ct-card__body">
+      <p class="ct-card__title">{{ title }}</p>
+
+      {% if description is not empty %}
+        <p class="ct-card__description">{{ description }}</p>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/components/03-organisms/card-group/card-group.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/card-group/card-group.component.yml
@@ -1,0 +1,35 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Card group
+status: stable
+description: A group of cards laid out in one, two or four columns that stack on narrow screens.
+props:
+  type: object
+  properties:
+    columns:
+      type: integer
+      title: Columns
+      description: Number of columns at desktop width.
+      enum:
+        - 1
+        - 2
+        - 3
+        - 4
+      default: 1
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: dark
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+    modifier_class:
+      type: string
+      title: Modifier class
+slots:
+  cards:
+    title: Cards
+    description: The rendered list of card components.

--- a/web/themes/custom/drevops/components/03-organisms/card-group/card-group.scss
+++ b/web/themes/custom/drevops/components/03-organisms/card-group/card-group.scss
@@ -1,0 +1,44 @@
+//
+// Card group component.
+//
+// Lays the cards out in one, two, three or four columns and collapses to a
+// single column on narrow screens. A single-column group leads each card's
+// marker beside the body; multi-column groups stack the marker above the body,
+// matching the static prototype's approach and trust grids. Spacing uses the
+// prototype's rem scale (CivicTheme exposes no global spacing tokens). Cards
+// reveal with a staggered fade via the shared reveal utilities.
+//
+
+.ct-card-group {
+  &__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  &--cols-2 &__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  &--cols-3 &__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  &--cols-4 &__grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  // Multi-column groups stack each card's marker above the body.
+  &--cols-2 .ct-card,
+  &--cols-3 .ct-card,
+  &--cols-4 .ct-card {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  @media (width <= 768px) {
+    &__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/card-group/card-group.twig
+++ b/web/themes/custom/drevops/components/03-organisms/card-group/card-group.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Card group component.
+ *
+ * Variables:
+ * - columns: [integer] Number of columns at desktop width: 1, 2, 3, 4.
+ * - theme: [string] Theme variation: light, dark.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ *
+ * Slots:
+ * - cards: The rendered list of card components.
+ */
+#}
+
+{% set columns = columns in [1, 2, 3, 4] ? columns : 1 %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set modifier_class = 'ct-card-group ct-card-group--cols-%d %s %s'|format(columns, theme_class, modifier_class|default(''))|trim %}
+
+{% if cards is not empty %}
+  <div class="{{ modifier_class }}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="ct-card-group__grid">
+      {{ cards }}
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/includes/cards.inc
+++ b/web/themes/custom/drevops/includes/cards.inc
@@ -11,12 +11,68 @@ use Drupal\civictheme\CivicthemeConstants;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\media\MediaInterface;
 
 /**
  * Implements template_preprocess_paragraph().
  */
 function drevops_preprocess_paragraph__civictheme_promo_card(array &$variables): void {
   _drevops_preprocess_paragraph__paragraph_field__summary($variables);
+}
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__card(array &$variables): void {
+  $paragraph = $variables['paragraph'];
+
+  $variables['type'] = civictheme_get_field_value($paragraph, 'field_c_p_type') ?? 'dot';
+  $variables['title'] = civictheme_get_field_value($paragraph, 'field_c_p_title');
+  $variables['description'] = drevops_get_field_value__summary($paragraph);
+
+  _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
+
+  // The card group renders its cards and tags each with its 1-based position so
+  // the number marker reflects the card's order rather than an authored value.
+  $variables['index'] = $variables['elements']['#card_index'] ?? 0;
+
+  $variables['icon'] = NULL;
+  $media = civictheme_get_field_value($paragraph, 'field_c_p_icon', TRUE, build: $variables);
+  if ($media instanceof MediaInterface) {
+    $image = civictheme_media_image_get_variables($media);
+    if ($image) {
+      $variables['icon'] = [
+        '#type' => 'inline_template',
+        '#template' => civictheme_embed_svg($image['url'], ['ct-icon']),
+      ];
+    }
+  }
+}
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__card_group(array &$variables): void {
+  $paragraph = $variables['paragraph'];
+
+  $variables['column_count'] = (int) (civictheme_get_field_value($paragraph, 'field_c_p_list_column_count') ?? 1);
+
+  _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
+
+  $view_builder = \Drupal::entityTypeManager()->getViewBuilder('paragraph');
+
+  $cards = [];
+  $index = 0;
+  foreach (civictheme_get_field_referenced_entities($paragraph, 'field_c_p_list_items', $variables) as $card) {
+    $index++;
+    $build = $view_builder->view($card);
+    // Pass the position to the card so its number marker and reveal delay follow
+    // the order set by the editor.
+    $build['#card_index'] = $index;
+    $cards[] = $build;
+  }
+
+  $variables['cards'] = $cards;
 }
 
 /**

--- a/web/themes/custom/drevops/includes/cards.inc
+++ b/web/themes/custom/drevops/includes/cards.inc
@@ -67,8 +67,8 @@ function drevops_preprocess_paragraph__card_group(array &$variables): void {
   foreach (civictheme_get_field_referenced_entities($paragraph, 'field_c_p_list_items', $variables) as $card) {
     $index++;
     $build = $view_builder->view($card);
-    // Pass the position to the card so its number marker and reveal delay follow
-    // the order set by the editor.
+    // Pass the position to the card so its number marker and reveal delay
+    // follow the order set by the editor.
     $build['#card_index'] = $index;
     $cards[] = $build;
   }

--- a/web/themes/custom/drevops/includes/cards.inc
+++ b/web/themes/custom/drevops/includes/cards.inc
@@ -34,13 +34,14 @@ function drevops_preprocess_paragraph__card(array &$variables): void {
 
   // The card group renders its cards and tags each with its 1-based position so
   // the number marker reflects the card's order rather than an authored value.
-  $variables['index'] = $variables['elements']['#card_index'] ?? 0;
+  // A card rendered outside a group still leads from one.
+  $variables['index'] = $variables['elements']['#card_index'] ?? 1;
 
   $variables['icon'] = NULL;
   $media = civictheme_get_field_value($paragraph, 'field_c_p_icon', TRUE, build: $variables);
   if ($media instanceof MediaInterface) {
     $image = civictheme_media_image_get_variables($media);
-    if ($image) {
+    if (!empty($image['url'])) {
       $variables['icon'] = [
         '#type' => 'inline_template',
         '#template' => civictheme_embed_svg($image['url'], ['ct-icon']),

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--card-group.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--card-group.html.twig
@@ -1,0 +1,12 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Card group paragraph.
+ */
+#}
+{{ include('drevops:card-group', {
+  columns: column_count,
+  theme: theme,
+  cards: cards,
+  attributes: component_attributes,
+}, with_context: false) }}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--card.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--card.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Card paragraph.
+ */
+#}
+{{ include('drevops:card', {
+  type: type,
+  index: index,
+  title: title,
+  description: description,
+  icon: icon,
+  theme: theme,
+  attributes: component_attributes,
+}, with_context: false) }}


### PR DESCRIPTION
Closes #194

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#194] Verb in past tense.`
- [x] Ticket number `#194` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally.

## Changed

1. Added `card` and `card_group` paragraph types with Drupal config (form/view displays, field definitions for `field_c_p_type`, `field_c_p_title`, `field_c_p_summary`, `field_c_p_icon`, `field_c_p_theme`, `field_c_p_list_items`, `field_c_p_list_column_count`).
2. Registered `card_group` as an allowed paragraph on `civictheme_page` nodes via `field_c_n_components`.
3. Added `number`, `dot`, and `icon` to the `field_c_p_type` allowed-values callback in `do_base.module`.
4. Added `drevops:card` SDC component (`02-molecules/card`) with Twig template, SCSS, and component YAML; the number marker zero-pads its index and the reveal delay is capped at 6.
5. Added `drevops:card-group` SDC component (`03-organisms/card-group`) with Twig template, SCSS, and component YAML; multi-column groups stack each card's marker above the body.
6. Added `cards.inc` preprocess functions for both paragraphs - `card` resolves type/title/description/theme and embeds the SVG icon inline; `card_group` iterates its child cards and tags each with a 1-based `#card_index` so the number marker reflects the editor-set order.
7. Added Twig paragraph templates (`paragraph--card.html.twig`, `paragraph--card-group.html.twig`) that delegate to the SDC components.
8. Added a custom `cardGroupCreateWithCards` Behat step to `FeatureContext.php` that creates nested card paragraphs in one call.
9. Added `paragraph_card.feature` covering: card group availability in the page form, sequential number indexing (01/02/03), dot and icon marker rendering, and column count (1/2/4).

## Screenshots

![Card markers](https://raw.githubusercontent.com/drevops/website/61be160e83eec71740d58667d5d6b95e75456a10/feature-194-card-markers/5ce2b7a3b96f9d66f11b0e5b888766b6e065f028.png)

## Before / After

```
BEFORE                                    AFTER
┌─────────────────────────────────┐       ┌─────────────────────────────────┐
│ Page body: no card component    │       │ Page body                       │
│                                 │       │ ┌─────────────────────────────┐ │
│ (only campaign, hero, etc.)     │       │ │ Card group (1–4 cols)       │ │
│                                 │       │ │ ┌──────┐ ┌──────┐ ┌──────┐ │ │
└─────────────────────────────────┘       │ │ │ 01   │ │ 02   │ │ 03   │ │ │
                                          │ │ │ Title│ │ Title│ │ Title│ │ │
                                          │ │ │ Desc │ │ Desc │ │ Desc │ │ │
                                          │ │ └──────┘ └──────┘ └──────┘ │ │
                                          │ └─────────────────────────────┘ │
                                          │                                  │
                                          │ Marker types:                    │
                                          │  • number → "01", "02", …       │
                                          │  • dot    → ● Title / Desc      │
                                          │  • icon   → ▣ Title / Desc      │
                                          └─────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Card component with configurable markers (numbers, dots, or icons) and light/dark themes
  * Added Card Group component with flexible 1-4 column layouts for organizing cards
  * Integrated media support for card icons

* **Tests**
  * Added comprehensive end-to-end tests for card and card group functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->