### PR TITLE
[#200] Assembled the services page from shared components.

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -354,4 +354,26 @@ class FeatureContext extends DrupalContext {
     $node->save();
   }
 
+  /**
+   * Assert the document does not overflow horizontally at a given width.
+   *
+   * @code
+   * Then the page has no horizontal overflow at 375 pixels wide
+   * @endcode
+   */
+  #[Then('the page has no horizontal overflow at :width pixels wide')]
+  public function assertNoHorizontalOverflowAtWidth(string $width): void {
+    $session = $this->getSession();
+    $session->resizeWindow((int) $width, 900, 'current');
+
+    // Content wider than the viewport is what produces a horizontal scrollbar;
+    // the comparison is against the full viewport rather than the scrollbar-
+    // reduced client width, with a one-pixel tolerance for sub-pixel rounding.
+    $overflow = (int) $session->evaluateScript('Math.ceil(document.documentElement.scrollWidth - window.innerWidth)');
+
+    if ($overflow > 1) {
+      throw new \Exception(sprintf('The page overflows horizontally by %dpx at %spx wide.', $overflow, $width));
+    }
+  }
+
 }

--- a/tests/behat/features/services_page.feature
+++ b/tests/behat/features/services_page.feature
@@ -1,0 +1,55 @@
+@p1 @drevops @services
+Feature: Services page
+
+  As a prospective client
+  I want a services page that explains each service in full
+  So that I can understand what DrevOps offers and how it is priced
+
+  @api
+  Scenario: The services page is assembled from the shared components in order
+    Given I am an anonymous user
+    When I go to "/services"
+    Then I should see an "article .component-hero.component-hero--inner" element
+    And I should see 3 ".component-service-detail" elements
+    And I should see an "article .ct-card-group.ct-card-group--cols-2" element
+    And I should see an "article .ct-cta" element
+    And I should not see a ".ct-banner" element
+    And the element ".component-service-detail" should appear after the element ".component-hero"
+    And the element ".ct-card-group" should appear after the element ".component-service-detail"
+    And the element ".ct-cta" should appear after the element ".ct-card-group"
+
+  @api
+  Scenario: Each service detail block shows its title, tagline, inclusions, pricing and action
+    Given I am an anonymous user
+    When I go to "/services"
+    Then I should see the text "Website Delivery"
+    And I should see the text "From requirements to production in one engagement."
+    And I should see the text "Architecture and technical planning"
+    And I should see the text "Fixed price, agreed up front"
+    And I should see the link "Discuss your project"
+    And I should see the text "Ongoing Support"
+    And I should see the text "Prepaid, month to month"
+    And I should see the text "Upgrades & Migrations"
+    And I should see the link "Book a free assessment"
+
+  @api
+  Scenario: The hero, approach list and call to action render in the dark scheme
+    Given I am an anonymous user
+    When I go to "/services"
+    Then I should see the text "What we do"
+    And I should see the text "Engineering that keeps your platform running."
+    And I should see an "article .component-hero.ct-theme-dark" element
+    And I should see the text "AI-accelerated delivery"
+    And I should see the text "Flat-rate pricing"
+    And I should see the text "Tested by default"
+    And I should see the text "Direct communication"
+    And I should see an "article .ct-card-group.ct-theme-dark" element
+    And I should see the text "Ready to talk about your platform?"
+    And I should see the link "Get in touch"
+    And I should see an "article .ct-cta.ct-theme-dark" element
+
+  @api @javascript
+  Scenario: The services page reflows without horizontal scrolling on a phone
+    Given I am an anonymous user
+    When I go to "/services"
+    Then the page has no horizontal overflow at 375 pixels wide

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -227,6 +227,208 @@ function do_base_deploy_homepage_blog_teaser(): string {
 }
 
 /**
+ * Seed the Services page assembled from the shared components.
+ */
+function do_base_deploy_seed_services_page(): string {
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  // Reassemble the existing Services page when present so its /services alias
+  // and revision history are preserved; create it only on a site that has none.
+  $existing = $node_storage->loadByProperties([
+    'type' => 'civictheme_page',
+    'title' => 'Services',
+  ]);
+  $node = $existing ? reset($existing) : $node_storage->create([
+    'type' => 'civictheme_page',
+    'title' => 'Services',
+    'status' => 1,
+    'path' => ['alias' => '/services', 'pathauto' => 0],
+  ]);
+
+  // The components the page carried before the rebuild are deleted afterwards
+  // so swapping the stack does not leave orphaned paragraphs behind.
+  $superseded = $node->get('field_c_n_components')->referencedEntities();
+
+  // Building, attaching and cleaning up run inside one transaction so a failure
+  // part way through rolls back rather than leaving half-saved paragraphs
+  // orphaned instead of attached to the page.
+  $transaction = \Drupal::database()->startTransaction();
+
+  try {
+    $components = _do_base_build_services_components();
+
+    $node->set('field_c_n_components', array_map(static fn (Paragraph $component): array => [
+      'target_id' => $component->id(),
+      'target_revision_id' => $component->getRevisionId(),
+    ], $components));
+    $node->save();
+
+    foreach ($superseded as $paragraph) {
+      $paragraph->delete();
+    }
+  }
+  catch (\Throwable $exception) {
+    $transaction->rollBack();
+
+    throw $exception;
+  }
+
+  return sprintf('Assembled the Services page (node %s) from %d components.', $node->id(), count($components));
+}
+
+/**
+ * Build and save the Services page components in their render order.
+ *
+ * @return \Drupal\paragraphs\Entity\Paragraph[]
+ *   The saved hero, service-detail, card-list and call-to-action paragraphs.
+ */
+function _do_base_build_services_components(): array {
+  $save_paragraph = static function (array $values): Paragraph {
+    $paragraph = Paragraph::create($values);
+    $paragraph->save();
+
+    return $paragraph;
+  };
+
+  $components = [];
+
+  $components[] = $save_paragraph([
+    'type' => 'hero',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_type' => 'inner',
+    'field_c_p_subtitle' => 'What we do',
+    'field_c_p_title' => 'Engineering that keeps your platform running.',
+    'field_c_p_summary' => "We build, support, and upgrade reliable websites for businesses and organisations that can't afford downtime, security gaps, or slow delivery. Now faster, with AI-assisted development at the same tested standard.",
+  ]);
+
+  $services = [
+    [
+      'title' => 'Website Delivery',
+      'tagline' => 'From requirements to production in one engagement.',
+      'description' => "<p>We build your site end to end, with automated testing and CI/CD baked in from the first commit. Architecture, development, design, and deployment handled together, so what launches is solid, not a prototype you'll be fixing after go-live.</p><p>AI-assisted delivery gets you there faster, at the same tested standard. Every project ships with a complete test suite, documentation, and a handover that actually works.</p>",
+      'includes' => [
+        'Architecture and technical planning',
+        'Custom design and development',
+        'Automated testing on every change',
+        'Continuous integration and deployment',
+        'Content migration and data import',
+        'Hosting setup and go-live support',
+      ],
+      'price_label' => 'Pricing',
+      'price' => 'Fixed price, agreed up front',
+      'action' => 'Discuss your project',
+    ],
+    [
+      'title' => 'Ongoing Support',
+      'tagline' => 'The people who built your site, keeping it running.',
+      'description' => '<p>Proactive maintenance from the people who built your site. Security updates, performance monitoring, and continuous improvement, all on a predictable prepaid arrangement.</p><p>No ticket queues, no outsourced support desks. You talk directly to the people who know your code.</p>',
+      'includes' => [
+        'Security patches and platform updates',
+        'Uptime and performance monitoring',
+        'Bug fixes and minor enhancements',
+        'Monthly reporting and recommendations',
+        'A direct line, no ticket queue',
+        'Priority response for critical issues',
+      ],
+      'price_label' => 'Support',
+      'price' => 'Prepaid, month to month',
+      'action' => 'Get a support quote',
+    ],
+    [
+      'title' => 'Upgrades & Migrations',
+      'tagline' => 'Move off end-of-life Drupal without breaking anything.',
+      'description' => '<p>Drupal 7 and 9 are end-of-life. Drupal 10 follows in December 2026. We handle the full migration with test coverage and zero-downtime deployments, so your organisation stays compliant and your users stay unaffected.</p><p>We assess your current platform, map out compatibility, migrate your custom code, and deliver an upgraded site with full test coverage, with AI speeding up the heavy lifting.</p>',
+      'includes' => [
+        'Platform audit and risk assessment',
+        'Module compatibility analysis',
+        'Custom code migration and refactoring',
+        'Data migration and content integrity checks',
+        'Automated test suite for the upgraded site',
+        'Zero-downtime deployment and rollback plan',
+      ],
+      'price_label' => 'Pricing',
+      'price' => 'Fixed price after a free assessment',
+      'action' => 'Book a free assessment',
+    ],
+  ];
+
+  foreach ($services as $service) {
+    $components[] = $save_paragraph([
+      'type' => 'service_detail',
+      'field_c_p_theme' => 'dark',
+      'field_c_p_title' => $service['title'],
+      'field_c_p_subtitle' => $service['tagline'],
+      'field_c_p_content' => [
+        'value' => $service['description'],
+        'format' => 'civictheme_rich_text',
+      ],
+      'field_p_includes' => $service['includes'],
+      'field_p_price_label' => $service['price_label'],
+      'field_p_price' => $service['price'],
+      'field_c_p_link' => [
+        'uri' => 'internal:/contact',
+        'title' => $service['action'],
+      ],
+    ]);
+  }
+
+  $approach = [
+    [
+      'title' => 'AI-accelerated delivery',
+      'description' => 'AI does the heavy lifting on production work, so you get the same tested quality in a fraction of the build time. Every change is still reviewed and tested before it ships.',
+    ],
+    [
+      'title' => 'Flat-rate pricing',
+      'description' => 'We quote a fixed price upfront. No hourly billing surprises, no retainer games, no scope creep charges.',
+    ],
+    [
+      'title' => 'Tested by default',
+      'description' => "Every platform ships with automated tests. If it's not tested, it doesn't deploy. No exceptions.",
+    ],
+    [
+      'title' => 'Direct communication',
+      'description' => 'You talk to the engineers building your site. No project managers relaying messages, no layers in between.',
+    ],
+  ];
+
+  $cards = [];
+  foreach ($approach as $point) {
+    $card = $save_paragraph([
+      'type' => 'card',
+      'field_c_p_type' => 'dot',
+      'field_c_p_theme' => 'dark',
+      'field_c_p_title' => $point['title'],
+      'field_c_p_summary' => $point['description'],
+    ]);
+
+    $cards[] = [
+      'target_id' => $card->id(),
+      'target_revision_id' => $card->getRevisionId(),
+    ];
+  }
+
+  $components[] = $save_paragraph([
+    'type' => 'card_group',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_list_column_count' => 2,
+    'field_c_p_list_items' => $cards,
+  ]);
+
+  $components[] = $save_paragraph([
+    'type' => 'cta',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_type' => 'display',
+    'field_title' => 'Ready to talk about your platform?',
+    'field_subtitle' => "Tell us where things stand. We'll be straight with you about whether we're the right fit.",
+    'field_link' => [
+      ['uri' => 'internal:/contact', 'title' => 'Get in touch'],
+    ],
+  ]);
+
+  return $components;
+}
+
+/**
  * Load the Blog topic term, creating it when the vocabulary allows.
  */
 function _do_base_ensure_blog_term(): ?TermInterface {

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -90,7 +90,12 @@ function _do_base_node_leads_with_hero(NodeInterface $node): bool {
     return FALSE;
   }
 
-  $first = $node->get('field_c_n_components')->referencedEntities()[0] ?? NULL;
+  $components = $node->get('field_c_n_components');
+  if ($components->isEmpty()) {
+    return FALSE;
+  }
+
+  $first = $components->first()->entity;
 
   return $first instanceof ParagraphInterface && $first->bundle() === 'hero';
 }

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -7,10 +7,16 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\block\BlockInterface;
 use Drupal\csp\Csp;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Allowed values for the shared paragraph component "type" selector.
