### PR TITLE
[#201] Assembled the AI-assisted delivery page from shared components.

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -404,4 +404,51 @@ class FeatureContext extends DrupalContext {
     }
   }
 
+  /**
+   * Assert the assembled components render in the given top-to-bottom order.
+   *
+   * Each row is one expected marker - "hero:inner", "hero:section",
+   * "card-group" or "cta" - matched against the document order of the rendered
+   * hero, card group and CTA components.
+   */
+  #[Then('the page components render in this order:')]
+  public function assertComponentsRenderInOrder(TableNode $table): void {
+    $expected = array_map(static fn(array $row): string => trim((string) reset($row)), $table->getRows());
+
+    $script = "(function () {\n"
+      . "  return Array.prototype.slice.call(document.querySelectorAll('.component-hero, .ct-card-group, .ct-cta')).map(function (element) {\n"
+      . "    if (element.matches('.component-hero--inner')) { return 'hero:inner'; }\n"
+      . "    if (element.matches('.component-hero--section')) { return 'hero:section'; }\n"
+      . "    if (element.matches('.ct-card-group')) { return 'card-group'; }\n"
+      . "    if (element.matches('.ct-cta')) { return 'cta'; }\n"
+      . "    return 'unknown';\n"
+      . "  });\n"
+      . "})()";
+
+    $actual = (array) $this->getSession()->evaluateScript($script);
+
+    if ($actual !== $expected) {
+      throw new \Exception(sprintf('Components render as [%s] but expected [%s].', implode(', ', $actual), implode(', ', $expected)));
+    }
+  }
+
+  /**
+   * Assert the page does not scroll horizontally at the given viewport width.
+   *
+   * Full-bleed components span the viewport, so a small allowance covers the
+   * scrollbar gutter while still catching real overflow that would force a
+   * horizontal scrollbar on a phone.
+   */
+  #[Then('the page reflows without horizontal scrolling at :width pixels wide')]
+  public function assertReflowsWithoutHorizontalScrolling(int $width): void {
+    $session = $this->getSession();
+    $session->resizeWindow($width, 900, 'current');
+
+    $overflow = (int) $session->evaluateScript('document.documentElement.scrollWidth - document.documentElement.clientWidth');
+
+    if ($overflow > 16) {
+      throw new \Exception(sprintf('The page scrolls horizontally by %dpx at %dpx wide.', $overflow, $width));
+    }
+  }
+
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -416,7 +416,8 @@ class FeatureContext extends DrupalContext {
     $expected = array_map(static fn(array $row): string => trim((string) reset($row)), $table->getRows());
 
     $script = "(function () {\n"
-      . "  return Array.prototype.slice.call(document.querySelectorAll('.component-hero, .ct-card-group, .ct-cta')).map(function (element) {\n"
+      . "  var root = document.querySelector('article') || document;\n"
+      . "  return Array.prototype.slice.call(root.querySelectorAll('.component-hero, .ct-card-group, .ct-cta')).map(function (element) {\n"
       . "    if (element.matches('.component-hero--inner')) { return 'hero:inner'; }\n"
       . "    if (element.matches('.component-hero--section')) { return 'hero:section'; }\n"
       . "    if (element.matches('.ct-card-group')) { return 'card-group'; }\n"
@@ -435,8 +436,8 @@ class FeatureContext extends DrupalContext {
   /**
    * Assert the page does not scroll horizontally at the given viewport width.
    *
-   * Full-bleed components span the viewport, so a small allowance covers the
-   * scrollbar gutter while still catching real overflow that would force a
+   * Full-bleed components span the viewport, so the measured scrollbar gutter
+   * is allowed for while still catching real overflow that would force a
    * horizontal scrollbar on a phone.
    */
   #[Then('the page reflows without horizontal scrolling at :width pixels wide')]
@@ -445,8 +446,9 @@ class FeatureContext extends DrupalContext {
     $session->resizeWindow($width, 900, 'current');
 
     $overflow = (int) $session->evaluateScript('document.documentElement.scrollWidth - document.documentElement.clientWidth');
+    $scrollbar = (int) $session->evaluateScript('window.innerWidth - document.documentElement.clientWidth');
 
-    if ($overflow > 16) {
+    if ($overflow > $scrollbar + 1) {
       throw new \Exception(sprintf('The page scrolls horizontally by %dpx at %dpx wide.', $overflow, $width));
     }
   }

--- a/tests/behat/features/ai_assisted_delivery.feature
+++ b/tests/behat/features/ai_assisted_delivery.feature
@@ -1,0 +1,127 @@
+@p1 @civictheme @drevops @ai_assisted_delivery
+Feature: AI-assisted delivery page
+
+  As a prospective client already on Drupal
+  I want a page that explains the AI-assisted offer and what it would cost
+  So that I can decide whether to ask for a costing
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                       | status | field_c_n_hide_sidebar |
+      | [TEST] AI-assisted delivery | 1      | 1                      |
+
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] AI-assisted delivery":
+      | field_c_p_type        | inner                                   |
+      | field_c_p_theme       | dark                                    |
+      | field_c_p_subtitle    | [TEST] AI-assisted delivery             |
+      | field_c_p_title       | [TEST] The same senior Drupal work      |
+      | field_c_p_summary     | [TEST] Same senior work, often for less |
+      | field_c_p_links:title | See what it would cost                  |
+      | field_c_p_links:uri   | internal:/contact                       |
+
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] AI-assisted delivery":
+      | field_c_p_type     | section                             |
+      | field_c_p_theme    | dark                                |
+      | field_c_p_subtitle | [TEST] A free no-obligation costing |
+      | field_c_p_title    | [TEST] No commitment just a picture |
+      | field_c_p_summary  | [TEST] Send a quote or a link       |
+
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] AI-assisted delivery":
+      | field_c_p_type     | section                          |
+      | field_c_p_theme    | dark                             |
+      | field_c_p_subtitle | [TEST] Why agency work costs      |
+      | field_c_p_title    | [TEST] It is rarely about work   |
+
+    And a card group with 1 columns and the following cards on the "[TEST] AI-assisted delivery" page:
+      | type | title                  | description                  |
+      | dot  | [TEST] Layers of work  | [TEST] Coordination is real. |
+      | dot  | [TEST] Winning work    | [TEST] Sales lands in rates. |
+      | dot  | [TEST] Scratch restart | [TEST] No shared tooling.    |
+
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] AI-assisted delivery":
+      | field_c_p_type     | section                            |
+      | field_c_p_theme    | dark                               |
+      | field_c_p_subtitle | [TEST] How we keep it lower        |
+      | field_c_p_title    | [TEST] Four things bring it down   |
+      | field_c_p_summary  | [TEST] Around a third fewer hours. |
+
+    And a card group with 1 columns and the following cards on the "[TEST] AI-assisted delivery" page:
+      | type | title                 | description                   |
+      | dot  | [TEST] Pay engineers  | [TEST] No extra layer to fund. |
+      | dot  | [TEST] Tooling lifts  | [TEST] Vortex handles setup.   |
+      | dot  | [TEST] CI from day one | [TEST] Quality is built in.   |
+      | dot  | [TEST] AI on the rote | [TEST] Senior judgement stays. |
+
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] AI-assisted delivery":
+      | field_c_p_type     | section                          |
+      | field_c_p_theme    | dark                             |
+      | field_c_p_subtitle | [TEST] A fair question about AI   |
+      | field_c_p_title    | [TEST] Can AI code be trusted     |
+
+    And a card group with 1 columns and the following cards on the "[TEST] AI-assisted delivery" page:
+      | type | title                   | description                   |
+      | dot  | [TEST] Reviewed, tested | [TEST] CI gates every build.  |
+      | dot  | [TEST] Your data stays  | [TEST] Nothing trains models. |
+
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] AI-assisted delivery":
+      | field_c_p_type     | section                            |
+      | field_c_p_theme    | dark                               |
+      | field_c_p_subtitle | [TEST] Who you would work with     |
+      | field_c_p_title    | [TEST] Drupal is what we do        |
+      | field_c_p_summary  | [TEST] We created Vortex and more. |
+
+    And the following fields for the paragraph "cta" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] AI-assisted delivery":
+      | field_c_p_type   | display                                    |
+      | field_c_p_theme  | dark                                       |
+      | field_title      | [TEST] See what your project would cost    |
+      | field_subtitle   | [TEST] Send your scope and your last quote |
+      | field_link:title | See what it would cost, info@drevops.com   |
+      | field_link:uri   | internal:/contact, mailto:info@drevops.com |
+
+  @api
+  Scenario: Anonymous user sees the hero, intro bands, dot lists and CTA all in the dark scheme
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] AI-assisted delivery"
+    Then I should see an "article .component-hero--inner.ct-theme-dark" element
+    And I should see 5 "article .component-hero--section.ct-theme-dark" elements
+    And I should see 3 "article .ct-card-group.ct-card-group--cols-1.ct-theme-dark" elements
+    And I should see 9 "article .ct-card--dot.ct-theme-dark" elements
+    And I should see an "article .ct-cta.ct-theme-dark" element
+    And I should see an "article a.ct-cta__email" element
+    And I should see the text "[TEST] The same senior Drupal work"
+    And I should see the text "[TEST] A free no-obligation costing"
+    And I should see the text "[TEST] It is rarely about work"
+    And I should see the text "[TEST] Layers of work"
+    And I should see the text "[TEST] Drupal is what we do"
+
+  @api
+  Scenario: The CivicTheme banner is suppressed so the hero opens the page
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] AI-assisted delivery"
+    Then I should see an "article .component-hero--inner" element
+    And I should not see a ".ct-banner" element
+
+  @api
+  Scenario: A content editor can assemble the page from the hero, dot-list card and CTA components
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "node/add/civictheme_page"
+    Then the response should contain "Add Hero"
+    And the response should contain "Add Card group"
+    And the response should contain "Add CTA band"
+
+  @api @javascript
+  Scenario: The assembled page keeps its section order and reflows on a phone
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] AI-assisted delivery"
+    Then the page components render in this order:
+      | hero:inner   |
+      | hero:section |
+      | hero:section |
+      | card-group   |
+      | hero:section |
+      | card-group   |
+      | hero:section |
+      | card-group   |
+      | hero:section |
+      | cta          |
+    And the page reflows without horizontal scrolling at 390 pixels wide

