### PR TITLE
[#195] Added CTA band paragraph component with actions and email link.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.cta.default.yml
+++ b/config/default/core.entity_form_display.paragraph.cta.default.yml
@@ -1,0 +1,57 @@
+uuid: 4cd2db44-2983-469a-b06d-d18d65eb7182
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta.field_c_p_theme
+    - field.field.paragraph.cta.field_c_p_type
+    - field.field.paragraph.cta.field_link
+    - field.field.paragraph.cta.field_subtitle
+    - field.field.paragraph.cta.field_title
+    - paragraphs.paragraphs_type.cta
+  module:
+    - link
+id: paragraph.cta.default
+targetEntityType: paragraph
+bundle: cta
+mode: default
+content:
+  field_c_p_theme:
+    type: options_select
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_p_type:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_link:
+    type: link_default
+    weight: 3
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_subtitle:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_view_display.paragraph.cta.default.yml
+++ b/config/default/core.entity_view_display.paragraph.cta.default.yml
@@ -1,0 +1,23 @@
+uuid: 08669bc4-50c4-4dac-a54d-ef8374f28ce4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta.field_c_p_theme
+    - field.field.paragraph.cta.field_c_p_type
+    - field.field.paragraph.cta.field_link
+    - field.field.paragraph.cta.field_subtitle
+    - field.field.paragraph.cta.field_title
+    - paragraphs.paragraphs_type.cta
+id: paragraph.cta.default
+targetEntityType: paragraph
+bundle: cta
+mode: default
+content: {  }
+hidden:
+  field_c_p_theme: true
+  field_c_p_type: true
+  field_link: true
+  field_subtitle: true
+  field_title: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -22,6 +22,7 @@ dependencies:
     - paragraphs.paragraphs_type.civictheme_slider
     - paragraphs.paragraphs_type.civictheme_webform
     - paragraphs.paragraphs_type.contact_detail
+    - paragraphs.paragraphs_type.cta
     - paragraphs.paragraphs_type.divider
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.hero
@@ -67,6 +68,7 @@ settings:
       stat: stat
       contact_detail: contact_detail
       card_group: card_group
+      cta: cta
     negate: 0
     target_bundles_drag_drop:
       campaign:
@@ -167,6 +169,9 @@ settings:
         enabled: true
       contact_detail:
         weight: 61
+        enabled: true
+      cta:
+        weight: 63
         enabled: true
       divider:
         weight: 60

--- a/config/default/field.field.paragraph.cta.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.cta.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: 99368b83-5916-4219-9389-e70fed93c38b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.cta
+  module:
+    - options
+id: paragraph.cta.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: cta
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.cta.field_c_p_type.yml
+++ b/config/default/field.field.paragraph.cta.field_c_p_type.yml
@@ -1,0 +1,23 @@
+uuid: 06318a16-eb93-46a2-85d6-77f5bf5f676b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_type
+    - paragraphs.paragraphs_type.cta
+  module:
+    - options
+id: paragraph.cta.field_c_p_type
+field_name: field_c_p_type
+entity_type: paragraph
+bundle: cta
+label: Type
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: display
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.cta.field_link.yml
+++ b/config/default/field.field.paragraph.cta.field_link.yml
@@ -18,6 +18,6 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  title: 1
+  title: 2
   link_type: 17
 field_type: link

--- a/config/default/field.field.paragraph.cta.field_link.yml
+++ b/config/default/field.field.paragraph.cta.field_link.yml
@@ -1,0 +1,23 @@
+uuid: 12cdfbe5-3c70-40fe-af7e-453389ec12ba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.cta
+  module:
+    - link
+id: paragraph.cta.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: cta
+label: Actions
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/config/default/field.field.paragraph.cta.field_subtitle.yml
+++ b/config/default/field.field.paragraph.cta.field_subtitle.yml
@@ -1,0 +1,19 @@
+uuid: ed6155d6-368d-4a08-b829-f17bf11cfd81
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_subtitle
+    - paragraphs.paragraphs_type.cta
+id: paragraph.cta.field_subtitle
+field_name: field_subtitle
+entity_type: paragraph
+bundle: cta
+label: Sub-line
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.cta.field_title.yml
+++ b/config/default/field.field.paragraph.cta.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 0796bdd5-31d0-4d87-8518-ed07dd84a11f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.cta
+id: paragraph.cta.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: cta
+label: Heading
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.paragraph.field_link.yml
+++ b/config/default/field.storage.paragraph.field_link.yml
@@ -12,7 +12,7 @@ type: link
 settings: {  }
 module: link
 locked: false
-cardinality: 2
+cardinality: 3
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/default/paragraphs.paragraphs_type.cta.yml
+++ b/config/default/paragraphs.paragraphs_type.cta.yml
@@ -1,0 +1,10 @@
+uuid: 592829ad-f98f-47d5-969a-3edeeed56d00
+langcode: en
+status: true
+dependencies: {  }
+id: cta
+label: 'CTA band'
+icon_uuid: null
+icon_default: null
+description: 'A full-width closing call-to-action band with an oversized heading, a sub-line, action buttons and an email link.'
+behavior_plugins: {  }

--- a/tests/behat/features/paragraph_cta.feature
+++ b/tests/behat/features/paragraph_cta.feature
@@ -1,0 +1,72 @@
+@p1 @civictheme @drevops @cta
+Feature: CTA band
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                  | status |
+      | [TEST] Page CTA full   | 1      |
+      | [TEST] Page CTA single | 1      |
+      | [TEST] Page CTA light  | 1      |
+
+  @api
+  Scenario: Anonymous user sees a CTA band with heading, sub-line, actions and a distinct email link
+    Given I am an anonymous user
+    And the following fields for the paragraph "cta" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page CTA full":
+      | field_c_p_type   | display                                                                        |
+      | field_title      | Let us talk about your website                                                 |
+      | field_subtitle   | Tell us where things stand and we will be straight about the fit               |
+      | field_c_p_theme  | dark                                                                           |
+      | field_link:title | Start a conversation, See what it would cost, info@drevops.com                 |
+      | field_link:uri   | https://example.com/contact, https://example.com/cost, mailto:info@drevops.com |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page CTA full"
+    Then I should see an "article .ct-cta" element
+    And I should see an "article .ct-cta.ct-theme-dark" element
+    And I should see an "article .ct-cta__underline" element
+    And I should see the text "Tell us where things stand and we will be straight about the fit"
+    And I should see the link "Start a conversation"
+    And I should see the link "See what it would cost"
+    And I should see 2 "article .ct-cta__action" elements
+    And I should see an "article .ct-cta__action--secondary" element
+    And I should see an "article .ct-cta__action--primary" element
+    And I should see an "article a.ct-cta__email" element
+    And I should see the link "info@drevops.com"
+
+  @api
+  Scenario: A single action renders only a primary button and no email link
+    Given I am an anonymous user
+    And the following fields for the paragraph "cta" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page CTA single":
+      | field_c_p_type   | display                     |
+      | field_title      | A single call to action     |
+      | field_c_p_theme  | dark                        |
+      | field_link:title | Get in touch                |
+      | field_link:uri   | https://example.com/contact |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page CTA single"
+    Then I should see an "article .ct-cta" element
+    And I should see the link "Get in touch"
+    And I should see 1 "article .ct-cta__action" element
+    And I should see an "article .ct-cta__action--primary" element
+    And I should not see an "article .ct-cta__action--secondary" element
+    And I should not see an "article a.ct-cta__email" element
+
+  @api
+  Scenario: A content editor is offered the CTA band component on a page
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "node/add/civictheme_page"
+    Then the response should contain "Add CTA band"
+
+  @api
+  Scenario: A CTA band honours the light theme
+    Given I am an anonymous user
+    And the following fields for the paragraph "cta" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page CTA light":
+      | field_c_p_type   | display                     |
+      | field_title      | A light scheme CTA band     |
+      | field_c_p_theme  | light                       |
+      | field_link:title | Get in touch                |
+      | field_link:uri   | https://example.com/contact |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page CTA light"
+    Then I should see an "article .ct-cta.ct-theme-light" element
+    And I should not see an "article .ct-cta.ct-theme-dark" element
+    And I should see the link "Get in touch"

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -36,6 +36,9 @@ function do_base_field_c_p_type_allowed_values(FieldStorageDefinitionInterface $
       'dot' => 'Dot',
       'icon' => 'Icon',
     ],
+    'cta' => [
+      'display' => 'Display',
+    ],
   ];
 
   $bundle = $entity?->bundle();

