### PR TITLE
[#197] Added the blog listing, homepage teaser and read time.

### DIFF
--- a/config/default/core.entity_form_display.node.civictheme_page.default.yml
+++ b/config/default/core.entity_form_display.node.civictheme_page.default.yml
@@ -24,6 +24,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - field.field.node.civictheme_page.field_c_n_vertical_spacing
     - field.field.node.civictheme_page.field_n_metatags
+    - field.field.node.civictheme_page.field_read_time
     - node.type.civictheme_page
     - workflows.workflow.civictheme_editorial
   module:
@@ -362,6 +363,14 @@ content:
     settings:
       sidebar: true
       use_details: true
+    third_party_settings: {  }
+  field_read_time:
+    type: string_textfield
+    weight: 30
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   langcode:
     type: language_select

--- a/config/default/core.entity_view_display.node.civictheme_page.civictheme_navigation_card.yml
+++ b/config/default/core.entity_view_display.node.civictheme_page.civictheme_navigation_card.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - field.field.node.civictheme_page.field_c_n_vertical_spacing
     - field.field.node.civictheme_page.field_n_metatags
+    - field.field.node.civictheme_page.field_read_time
     - node.type.civictheme_page
   module:
     - layout_builder
@@ -80,6 +81,7 @@ hidden:
   field_c_n_topics: true
   field_c_n_vertical_spacing: true
   field_n_metatags: true
+  field_read_time: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.civictheme_page.civictheme_promo_card.yml
+++ b/config/default/core.entity_view_display.node.civictheme_page.civictheme_promo_card.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - field.field.node.civictheme_page.field_c_n_vertical_spacing
     - field.field.node.civictheme_page.field_n_metatags
+    - field.field.node.civictheme_page.field_read_time
     - node.type.civictheme_page
   module:
     - layout_builder
@@ -85,5 +86,6 @@ hidden:
   field_c_n_topics: true
   field_c_n_vertical_spacing: true
   field_n_metatags: true
+  field_read_time: true
   langcode: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.civictheme_page.civictheme_slider_slide.yml
+++ b/config/default/core.entity_view_display.node.civictheme_page.civictheme_slider_slide.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - field.field.node.civictheme_page.field_c_n_vertical_spacing
     - field.field.node.civictheme_page.field_n_metatags
+    - field.field.node.civictheme_page.field_read_time
     - node.type.civictheme_page
   module:
     - layout_builder
@@ -81,6 +82,7 @@ hidden:
   field_c_n_topics: true
   field_c_n_vertical_spacing: true
   field_n_metatags: true
+  field_read_time: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.civictheme_page.default.yml
+++ b/config/default/core.entity_view_display.node.civictheme_page.default.yml
@@ -24,6 +24,7 @@ dependencies:
     - field.field.node.civictheme_page.field_c_n_topics
     - field.field.node.civictheme_page.field_c_n_vertical_spacing
     - field.field.node.civictheme_page.field_n_metatags
+    - field.field.node.civictheme_page.field_read_time
     - node.type.civictheme_page
   module:
     - datetime
@@ -208,6 +209,7 @@ hidden:
   field_c_n_summary: true
   field_c_n_thumbnail: true
   field_c_n_topics: true
+  field_read_time: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_read_time.yml
+++ b/config/default/field.field.node.civictheme_page.field_read_time.yml
@@ -1,0 +1,19 @@
+uuid: 26c49fd3-207b-4f0a-b8d0-57f32c964fd9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_read_time
+    - node.type.civictheme_page
+id: node.civictheme_page.field_read_time
+field_name: field_read_time
+entity_type: node
+bundle: civictheme_page
+label: 'Read time'
+description: 'Estimated reading time shown on teasers and cards, for example "8 min read".'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.storage.node.field_read_time.yml
+++ b/config/default/field.storage.node.field_read_time.yml
@@ -1,0 +1,21 @@
+uuid: 947bffb4-e2bb-45bc-9cf7-e3121edd2d98
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_read_time
+field_name: field_read_time
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/behat/features/blog.feature
+++ b/tests/behat/features/blog.feature
@@ -1,0 +1,41 @@
+@blog
+Feature: Blog listing and homepage teaser
+
+  As a site visitor
+  I want a blog listing and a homepage preview of the latest posts
+  So that I can discover and reach DrevOps articles
+
+  @api
+  Scenario: A page tagged with the Blog label appears on the listing as a card that links through
+    Given the following managed files:
+      | path      | uri                          | status |
+      | image.jpg | public://blog_test/image.jpg | 1      |
+    And the following media "civictheme_image" exist:
+      | name              | field_c_m_image |
+      | [TEST] Blog Image | image.jpg       |
+    And the following "civictheme_page" content:
+      | title                | status | field_c_n_topics | field_c_n_summary        | field_read_time | field_c_n_thumbnail |
+      | [TEST] Blog Post One | 1      | Blog             | [TEST] Blog post summary | 7 min read      | [TEST] Blog Image   |
+    And I am an anonymous user
+
+    When I go to "/blog"
+    Then I should get a "200" HTTP response
+    And the response should contain "ct-page--blog"
+    And I should see "[TEST] Blog Post One"
+    And I should see "[TEST] Blog post summary"
+    And I should see "7 min read"
+    And the response should contain "ct-promo-card"
+    And the response should contain "/sites/default/files"
+
+    When I follow "[TEST] Blog Post One"
+    Then I should get a "200" HTTP response
+    And I should see "[TEST] Blog Post One"
+
+  @api
+  Scenario: The homepage shows a teaser of the latest blog posts
+    Given I am an anonymous user
+
+    When I go to the homepage
+    Then I should see "From the blog"
+    And I should see "All articles"
+    And the response should contain "ct-promo-card"

--- a/tests/behat/features/blog.feature
+++ b/tests/behat/features/blog.feature
@@ -25,7 +25,7 @@ Feature: Blog listing and homepage teaser
     And I should see "[TEST] Blog post summary"
     And I should see "7 min read"
     And the response should contain "ct-promo-card"
-    And the response should contain "/sites/default/files"
+    And the response should contain "/sites/default/files/styles/civictheme_promo_card"
 
     When I follow "[TEST] Blog Post One"
     Then I should get a "200" HTTP response

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -128,39 +128,40 @@ function do_base_deploy_blog_read_time(array &$sandbox): string {
   }
 
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-  $batch_size = 25;
 
-  // Re-query blog posts that still have no read time and fill one batch per
-  // pass. A saved node drops out of the next query, so repeated passes drain
-  // the backlog without tracking offsets; the hook finishes once a pass finds
-  // nothing left. Editors can override the estimate at any time.
-  $ids = $node_storage->getQuery()
-    ->accessCheck(FALSE)
-    ->condition('type', 'civictheme_page')
-    ->condition('field_c_n_topics', $term->id())
-    ->notExists('field_read_time')
-    ->range(0, $batch_size)
-    ->execute();
+  // Collect the backlog once, then drain it one batch per pass. Tracking the
+  // ids in the sandbox (rather than re-querying for an empty read time) means
+  // posts that are intentionally left blank do not keep reappearing, so the
+  // hook still terminates. Editors can override the estimate at any time.
+  if (!isset($sandbox['ids'])) {
+    $sandbox['ids'] = array_values($node_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'civictheme_page')
+      ->condition('field_c_n_topics', $term->id())
+      ->notExists('field_read_time')
+      ->execute());
+    $sandbox['backfilled'] = 0;
+  }
 