@@ -52,6 +58,41 @@ function do_base_field_c_p_type_allowed_values(FieldStorageDefinitionInterface $
   }
 
   return $all;
+}
+
+/**
+ * Implements hook_block_access().
+ */
+function do_base_block_access(BlockInterface $block, string $operation, AccountInterface $account): AccessResultInterface {
+  if ($operation !== 'view' || $block->id() !== 'drevops_banner') {
+    return AccessResult::neutral();
+  }
+
+  // A hero-led page supplies its own heading through the hero component, so the
+  // CivicTheme title banner is hidden to avoid stacking a duplicate page title
+  // and breadcrumb above the hero. The decision varies per route and follows
+  // the node's component list, so both are recorded as cacheability metadata.
+  $route_match = \Drupal::routeMatch();
+  $node = $route_match->getParameter('node_revision') ?: $route_match->getParameter('node');
+
+  if ($node instanceof NodeInterface && _do_base_node_leads_with_hero($node)) {
+    return AccessResult::forbidden()->addCacheContexts(['route'])->addCacheableDependency($node);
+  }
+
+  return AccessResult::neutral()->addCacheContexts(['route']);
+}
+
+/**
+ * Checks whether a node's first layout component is a hero paragraph.
+ */
+function _do_base_node_leads_with_hero(NodeInterface $node): bool {
+  if (!$node->hasField('field_c_n_components')) {
+    return FALSE;
+  }
+
+  $first = $node->get('field_c_n_components')->referencedEntities()[0] ?? NULL;
+
+  return $first instanceof ParagraphInterface && $first->bundle() === 'hero';
 }
 
 /**

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -90,12 +90,7 @@ function _do_base_node_leads_with_hero(NodeInterface $node): bool {
     return FALSE;
   }
 
-  $components = $node->get('field_c_n_components');
-  if ($components->isEmpty()) {
-    return FALSE;
-  }
-
-  $first = $components->first()->entity;
+  $first = $node->get('field_c_n_components')->referencedEntities()[0] ?? NULL;
 
   return $first instanceof ParagraphInterface && $first->bundle() === 'hero';
 }


### PR DESCRIPTION
Closes #200

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#200] Verb in past tense.`
- [x] Ticket number `#200` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added `do_base_deploy_seed_services_page()` deploy hook in `do_base.deploy.php` that reassembles the `/services` page node (`civictheme_page`) idempotently from shared components: a dark-scheme inner hero, three service-detail paragraphs (Website Delivery, Ongoing Support, Upgrades & Migrations), a two-column card group ("Our approach"), and a closing CTA. The rebuild runs inside a database transaction and deletes superseded paragraphs, preserving the node's URL alias and revision history.
2. Added `do_base_block_access` hook and `_do_base_node_leads_with_hero()` helper in `do_base.module` that forbids the CivicTheme title banner block (`drevops_banner`) on any node whose first component is a hero paragraph, so the hero leads the page without a duplicate title and breadcrumb above it.
3. Added `tests/behat/features/services_page.feature` with four scenarios covering component assembly order, service-detail content, dark colour scheme, and mobile no-horizontal-overflow.
4. Added a reusable `the page has no horizontal overflow at :width pixels wide` Behat step to `FeatureContext.php` that resizes the browser and asserts `scrollWidth <= innerWidth` within one pixel of tolerance.

## Screenshots

![Services page](https://raw.githubusercontent.com/drevops/website/97a7d9860848688e0b2ba1e6091240a295562697/feature-200-services-page/57472a94ede811270db8bf79478c9db6897e9559.png)

## Known divergences from the prototype

- The Hero `inner` variant does not apply the accent colour the prototype shows on the heading's last phrase - this is a gap in the Hero component, owned by the Hero component story.
- The Card group component has no section-label slot, so the prototype's "Our approach" label above the card grid is absent - this is a gap in the Card group component, owned by its own story.

## Before / After

```
Before                                    After
┌─────────────────────────────────────┐   ┌─────────────────────────────────────┐
│  [CivicTheme title banner]          │   │  (banner suppressed - hero leads)   │
│  ┌───────────────────────────────┐  │   │  ┌───────────────────────────────┐  │
│  │  Manual list (single block)   │  │   │  │  Hero - inner / dark scheme   │  │
│  │  (no hero, no scheme)         │  │   │  │  "Engineering that keeps..."  │  │
│  └───────────────────────────────┘  │   │  └───────────────────────────────┘  │
└─────────────────────────────────────┘   │  ┌───────────────────────────────┐  │
                                          │  │  Service detail - dark        │  │
                                          │  │  Website Delivery             │  │
                                          │  ├───────────────────────────────┤  │
                                          │  │  Service detail - dark        │  │
                                          │  │  Ongoing Support              │  │
                                          │  ├───────────────────────────────┤  │
                                          │  │  Service detail - dark        │  │
                                          │  │  Upgrades & Migrations        │  │
                                          │  └───────────────────────────────┘  │
                                          │  ┌───────────────────────────────┐  │
                                          │  │  Card group (2-col) - dark    │  │
                                          │  │  AI-accel · Flat-rate         │  │
                                          │  │  Tested · Direct comms        │  │
                                          │  └───────────────────────────────┘  │
                                          │  ┌───────────────────────────────┐  │
                                          │  │  CTA - dark                   │  │
                                          │  │  "Ready to talk..."           │  │
                                          │  └───────────────────────────────┘  │
                                          └─────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services page now displays hero, service details, approach information, and calls-to-action sections.
  * Smart banner visibility prevents duplication on pages with hero sections.

* **Tests**
  * Added comprehensive tests for Services page layout, design themes, and mobile responsiveness.
  * Validates proper content display and no horizontal scroll issues on all viewport widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->