--- a/web/themes/custom/drevops/components/03-organisms/cta-band/cta-band.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/cta-band/cta-band.component.yml
@@ -1,0 +1,67 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: CTA Band
+status: stable
+description: A full-width closing call-to-action band with an oversized heading whose last word is underlined, a sub-line, up to three action buttons and a distinct email link, on a raised surface.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: dark
+    type:
+      type: string
+      title: Type
+      description: Display variant of the band.
+      enum:
+        - display
+      default: display
+    heading:
+      type: string
+      title: Heading
+      description: Oversized heading. Its last word is rendered with an accent underline.
+    sub:
+      type: string
+      title: Sub-line
+      description: Supporting line shown below the heading.
+    actions:
+      type: array
+      title: Actions
+      description: Up to three action links. The last action renders as the primary button, the rest as secondary.
+      maxItems: 3
+      items:
+        type: object
+        properties:
+          url:
+            type: string
+            title: URL
+            description: Action URL.
+          title:
+            type: string
+            title: Title
+            description: Action label.
+    email:
+      type: object
+      title: Email
+      description: A distinct email link shown beneath the actions.
+      properties:
+        url:
+          type: string
+          title: URL
+          description: The mailto URL.
+        label:
+          type: string
+          title: Label
+          description: The email address shown as the link text.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier class
+      description: Additional CSS classes.