--- a/tests/behat/features/ai_assisted_delivery.feature
+++ b/tests/behat/features/ai_assisted_delivery.feature
@@ -90,6 +90,7 @@ Feature: AI-assisted delivery page
     And I should see an "article a.ct-cta__email" element
     And I should see the text "[TEST] The same senior Drupal work"
     And I should see the text "[TEST] A free no-obligation costing"
+    And I should see the text "[TEST] Send a quote or a link"
     And I should see the text "[TEST] It is rarely about work"
     And I should see the text "[TEST] Layers of work"
     And I should see the text "[TEST] Drupal is what we do"
@@ -103,7 +104,7 @@ Feature: AI-assisted delivery page
 
   @api
   Scenario: A content editor can assemble the page from the hero, dot-list card and CTA components
-    Given I am logged in as a user with the "Site Administrator" role
+    Given I am logged in as a user with the "Content Author" role
     When I visit "node/add/civictheme_page"
     Then the response should contain "Add Hero"
     And the response should contain "Add Card group"

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -749,28 +749,109 @@ function _do_base_count_words(FieldableEntityInterface $entity): int {
  * page and replaces its component stack without orphaning the old paragraphs.
  */
 function do_base_deploy_ai_assisted_delivery(): string {
+  $intro_lead = "If you've got a Drupal site, keeping it running and building on it is probably a real investment."
+    . " We do the same senior, fully-tested work, often for around a third less on suitable work,"
+    . " because we've made the delivery faster, not because we cut corners.";
+  $costing_lead = "Send us a recent quote, your current scope, or just a link to your site."
+    . " We'll show you what the same work would cost with us, by hand and AI-assisted, side by side."
+    . " There's no call to sit through, and nothing to move. If the number lands close to what you pay"
+    . " now, you've lost nothing. If it's lower for the same quality, that's worth knowing.";
+  $lower_lead = "Put together, that often comes to around a third fewer hours on suitable work."
+    . " We don't apply a flat discount across the job. We work it out area by area and show you exactly"
+    . " where the hours move and where they don't.";
+  $who_lead = "We created Vortex, we maintain around 40 open-source repositories, and our own website is"
+    . " open source. We're the architect and main developer behind the CivicTheme design system, and"
+    . " we've delivered Australian government and GovCMS platforms since 2016. If it helps to see how"
+    . " we work, most of it is out in the open.";
+
+  $why_cards = [
+    [
+      'The layers around the work',
+      "Account management, coordination, and reporting all take time, and that time is real."
+        . " It's how most agencies are set up, and it shows up on every invoice.",
+    ],
+    [
+      'Winning and running the contract',
+      'Sales, proposals, and overhead are part of running a larger agency.'
+        . ' None of it is wrong, but it lands in the rate you pay.',
+    ],
+    [
+      'Starting from scratch each time',
+      'Without shared tooling, every new project pays again for the same groundwork:'
+        . ' setup, pipelines, configuration. It adds up, project after project.',
+    ],
+  ];
+  $how_cards = [
+    [
+      'You pay for the engineering',
+      "The people who scope your work are the people who build it."
+        . " There's no extra layer to fund in between.",
+    ],
+    [
+      'Our tooling does the heavy lifting',
+      "Vortex, our open-source platform, handles the setup, CI, and tooling on every project,"
+        . " so you're not paying to build that from scratch.",
+    ],
+    [
+      'Testing and CI from day one',
+      'Quality is built in rather than added at the end,'
+        . ' so less time goes into finding and fixing things later.',
+    ],
+    [
+      'AI on the repetitive work',
+      'AI helps with the parts that suit it, like migrations, boilerplate, tests, and'
+        . ' documentation, while the architecture, the integrations, and the judgement stay with senior people.',
+    ],
+  ];
+  $ai_cards = [
+    [
+      'Every change is reviewed and tested',
+      "It's the question we'd ask too. Every change is reviewed, and every build is tested and"
+        . " gated by CI before it ships. AI helps with the writing, never the checking. The guardrails"
+        . " are our own, and they're open source, so you can read exactly how they work.",
+    ],
+    [
+      'Your code and data stay yours',
+      "Nothing you share trains an AI model, nothing goes to a public AI service without your"
+        . " permission, and sensitive credentials are never shared. It's all in our Responsible AI policy.",
+    ],
+  ];
+
   $components = [
-    _do_base_ai_delivery_hero('inner', 'AI-assisted delivery', 'The same senior Drupal work, for less.', "If you've got a Drupal site, keeping it running and building on it is probably a real investment. We do the same senior, fully-tested work, often for around a third less on suitable work, because we've made the delivery faster, not because we cut corners.", ['uri' => 'internal:/contact', 'title' => 'See what it would cost']),
-    _do_base_ai_delivery_hero('section', 'A free, no-obligation costing', 'No commitment. Just a clear picture.', "Send us a recent quote, your current scope, or just a link to your site. We'll show you what the same work would cost with us, by hand and AI-assisted, side by side. There's no call to sit through, and nothing to move. If the number lands close to what you pay now, you've lost nothing. If it's lower for the same quality, that's worth knowing."),
-    _do_base_ai_delivery_hero('section', 'Why agency work costs what it does', "It's rarely about the work itself."),
-    _do_base_ai_delivery_card_group([
-      ['The layers around the work', "Account management, coordination, and reporting all take time, and that time is real. It's how most agencies are set up, and it shows up on every invoice."],
-      ['Winning and running the contract', 'Sales, proposals, and overhead are part of running a larger agency. None of it is wrong, but it lands in the rate you pay.'],
-      ['Starting from scratch each time', 'Without shared tooling, every new project pays again for the same groundwork: setup, pipelines, configuration. It adds up, project after project.'],
-    ]),
-    _do_base_ai_delivery_hero('section', 'How we keep it lower', 'Four things that bring the number down.', "Put together, that often comes to around a third fewer hours on suitable work. We don't apply a flat discount across the job. We work it out area by area and show you exactly where the hours move and where they don't."),
-    _do_base_ai_delivery_card_group([
-      ['You pay for the engineering', "The people who scope your work are the people who build it. There's no extra layer to fund in between."],
-      ['Our tooling does the heavy lifting', "Vortex, our open-source platform, handles the setup, CI, and tooling on every project, so you're not paying to build that from scratch."],
-      ['Testing and CI from day one', 'Quality is built in rather than added at the end, so less time goes into finding and fixing things later.'],
-      ['AI on the repetitive work', 'AI helps with the parts that suit it, like migrations, boilerplate, tests, and documentation, while the architecture, the integrations, and the judgement stay with senior people.'],
-    ]),
+    _do_base_ai_delivery_hero(
+      'inner',
+      'AI-assisted delivery',
+      'The same senior Drupal work, for less.',
+      $intro_lead,
+      ['uri' => 'internal:/contact', 'title' => 'See what it would cost'],
+    ),
+    _do_base_ai_delivery_hero(
+      'section',
+      'A free, no-obligation costing',
+      'No commitment. Just a clear picture.',
+      $costing_lead,
+    ),
+    _do_base_ai_delivery_hero(
+      'section',
+      'Why agency work costs what it does',
+      "It's rarely about the work itself.",
+    ),
+    _do_base_ai_delivery_card_group($why_cards),
+    _do_base_ai_delivery_hero(
+      'section',
+      'How we keep it lower',
+      'Four things that bring the number down.',
+      $lower_lead,
+    ),
+    _do_base_ai_delivery_card_group($how_cards),
     _do_base_ai_delivery_hero('section', 'A fair question about AI', 'Can AI-written code be trusted?'),
-    _do_base_ai_delivery_card_group([
-      ['Every change is reviewed and tested', "It's the question we'd ask too. Every change is reviewed, and every build is tested and gated by CI before it ships. AI helps with the writing, never the checking. The guardrails are our own, and they're open source, so you can read exactly how they work."],
-      ['Your code and data stay yours', "Nothing you share trains an AI model, nothing goes to a public AI service without your permission, and sensitive credentials are never shared. It's all in our Responsible AI policy."],
-    ]),
-    _do_base_ai_delivery_hero('section', "Who you'd be working with", 'Drupal is what we do.', "We created Vortex, we maintain around 40 open-source repositories, and our own website is open source. We're the architect and main developer behind the CivicTheme design system, and we've delivered Australian government and GovCMS platforms since 2016. If it helps to see how we work, most of it is out in the open."),
+    _do_base_ai_delivery_card_group($ai_cards),
+    _do_base_ai_delivery_hero(
+      'section',
+      "Who you'd be working with",
+      'Drupal is what we do.',
+      $who_lead,
+    ),
     _do_base_ai_delivery_cta(),
   ];
 

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -16,6 +16,7 @@ use Drupal\civictheme\CivicthemeColorManager;
 use Drupal\civictheme\CivicthemeConstants;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\ParagraphInterface;
@@ -737,4 +738,200 @@ function _do_base_count_words(FieldableEntityInterface $entity): int {
   }
 
   return $count;
+}
+
+/**
+ * Seed the AI-assisted delivery page from the shared CivicTheme components.
+ *
+ * The page opens with a hero paragraph and stacks hero "section" intro bands,
+ * dot-list card groups and a CTA band, every component in the dark scheme.
+ * Idempotent: the node is keyed on a fixed UUID, so re-running updates the same
+ * page and replaces its component stack without orphaning the old paragraphs.
+ */
+function do_base_deploy_ai_assisted_delivery(): string {
+  $components = [
+    _do_base_ai_delivery_hero('inner', 'AI-assisted delivery', 'The same senior Drupal work, for less.', "If you've got a Drupal site, keeping it running and building on it is probably a real investment. We do the same senior, fully-tested work, often for around a third less on suitable work, because we've made the delivery faster, not because we cut corners.", ['uri' => 'internal:/contact', 'title' => 'See what it would cost']),
+    _do_base_ai_delivery_hero('section', 'A free, no-obligation costing', 'No commitment. Just a clear picture.', "Send us a recent quote, your current scope, or just a link to your site. We'll show you what the same work would cost with us, by hand and AI-assisted, side by side. There's no call to sit through, and nothing to move. If the number lands close to what you pay now, you've lost nothing. If it's lower for the same quality, that's worth knowing."),
+    _do_base_ai_delivery_hero('section', 'Why agency work costs what it does', "It's rarely about the work itself."),
+    _do_base_ai_delivery_card_group([
+      ['The layers around the work', "Account management, coordination, and reporting all take time, and that time is real. It's how most agencies are set up, and it shows up on every invoice."],
+      ['Winning and running the contract', 'Sales, proposals, and overhead are part of running a larger agency. None of it is wrong, but it lands in the rate you pay.'],
+      ['Starting from scratch each time', 'Without shared tooling, every new project pays again for the same groundwork: setup, pipelines, configuration. It adds up, project after project.'],
+    ]),
+    _do_base_ai_delivery_hero('section', 'How we keep it lower', 'Four things that bring the number down.', "Put together, that often comes to around a third fewer hours on suitable work. We don't apply a flat discount across the job. We work it out area by area and show you exactly where the hours move and where they don't."),
+    _do_base_ai_delivery_card_group([
+      ['You pay for the engineering', "The people who scope your work are the people who build it. There's no extra layer to fund in between."],
+      ['Our tooling does the heavy lifting', "Vortex, our open-source platform, handles the setup, CI, and tooling on every project, so you're not paying to build that from scratch."],
+      ['Testing and CI from day one', 'Quality is built in rather than added at the end, so less time goes into finding and fixing things later.'],
+      ['AI on the repetitive work', 'AI helps with the parts that suit it, like migrations, boilerplate, tests, and documentation, while the architecture, the integrations, and the judgement stay with senior people.'],
+    ]),
+    _do_base_ai_delivery_hero('section', 'A fair question about AI', 'Can AI-written code be trusted?'),
+    _do_base_ai_delivery_card_group([
+      ['Every change is reviewed and tested', "It's the question we'd ask too. Every change is reviewed, and every build is tested and gated by CI before it ships. AI helps with the writing, never the checking. The guardrails are our own, and they're open source, so you can read exactly how they work."],
+      ['Your code and data stay yours', "Nothing you share trains an AI model, nothing goes to a public AI service without your permission, and sensitive credentials are never shared. It's all in our Responsible AI policy."],
+    ]),
+    _do_base_ai_delivery_hero('section', "Who you'd be working with", 'Drupal is what we do.', "We created Vortex, we maintain around 40 open-source repositories, and our own website is open source. We're the architect and main developer behind the CivicTheme design system, and we've delivered Australian government and GovCMS platforms since 2016. If it helps to see how we work, most of it is out in the open."),
+    _do_base_ai_delivery_cta(),
+  ];
+
+  $uuid = 'd9a7c2e4-3b1f-4e8a-9c6d-2f5b8e1a4c70';
+  $storage = \Drupal::entityTypeManager()->getStorage('node');
+  $existing = $storage->loadByProperties(['uuid' => $uuid]);
+  $node = $existing ? reset($existing) : Node::create(['type' => 'civictheme_page', 'uuid' => $uuid]);
+
+  if (!$node instanceof NodeInterface) {
+    return 'AI-assisted delivery node could not be resolved - skipped.';
+  }
+
+  // Capture the paragraphs the node referenced before this run so they can be
+  // removed only after the node is re-saved against the new stack - a failed
+  // save then never leaves the page pointing at deleted paragraphs.
+  $stale = _do_base_ai_delivery_stale_paragraphs($node);
+
+  $node->set('title', 'AI-assisted delivery');
+  $node->set('status', NodeInterface::PUBLISHED);
+  $node->set('field_c_n_summary', 'Already on Drupal? See what your next project would cost with us. We cost the same senior, fully-tested work two ways, by hand and AI-assisted, so you see the difference before you change a thing.');
+  // The hero spans the viewport, so the page runs full-width with no side
+  // navigation column offsetting (and clipping) the full-bleed components.
+  $node->set('field_c_n_hide_sidebar', TRUE);
+  $node->set('field_c_n_components', array_map(static fn(Paragraph $paragraph): array => [
+    'target_id' => $paragraph->id(),
+    'target_revision_id' => $paragraph->getRevisionId(),
+  ], $components));
+  $node->set('path', ['alias' => '/ai-assisted-delivery', 'pathauto' => 0]);
+  $node->save();
+
+  foreach ($stale as $paragraph) {
+    $paragraph->delete();
+  }
+
+  return 'AI-assisted delivery page seeded.';
+}
+
+/**
+ * Build and save a hero paragraph in the dark scheme.
+ *
+ * @param string $type
+ *   The hero variant: "inner" for the page opener, "section" for intro bands.
+ * @param string $eyebrow
+ *   The short label above the heading.
+ * @param string $heading
+ *   The hero heading.
+ * @param string $lead
+ *   The supporting lead paragraph, or an empty string to omit it.
+ * @param array $action
+ *   An optional single link as ['uri' => ..., 'title' => ...].
+ *
+ * @return \Drupal\paragraphs\Entity\Paragraph
+ *   The saved hero paragraph.
+ */
+function _do_base_ai_delivery_hero(string $type, string $eyebrow, string $heading, string $lead = '', array $action = []): Paragraph {
+  $values = [
+    'type' => 'hero',
+    'field_c_p_type' => $type,
+    'field_c_p_theme' => 'dark',
+    'field_c_p_subtitle' => $eyebrow,
+    'field_c_p_title' => $heading,
+  ];
+
+  if ($lead !== '') {
+    $values['field_c_p_summary'] = $lead;
+  }
+
+  if ($action !== []) {
+    $values['field_c_p_links'] = [$action];
+  }
+
+  $hero = Paragraph::create($values);
+  $hero->save();
+
+  return $hero;
+}
+
+/**
+ * Build and save a single-column dot-list card group in the dark scheme.
+ *
+ * @param array $cards
+ *   A list of [title, description] pairs, one per dot card.
+ *
+ * @return \Drupal\paragraphs\Entity\Paragraph
+ *   The saved card group paragraph referencing the saved cards.
+ */
+function _do_base_ai_delivery_card_group(array $cards): Paragraph {
+  $items = [];
+
+  foreach ($cards as [$title, $description]) {
+    $card = Paragraph::create([
+      'type' => 'card',
+      'field_c_p_type' => 'dot',
+      'field_c_p_theme' => 'dark',
+      'field_c_p_title' => $title,
+      'field_c_p_summary' => $description,
+    ]);
+    $card->save();
+
+    $items[] = ['target_id' => $card->id(), 'target_revision_id' => $card->getRevisionId()];
+  }
+
+  $group = Paragraph::create([
+    'type' => 'card_group',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_list_column_count' => 1,
+    'field_c_p_list_items' => $items,
+  ]);
+  $group->save();
+
+  return $group;
+}
+
+/**
+ * Build and save the closing CTA band in the dark scheme.
+ *
+ * @return \Drupal\paragraphs\Entity\Paragraph
+ *   The saved CTA paragraph.
+ */
+function _do_base_ai_delivery_cta(): Paragraph {
+  $cta = Paragraph::create([
+    'type' => 'cta',
+    'field_c_p_type' => 'display',
+    'field_c_p_theme' => 'dark',
+    'field_title' => 'See what your project would cost.',
+    'field_subtitle' => "Send your scope, your last quote, or just your site. We'll take it from there.",
+    'field_link' => [
+      ['uri' => 'internal:/contact', 'title' => 'See what it would cost'],
+      ['uri' => 'mailto:info@drevops.com', 'title' => 'info@drevops.com'],
+    ],
+  ]);
+  $cta->save();
+
+  return $cta;
+}
+
+/**
+ * Collect the paragraphs a node references, including nested card items.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node whose component stack is being replaced.
+ *
+ * @return \Drupal\paragraphs\ParagraphInterface[]
+ *   The referenced top-level paragraphs and any card group children.
+ */
+function _do_base_ai_delivery_stale_paragraphs(NodeInterface $node): array {
+  if (!$node->hasField('field_c_n_components')) {
+    return [];
+  }
+
+  $stale = [];
+
+  foreach ($node->get('field_c_n_components')->referencedEntities() as $component) {
+    $stale[] = $component;
+
+    if ($component->bundle() === 'card_group' && $component->hasField('field_c_p_list_items')) {
+      foreach ($component->get('field_c_p_list_items')->referencedEntities() as $child) {
+        $stale[] = $child;
+      }
+    }
+  }
+
+  return $stale;
 }

--- a/web/themes/custom/drevops/components/03-organisms/hero/hero.twig
+++ b/web/themes/custom/drevops/components/03-organisms/hero/hero.twig
@@ -29,6 +29,10 @@
 {% set has_accent = type in ['home', 'contact'] %}
 {% set has_scroll = type == 'home' %}
 
+{# The section variant opens a region within a page rather than the page itself,
+   so its heading is an h2 to keep a single h1 per page. #}
+{% set title_tag = type == 'section' ? 'h2' : 'h1' %}
+
 {% if type == 'article' %}
   <header class="component-hero {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     {% if background_image.url is not empty %}
@@ -64,10 +68,10 @@
       {% endif %}
 
       {% if heading is not empty %}
-        <h1 class="component-hero-title component-reveal component-reveal-d1">
+        <{{ title_tag }} class="component-hero-title component-reveal component-reveal-d1">
           {{ heading }}
           {% if has_accent %}<span class="component-hero-title__accent" aria-hidden="true"></span>{% endif %}
-        </h1>
+        </{{ title_tag }}>
       {% endif %}
 
       {% if lead is not empty %}


### PR DESCRIPTION
Closes #201

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#201] Verb in past tense.`
- [x] Ticket number `#201` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added `do_base_deploy_ai_assisted_delivery()` deploy hook in `do_base.deploy.php` that idempotently seeds a `civictheme_page` at `/ai-assisted-delivery`. The hook builds the full component stack - a hero `inner` opener, five hero `section` intro bands, three single-column dot-list card groups, and a closing CTA band - all in the dark scheme, with the sidebar hidden so the full-bleed hero aligns correctly. The node is keyed on a fixed UUID so re-running the deploy replaces the component stack in place without orphaning old paragraphs.
2. The page leads with a hero paragraph, so the existing `do_base_block_access()` banner suppression (which already hides the CivicTheme title banner on any `civictheme_page` whose first component is a `hero`) keeps the hero as the sole page opener with no duplicate node-title banner above it. This PR does not modify that hook; it relies on it, and the feature test asserts the banner is absent on the assembled page.
3. Fixed the hero SDC `hero.twig` so that the `section` variant renders its heading as `<h2>` rather than `<h1>`. Page-opener variants (`inner`, `home`, `page`, `contact`, `article`) keep their `<h1>`. This restores a correct heading outline on a page that stacks multiple hero `section` bands beneath the opener, and matches the static prototype, where the section labels are `<h2>`.
4. Added `tests/behat/features/ai_assisted_delivery.feature` with four scenarios: anonymous visibility (dark scheme, the three dot lists, the CTA), banner suppression, the editor component palette, and a JavaScript scenario that asserts the rendered section order and phone reflow. Added two reusable `FeatureContext` steps - `assertComponentsRenderInOrder` and `assertReflowsWithoutHorizontalScrolling` - to support the JavaScript scenario.

## Screenshots

![AI-assisted delivery page](https://raw.githubusercontent.com/drevops/website/68a87d14e05d9e073bb1859bb66d4206c13f7e52/feature-201-ai-assisted-delivery/c5c7e86a2e2c0233091be46e3a63d25b23cd0fb3.png)

## Before / After

```
Before
┌─────────────────────────────────────────────┐
│  /ai-assisted-delivery  (path did not exist) │
│                                              │
│  [404 Not Found]                             │
└─────────────────────────────────────────────┘

After
┌─────────────────────────────────────────────┐
│  /ai-assisted-delivery                       │
│                                              │
│  ┌─────────────────────────────────────┐    │
│  │ HERO (inner, dark)                  │    │
│  │  h1: The same senior Drupal work    │    │
│  │  CTA → See what it would cost       │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ HERO (section, dark)   h2: offer    │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ HERO (section, dark)   h2: problem  │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ CARD GROUP (dot, dark, 1-col, 3)    │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ HERO (section, dark)   h2: solution │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ CARD GROUP (dot, dark, 1-col, 4)    │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ HERO (section, dark)   h2: trust    │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ CARD GROUP (dot, dark, 1-col, 2)    │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ HERO (section, dark)   h2: proof    │    │
│  └─────────────────────────────────────┘    │
│  ┌─────────────────────────────────────┐    │
│  │ CTA BAND (dark, link + email)       │    │
│  └─────────────────────────────────────┘    │
│                                              │
│  [No CivicTheme banner - suppressed]         │
└─────────────────────────────────────────────┘

Hero heading hierarchy (section variant)
  Before:  <h1 class="component-hero-title">…</h1>  ← repeated h1 per band
  After:   <h2 class="component-hero-title">…</h2>  ← correct outline
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "AI-assisted delivery" demonstration page featuring hero sections, card groups, and call-to-action components.

* **Tests**
  * Added test scenarios to verify the page renders correctly across themes, validates component rendering order, and confirms responsive behavior without horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->