-  $processed = 0;
-
-  foreach ($ids as $id) {
+  foreach (array_splice($sandbox['ids'], 0, 25) as $id) {
     $node = $node_storage->load($id);
 
     if ($node instanceof FieldableEntityInterface && $node->hasField('field_read_time')) {
-      $minutes = max(1, (int) round(_do_base_count_words($node) / 200));
-      $node->set('field_read_time', sprintf('%d min read', $minutes));
-      $node->save();
-    }
+      $words = _do_base_count_words($node);
 
-    $processed++;
+      // Skip empty posts rather than label them "1 min read".
+      if ($words > 0) {
+        $minutes = max(1, (int) round($words / 200));
+        $node->set('field_read_time', sprintf('%d min read', $minutes));
+        $node->save();
+        $sandbox['backfilled']++;
+      }
+    }
   }
 
-  $backfilled = (int) ($sandbox['backfilled'] ?? 0) + $processed;
-  $sandbox['backfilled'] = $backfilled;
-  $sandbox['#finished'] = $processed === 0 ? 1 : 0;
+  $sandbox['#finished'] = empty($sandbox['ids']) ? 1 : 0;
 
-  return sprintf('Set the read time on %d blog post(s).', $backfilled);
+  return sprintf('Set the read time on %d blog post(s).', $sandbox['backfilled']);
 }
 
 /**

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\civictheme\CivicthemeColorManager;
 use Drupal\civictheme\CivicthemeConstants;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Rebuild CivicTheme colour stylesheets from the imported colour configuration.
@@ -97,4 +100,179 @@ function do_base_deploy_component_dark_theme(array &$sandbox): string {
   $sandbox['#finished'] = $processed === 0 ? 1 : 0;
 
   return sprintf('Set the dark colour scheme on %d component(s).', $migrated);
+}
+
+/**
+ * Ensure the Blog topic term used to tag and list blog posts exists.
+ */
+function do_base_deploy_blog_topic(): string {
+  $term = _do_base_ensure_blog_term();
+
+  if (!$term instanceof TermInterface) {
+    return 'The civictheme_topics vocabulary is unavailable; skipped the Blog topic term.';
+  }
+
+  return sprintf('Blog topic term is available (term %d).', $term->id());
+}
+
+/**
+ * Backfill the read time on blog posts that do not have one yet.
+ */
+function do_base_deploy_blog_read_time(array &$sandbox): string {
+  $term = _do_base_ensure_blog_term();
+
+  if (!$term instanceof TermInterface) {
+    $sandbox['#finished'] = 1;
+
+    return 'The Blog topic term is unavailable; skipped the read time backfill.';
+  }
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $batch_size = 25;
+
+  // Re-query blog posts that still have no read time and fill one batch per
+  // pass. A saved node drops out of the next query, so repeated passes drain
+  // the backlog without tracking offsets; the hook finishes once a pass finds
+  // nothing left. Editors can override the estimate at any time.
+  $ids = $node_storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('type', 'civictheme_page')
+    ->condition('field_c_n_topics', $term->id())
+    ->notExists('field_read_time')
+    ->range(0, $batch_size)
+    ->execute();
+
+  $processed = 0;
+
+  foreach ($ids as $id) {
+    $node = $node_storage->load($id);
+
+    if ($node instanceof FieldableEntityInterface && $node->hasField('field_read_time')) {
+      $minutes = max(1, (int) round(_do_base_count_words($node) / 200));
+      $node->set('field_read_time', sprintf('%d min read', $minutes));
+      $node->save();
+    }
+
+    $processed++;
+  }
+
+  $backfilled = (int) ($sandbox['backfilled'] ?? 0) + $processed;
+  $sandbox['backfilled'] = $backfilled;
+  $sandbox['#finished'] = $processed === 0 ? 1 : 0;
+
+  return sprintf('Set the read time on %d blog post(s).', $backfilled);
+}
+
+/**
+ * Add the "From the blog" teaser to the front page when it is not present.
+ */
+function do_base_deploy_homepage_blog_teaser(): string {
+  $front = \Drupal::config('system.site')->get('page.front');
+
+  if (empty($front)) {
+    return 'No front page is configured; skipped the homepage blog teaser.';
+  }
+
+  $path = \Drupal::service('path_alias.manager')->getPathByAlias($front);
+
+  if (!preg_match('#^/node/(\d+)$#', $path, $matches)) {
+    return 'The front page is not a node; skipped the homepage blog teaser.';
+  }
+
+  $node = \Drupal::entityTypeManager()->getStorage('node')->load((int) $matches[1]);
+
+  if (!$node instanceof FieldableEntityInterface || !$node->hasField('field_c_n_components')) {
+    return 'The front page has no components field; skipped the homepage blog teaser.';
+  }
+
+  // Idempotency guard: identify our teaser by its title so re-runs do not add a
+  // second copy.
+  foreach ($node->get('field_c_n_components')->referencedEntities() as $component) {
+    if ($component->bundle() === 'civictheme_automated_list' && $component->hasField('field_c_p_title') && $component->get('field_c_p_title')->value === 'From the blog') {
+      return 'The homepage blog teaser is already present.';
+    }
+  }
+
+  $term = _do_base_ensure_blog_term();
+
+  if (!$term instanceof TermInterface) {
+    return 'The Blog topic term is unavailable; skipped the homepage blog teaser.';
+  }
+
+  // Mirror the configuration of the /blog listing so the teaser renders the
+  // same promo cards, limited to the three latest posts with a link through to
+  // the full listing.
+  $teaser = Paragraph::create([
+    'type' => 'civictheme_automated_list',
+    'field_c_p_title' => 'From the blog',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_vertical_spacing' => 'both',
+    'field_c_p_list_type' => 'civictheme_automated_list__block1',
+    'field_c_p_list_content_type' => 'civictheme_page',
+    'field_c_p_list_topics' => ['target_id' => $term->id()],
+    'field_c_p_list_column_count' => 3,
+    'field_c_p_list_item_view_as' => 'civictheme_promo_card',
+    'field_c_p_list_item_theme' => 'dark',
+    'field_c_p_list_limit_type' => 'limited',
+    'field_c_p_list_limit' => 3,
+    'field_c_p_list_link_above' => ['uri' => 'internal:/blog', 'title' => 'All articles'],
+  ]);
+  $teaser->save();
+
+  $node->get('field_c_n_components')->appendItem($teaser);
+  $node->save();
+
+  return 'Added the "From the blog" teaser to the front page.';
+}
+
+/**
+ * Load the Blog topic term, creating it when the vocabulary allows.
+ */
+function _do_base_ensure_blog_term(): ?TermInterface {
+  $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
+  $existing = $storage->loadByProperties([
+    'vid' => 'civictheme_topics',
+    'name' => 'Blog',
+  ]);
+
+  if (!empty($existing)) {
+    return reset($existing);
+  }
+
+  if (!Vocabulary::load('civictheme_topics')) {
+    return NULL;
+  }
+
+  $term = $storage->create(['vid' => 'civictheme_topics', 'name' => 'Blog']);
+  $term->save();
+
+  return $term;
+}
+
+/**
+ * Count words across an entity's text fields, recursing into its paragraphs.
+ */
+function _do_base_count_words(FieldableEntityInterface $entity): int {
+  $text_types = ['string', 'string_long', 'text', 'text_long', 'text_with_summary'];
+  $count = 0;
+
+  foreach ($entity->getFields() as $field) {
+    $type = $field->getFieldDefinition()->getType();
+
+    if (in_array($type, $text_types, TRUE)) {
+      foreach ($field as $item) {
+        $count += str_word_count(strip_tags((string) ($item->value ?? '')));
+      }
+    }
+    elseif ($type === 'entity_reference_revisions') {
+      foreach ($field->referencedEntities() as $child) {
+        if ($child instanceof FieldableEntityInterface) {
+          $count += _do_base_count_words($child);
+        }
+      }
+    }
+  }
+
+  return $count;
 }