--- a/web/themes/custom/drevops/components/03-organisms/cta-band/cta-band.scss
+++ b/web/themes/custom/drevops/components/03-organisms/cta-band/cta-band.scss
@@ -1,0 +1,209 @@
+//
+// CTA Band component.
+//
+// A full-width closing call-to-action band ported from the static prototype's
+// closing CTA section. An oversized heading with its last word underlined sits
+// above a sub-line, a row of action buttons and a distinct email link, centred
+// on a raised surface. Colours resolve through per-theme local variables (dark
+// by default, light when ct-theme-light is set) so the band renders correctly
+// in either CivicTheme scheme; spacing uses the prototype's rem scale
+// (CivicTheme exposes no global spacing tokens). The entrance fade is provided
+// by the shared .component-reveal library, which gates itself behind
+// prefers-reduced-motion.
+//
+
+.ct-cta {
+  // Dark scheme is the default; ct-theme-light overrides below.
+  --ct-cta-surface-color: var(--ct-color-dark-background-light);
+  --ct-cta-heading-color: var(--ct-color-dark-heading);
+  --ct-cta-body-color: var(--ct-color-dark-body);
+  --ct-cta-accent-color: var(--ct-color-dark-interaction-background);
+  --ct-cta-accent-hover-color: var(--ct-color-dark-interaction-hover-background);
+
+  position: relative;
+  overflow: hidden;
+  padding: 10rem 0;
+  text-align: center;
+  background: var(--ct-cta-surface-color);
+
+  &.ct-theme-light {
+    --ct-cta-surface-color: var(--ct-color-light-background-light);
+    --ct-cta-heading-color: var(--ct-color-light-heading);
+    --ct-cta-body-color: var(--ct-color-light-body);
+    --ct-cta-accent-color: var(--ct-color-light-interaction-background);
+    --ct-cta-accent-hover-color: var(--ct-color-light-interaction-hover-background);
+  }
+
+  // Centred accent glow behind the content.
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 700px;
+    height: 500px;
+    transform: translate(-50%, -50%);
+    background: radial-gradient(ellipse at center, color-mix(in srgb, var(--ct-cta-accent-color) 10%, transparent) 0%, color-mix(in srgb, var(--ct-cta-accent-color) 3%, transparent) 50%, transparent 70%);
+    pointer-events: none;
+  }
+
+  @media (width <= 768px) {
+    padding: 8.75rem 0;
+  }
+
+  &__inner {
+    position: relative;
+    z-index: 2;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 4rem;
+
+    @media (width <= 768px) {
+      padding: 0 1.5rem;
+    }
+  }
+
+  &__title {
+    margin: 0 0 3rem;
+    font-family: var(--ct-typography-display-font-name);
+    font-size: clamp(3.5rem, 8vw, 5.75rem);
+    font-weight: var(--ct-typography-heading-h1-font-weight);
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    color: var(--ct-cta-heading-color);
+  }
+
+  // The last word of the heading carries a gradient underline.
+  &__underline {
+    position: relative;
+    display: inline-block;
+
+    &::after {
+      content: '';
+      position: absolute;
+      right: 0;
+      bottom: 0.05em;
+      left: 0;
+      height: 2px;
+      background: linear-gradient(90deg, var(--ct-cta-accent-color), var(--ct-cta-accent-hover-color));
+    }
+  }
+
+  &__sub {
+    max-width: 640px;
+    margin: 0 auto 3.5rem;
+    font-size: var(--ct-typography-text-large-font-size);
+    line-height: 1.6;
+    letter-spacing: 0.02em;
+    color: var(--ct-cta-body-color);
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 3rem;
+
+    @media (width <= 480px) {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
+
+  &__action {
+    display: inline-block;
+    position: relative;
+    overflow: hidden;
+    padding: 1rem 2rem;
+    font-family: var(--ct-typography-label-regular-font-name);
+    font-size: 0.875rem;
+    font-weight: var(--ct-typography-label-regular-font-weight);
+    line-height: 1;
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: color 0.4s ease, border-color 0.4s ease;
+
+    // Hover fill: a faint tint that wipes in from the left.
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 0.4s ease;
+    }
+
+    &:hover {
+      text-decoration: none;
+
+      &::before {
+        transform: scaleX(1);
+      }
+    }
+
+    // The last action is the primary CTA: brand accent outline.
+    &--primary {
+      color: var(--ct-cta-accent-color);
+      border-color: color-mix(in srgb, var(--ct-cta-accent-color) 40%, transparent);
+
+      &::before {
+        background: color-mix(in srgb, var(--ct-cta-accent-color) 8%, transparent);
+      }
+
+      &:hover {
+        color: var(--ct-cta-accent-hover-color);
+        border-color: var(--ct-cta-accent-color);
+      }
+    }
+
+    // Earlier actions are secondary: neutral outline.
+    &--secondary {
+      color: var(--ct-cta-heading-color);
+      border-color: color-mix(in srgb, var(--ct-cta-heading-color) 30%, transparent);
+
+      &::before {
+        background: color-mix(in srgb, var(--ct-cta-heading-color) 8%, transparent);
+      }
+
+      &:hover {
+        color: var(--ct-cta-heading-color);
+        border-color: var(--ct-cta-heading-color);
+      }
+    }
+  }
+
+  &__email {
+    display: inline-block;
+    position: relative;
+    font-size: var(--ct-typography-heading-h3-font-size);
+    text-decoration: none;
+    letter-spacing: 0.04em;
+    color: var(--ct-cta-accent-color);
+    transition: color 0.4s ease;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: -3px;
+      left: 0;
+      width: 0;
+      height: 1px;
+      background: var(--ct-cta-accent-hover-color);
+      transition: width 0.4s ease;
+    }
+
+    &:hover {
+      text-decoration: none;
+      color: var(--ct-cta-accent-hover-color);
+
+      &::after {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/cta-band/cta-band.twig
+++ b/web/themes/custom/drevops/components/03-organisms/cta-band/cta-band.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * CTA Band component.
+ *
+ * Variables:
+ * - theme: [string] Theme variation: light, dark.
+ * - type: [string] Display variant.
+ * - heading: [string] Oversized heading; its last word is underlined.
+ * - sub: [string] Supporting line shown below the heading.
+ * - actions: [array] Up to three action links; the last renders as primary:
+ *   - url: [string] Action URL.
+ *   - title: [string] Action label.
+ * - email: [object] Distinct email link shown beneath the actions:
+ *   - url: [string] The mailto URL.
+ *   - label: [string] The email address shown as the link text.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ */
+#}
+
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set type_class = 'ct-cta--%s'|format(type|default('display')) %}
+{% set modifier_class = '%s %s %s'|format(theme_class, type_class, modifier_class|default(''))|trim %}
+
+{% set heading_words = heading|default('')|trim|split(' ')|filter(word => word is not empty) %}
+{% set last_word = heading_words|last %}
+{% set lead_words = heading_words|slice(0, heading_words|length - 1)|join(' ') %}
+
+{% if heading is not empty %}
+  <div class="ct-cta {{ modifier_class }}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="ct-cta__inner component-reveal">
+      <h2 class="ct-cta__title">
+        {%- if lead_words is not empty %}{{ lead_words }} {% endif -%}
+        <span class="ct-cta__underline">{{ last_word }}</span>
+      </h2>
+
+      {% if sub is not empty %}
+        <p class="ct-cta__sub">{{ sub }}</p>
+      {% endif %}
+
+      {% if actions is not empty %}
+        <div class="ct-cta__actions">
+          {% for action in actions %}
+            {% if action.url is not empty and action.title is not empty %}
+              <a href="{{ action.url }}" class="ct-cta__action ct-cta__action--{{ loop.last ? 'primary' : 'secondary' }}">{{ action.title }}</a>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      {% if email.url is not empty and email.label is not empty %}
+        <a href="{{ email.url }}" class="ct-cta__email">{{ email.label }}</a>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--cta.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--cta.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the CTA band paragraph.
+ *
+ * The shared Actions link field carries both buttons and an optional email
+ * link; the mailto: entry is rendered as the distinct email link, the rest as
+ * action buttons.
+ */
+#}
+{% set cta_actions = [] %}
+{% set cta_email = null %}
+{% for item in paragraph.field_link %}
+  {% if item.uri is not empty %}
+    {% if item.uri starts with 'mailto:' %}
+      {% set cta_email = {
+        url: item.url.toString(),
+        label: item.title|default(item.uri|replace({'mailto:': ''})),
+      } %}
+    {% else %}
+      {% set cta_actions = cta_actions|merge([{
+        url: item.url.toString(),
+        title: item.title,
+      }]) %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{{ include('drevops:cta-band', {
+  theme: paragraph.field_c_p_theme.value|default('dark'),
+  type: paragraph.field_c_p_type.value|default('display'),
+  heading: paragraph.field_title.value,
+  sub: paragraph.field_subtitle.value,
+  actions: cta_actions,
+  email: cta_email,
+  attributes: component_attributes,
+}) }}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--cta.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--cta.html.twig
@@ -11,15 +11,19 @@
 {% set cta_actions = [] %}
 {% set cta_email = null %}
 {% for item in paragraph.field_link %}
-  {% if item.uri is not empty %}
+  {% set link_url = item.url ? item.url.toString() : '' %}
+  {% if link_url is not empty %}
     {% if item.uri starts with 'mailto:' %}
-      {% set cta_email = {
-        url: item.url.toString(),
-        label: item.title|default(item.uri|replace({'mailto:': ''})),
-      } %}
+      {# Only the first email link is shown; the design carries a single address. #}
+      {% if cta_email is null %}
+        {% set cta_email = {
+          url: link_url,
+          label: item.title|default(item.uri|replace({'mailto:': ''})),
+        } %}
+      {% endif %}
     {% else %}
       {% set cta_actions = cta_actions|merge([{
-        url: item.url.toString(),
+        url: link_url,
         title: item.title,
       }]) %}
     {% endif %}


### PR DESCRIPTION
Closes #195

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#195] Verb in past tense.`
- [x] Ticket number `#195` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added a new `cta` paragraph bundle (`paragraphs.paragraphs_type.cta.yml`) - a full-width closing call-to-action band with an oversized heading, sub-line, action buttons, and a distinct email link.
2. Attached five shared fields to the `cta` bundle: `field_title` (required heading), `field_subtitle` (optional sub-line), `field_link` (up to 3 links - buttons and/or email), `field_c_p_theme`, and `field_c_p_type` - all via new `field.field.paragraph.cta.*` config files.
3. Widened `field.storage.paragraph.field_link` cardinality from 2 to 3 to accommodate two action buttons plus an email link simultaneously.
4. Extended `do_base_field_c_p_type_allowed_values()` in `do_base.module` with a `cta` bundle entry so the type field resolves its allowed values correctly.
5. Registered the `cta` bundle on `field.field.node.civictheme_page.field_c_n_components` so content editors can add a CTA band to pages.
6. Added an SDC component at `components/03-organisms/cta-band/` (`cta-band.component.yml`, `cta-band.twig`, `cta-band.scss`). The Twig template splits the heading's last word into a `ct-cta__underline` span, iterates actions assigning primary/secondary classes, and renders the email link separately. SCSS uses per-theme CSS custom properties resolving dark and light CivicTheme colour tokens, a centred radial-gradient glow, and fluid `clamp()`-based heading sizing.
7. Added a per-bundle Twig template (`paragraph--cta.html.twig`) that separates `mailto:` entries from regular action links before delegating to the SDC, so the single shared `field_link` field drives both the button row and the email link without a dedicated email field.
8. Added a Behat feature (`tests/behat/features/paragraph_cta.feature`) covering four scenarios: full band with two actions and an email link, single-action band (no secondary button, no email), light-theme variant, and the content editor UI check.

## Screenshots

![CTA band](https://raw.githubusercontent.com/drevops/website/0834d7ac01ebb14769fbd376e6199e813d521cba/feature-195-cta-band/6fabfe8d0cbb678a4c5ce8c29f8467ffafb30b33.png)

## Before / After

```
┌─────────────────────────────────────────────────────────┐
│ BEFORE                                                  │
│                                                         │
│  Page components field:                                 │
│  ┌──────────────────────────────────────────────────┐   │
│  │  hero | campaign | service_detail | divider ...  │   │
│  └──────────────────────────────────────────────────┘   │
│                                                         │
│  field_link cardinality: 2                              │
│                                                         │
│  do_base_field_c_p_type_allowed_values():               │
│  ┌───────────────────────────────────────────────────┐  │
│  │  (no cta bundle entry)                            │  │
│  └───────────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────┐
│ AFTER                                                   │
│                                                         │
│  Page components field:                                 │
│  ┌──────────────────────────────────────────────────┐   │
│  │  hero | campaign | service_detail | cta | ...    │   │
│  └──────────────────────────────────────────────────┘   │
│                                                         │
│  field_link cardinality: 3                              │
│                                                         │
│  do_base_field_c_p_type_allowed_values():               │
│  ┌───────────────────────────────────────────────────┐  │
│  │  cta => [ 'display' => 'Display' ]                │  │
│  └───────────────────────────────────────────────────┘  │
│                                                         │
│  CTA band on a page (dark theme):                       │
│  ┌──────────────────────────────────────────────────┐   │
│  │                                                  │   │
│  │   Let us talk about your                         │   │
│  │              ___________                         │   │
│  │             website                              │   │
│  │                                                  │   │
│  │   Tell us where things stand and we'll be        │   │
│  │   straight about the fit                         │   │
│  │                                                  │   │
│  │  [ Start a conversation ]  [ See what it costs ] │   │
│  │                                                  │   │
│  │            info@drevops.com                      │   │
│  │                                                  │   │
│  └──────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────┘
```