--- a/web/themes/custom/drevops/assets/sass/page/_page.scss
+++ b/web/themes/custom/drevops/assets/sass/page/_page.scss
@@ -34,7 +34,7 @@ body {
 
       // Lay the featured card out horizontally from the 'm' breakpoint up, so
       // its image and content sit side by side like the design's hero post.
-      @media (min-width: 768px) {
+      @media (width >= 768px) {
         .ct-promo-card {
           flex-direction: row;
           align-items: stretch;

--- a/web/themes/custom/drevops/assets/sass/page/_page.scss
+++ b/web/themes/custom/drevops/assets/sass/page/_page.scss
@@ -17,3 +17,43 @@ html {
 body {
   margin: 0;
 }
+
+//
+// Blog landing page.
+//
+// The newest post at the top of the blog automated list is presented as a
+// large, full-width featured card with a horizontal layout above the regular
+// grid of further posts. Scoped to the blog page so other automated lists
+// (including the homepage teaser) keep the standard uniform grid.
+//
+.ct-page--blog {
+  .ct-list {
+    .row > [class*='col-']:first-child {
+      flex: 0 0 100%;
+      max-width: 100%;
+
+      // Lay the featured card out horizontally from the 'm' breakpoint up, so
+      // its image and content sit side by side like the design's hero post.
+      @media (min-width: 768px) {
+        .ct-promo-card {
+          flex-direction: row;
+          align-items: stretch;
+        }
+
+        .ct-promo-card__image {
+          width: 50%;
+          height: auto;
+        }
+
+        .ct-promo-card__content {
+          width: 50%;
+          justify-content: center;
+        }
+
+        .ct-promo-card__title {
+          font-size: 1.75rem;
+        }
+      }
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/02-molecules/promo-card/promo-card.component.yml
+++ b/web/themes/custom/drevops/components/02-molecules/promo-card/promo-card.component.yml
@@ -54,6 +54,10 @@ props:
       type: string
       title: End Date
       description: Formatted end time.
+    read_time:
+      type: string
+      title: Read time
+      description: Estimated reading time, for example "8 min read".
     link:
       type: object
       title: Link

--- a/web/themes/custom/drevops/components/02-molecules/promo-card/promo-card.twig
+++ b/web/themes/custom/drevops/components/02-molecules/promo-card/promo-card.twig
@@ -16,6 +16,7 @@
  * - date: [string] Start date and time.
  * - date_end_iso: [string] End time in ISO format.
  * - date_end: [string] Formatted end time.
+ * - read_time: [string] Estimated reading time, for example "8 min read".
  * - link: [object] Card link object.
  *   Each property contains:
  *   - url: [string] Link URL.
@@ -43,6 +44,7 @@
  * - content_top_block
  * - subtitle_block
  * - date_block
+ * - read_time_block
  * - title_block
  * - content_middle_block
  * - summary_block
@@ -122,6 +124,18 @@
                 content: date_content,
                 icon: date_end ? 'calendar-2' : null,
                 icon_placement: 'before',
+              } only %}
+            </div>
+          {% endif %}
+        {% endblock %}
+
+        {% block read_time_block %}
+          {% if read_time is not empty %}
+            <div class="ct-promo-card__read-time">
+              {% include 'civictheme:tag' with {
+                theme: theme,
+                type: 'tertiary',
+                content: read_time,
               } only %}
             </div>
           {% endif %}

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -24,12 +24,21 @@ require_once __DIR__ . '/includes/cards.inc';
 require_once __DIR__ . '/includes/sidebar_navigation.inc';
 require_once __DIR__ . '/includes/skip_link.inc';
 require_once __DIR__ . '/includes/content_moderation.inc';
+require_once __DIR__ . '/includes/blog.inc';
 
 /**
  * Implements hook_preprocess_HOOK() for container templates.
  */
 function drevops_preprocess_container(array &$variables): void {
   $variables['modifier_class'] = FALSE;
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for the html template.
+ */
+function drevops_preprocess_html(array &$variables): void {
+  _drevops_preprocess_html__skip_link($variables);
+  _drevops_preprocess_html__blog($variables);
 }
 
 /**

--- a/web/themes/custom/drevops/includes/blog.inc
+++ b/web/themes/custom/drevops/includes/blog.inc
@@ -13,18 +13,19 @@ use Drupal\node\NodeInterface;
  * Add a body class on the blog landing page.
  */
 function _drevops_preprocess_html__blog(array &$variables): void {
-  // Tag the blog landing page so the listing's first card can be styled as a
-  // featured post. Resolved from the path alias rather than a fixed node id so
-  // it holds across environments.
   $node = \Drupal::routeMatch()->getParameter('node');
 
   if (!$node instanceof NodeInterface) {
     return;
   }
 
-  $alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node->id());
+  // Tag the blog landing page so the listing's first card can be styled as a
+  // featured post. Identify it by the node the "/blog" alias resolves to,
+  // rather than the alias the request arrived on, so it holds regardless of
+  // which alias (or language) was used to reach the node.
+  $blog_path = \Drupal::service('path_alias.manager')->getPathByAlias('/blog');
 
-  if ($alias === '/blog') {
+  if ($blog_path === '/node/' . $node->id()) {
     $variables['attributes']['class'][] = 'ct-page--blog';
   }
 }

--- a/web/themes/custom/drevops/includes/blog.inc
+++ b/web/themes/custom/drevops/includes/blog.inc
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Blog theme alterations.
+ */
+
+declare(strict_types=1);
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Add a body class on the blog landing page.
+ */
+function _drevops_preprocess_html__blog(array &$variables): void {
+  // Tag the blog landing page so the listing's first card can be styled as a
+  // featured post. Resolved from the path alias rather than a fixed node id so
+  // it holds across environments.
+  $node = \Drupal::routeMatch()->getParameter('node');
+
+  if (!$node instanceof NodeInterface) {
+    return;
+  }
+
+  $alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $node->id());
+
+  if ($alias === '/blog') {
+    $variables['attributes']['class'][] = 'ct-page--blog';
+  }
+}

--- a/web/themes/custom/drevops/includes/node.inc
+++ b/web/themes/custom/drevops/includes/node.inc
@@ -7,12 +7,28 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\FieldableEntityInterface;
+
 /**
  * Implements template_preprocess_node().
  */
 function _drevops_preprocess_node__civictheme_promo_card(array &$variables): void {
   // @see https://www.drupal.org/project/civictheme/issues/3415756
   _drevops_preprocess_paragraph__node_field__date($variables);
+  _drevops_preprocess_node__node_field__read_time($variables);
+}
+
+/**
+ * Pre-process for the Read time node field.
+ */
+function _drevops_preprocess_node__node_field__read_time(array &$variables): void {
+  $node = $variables['node'] ?? NULL;
+  if ($node instanceof FieldableEntityInterface && $node->hasField('field_read_time')) {
+    $read_time = civictheme_get_field_value($node, 'field_read_time', TRUE);
+    if (!empty($read_time)) {
+      $variables['read_time'] = $read_time;
+    }
+  }
 }
 
 /**

--- a/web/themes/custom/drevops/includes/skip_link.inc
+++ b/web/themes/custom/drevops/includes/skip_link.inc
@@ -10,9 +10,9 @@ declare(strict_types=1);
 use Drupal\civictheme\CivicthemeConstants;
 
 /**
- * Implements hook_preprocess_HOOK() for the html template.
+ * Pre-process the skip link for the html template.
  */
-function drevops_preprocess_html(array &$variables): void {
+function _drevops_preprocess_html__skip_link(array &$variables): void {
   // CivicTheme themes the skip link per page and leaves it light on content
   // pages; pin it to dark so this chrome matches the site-wide dark scheme.
   $variables['skip_link_theme'] = CivicthemeConstants::THEME_DARK;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#197] Verb in past tense.`
- [x] Ticket number `#197` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

Closes #197

## Changed

1. Added a `field_read_time` string field to the `civictheme_page` content type, with Drupal config exported across all view displays and the edit form.
2. Extended the `promo-card` Twig component (`promo-card.component.yml` and `promo-card.twig`) to accept and render a `read_time` prop as a tertiary tag badge, with a new `read_time_block` Twig block for downstream overrides.
3. Added `_drevops_preprocess_node__node_field__read_time()` in `includes/node.inc` to pass `field_read_time` into the promo-card template variables.
4. Added `includes/blog.inc` with `_drevops_preprocess_html__blog()`, which appends a `ct-page--blog` body class when the current node is the node the `/blog` alias resolves to. Refactored `drevops_preprocess_html()` in `drevops.theme` to dispatch to both the skip-link and blog sub-preprocessors (and renamed `skip_link.inc`'s function to `_drevops_preprocess_html__skip_link()` to match the pattern).
5. Added blog-page SCSS in `assets/sass/page/_page.scss`: the first grid column inside `.ct-page--blog .ct-list` stretches to full width and, at the `m` breakpoint, its promo card switches to a horizontal `flex-direction: row` layout to produce the featured-post hero treatment.
6. Added three deploy hooks in `do_base.deploy.php`: `do_base_deploy_blog_topic` (ensures the "Blog" `civictheme_topics` term exists), `do_base_deploy_blog_read_time` (batched backfill of `field_read_time` on existing tagged posts, counting words across text fields and nested paragraphs), and `do_base_deploy_homepage_blog_teaser` (idempotently appends a `civictheme_automated_list` paragraph to the front page showing the three latest Blog posts under a "From the blog" heading with an "All articles" link).
7. Added Behat feature `tests/behat/features/blog.feature` covering: a tagged page appearing on `/blog` as a promo card with the correct image style, read time, and a working link; and the homepage showing the "From the blog" teaser section.

## Screenshots

![Blog listing with featured post and read-time cards](https://raw.githubusercontent.com/drevops/website/b295de8c948de6d094214cc41cd9c7a83045b6f2/feature-197-blog-listing/790690e140d6f92c60b2832d4b9caa87977b08d5.png)

## Before / After

```
BEFORE                                     AFTER
┌──────────────────────────────────┐       ┌──────────────────────────────────┐
│ /blog                            │       │ /blog  (body: ct-page--blog)     │
│                                  │       │                                  │
│  ┌────────┐ ┌────────┐ ┌───────┐ │       │  ┌──────────────────────────────┐│
│  │ Card 1 │ │ Card 2 │ │Card 3 │ │       │  │  Featured Post (full width)  ││
│  │        │ │        │ │       │ │       │  │  [image | content side-by-side│
│  └────────┘ └────────┘ └───────┘ │       │  └──────────────────────────────┘│
│                                  │       │  ┌────────┐ ┌────────┐ ┌───────┐ │
│  No read time on cards           │       │  │ Card 2 │ │ Card 3 │ │Card 4 │ │
│  No blog body class              │       │  │7 min..│ │5 min..│ │3 min..│ │
│  No "Blog" topic term            │       │  └────────┘ └────────┘ └───────┘ │
│                                  │       │                                  │
└──────────────────────────────────┘       └──────────────────────────────────┘

┌──────────────────────────────────┐       ┌──────────────────────────────────┐
│ / (homepage)                     │       │ / (homepage)                     │
│                                  │       │                                  │
│  [Hero]                          │       │  [Hero]                          │
│  [Other components...]           │       │  [Other components...]           │
│                                  │       │                                  │
│  (no blog teaser)                │       │  ┌──────────────────────────────┐│
│                                  │       │  │  From the blog    All articles││
│                                  │       │  │  ┌──────┐ ┌──────┐ ┌──────┐ ││
│                                  │       │  │  │ Post │ │ Post │ │ Post │ ││
│                                  │       │  └──────────────────────────────┘│
└──────────────────────────────────┘       └──────────────────────────────────┘
```
