### PR TITLE
[#202] Assembled the blog landing and a sample blog post.

### DIFF
--- a/tests/behat/features/blog.feature
+++ b/tests/behat/features/blog.feature
@@ -39,3 +39,21 @@ Feature: Blog listing and homepage teaser
     Then I should see "From the blog"
     And I should see "All articles"
     And the response should contain "ct-promo-card"
+
+  @api
+  Scenario: The blog landing opens with the page hero and hides the legacy banner
+    Given the following "civictheme_page" content:
+      | title               | status |
+      | [TEST] Blog Landing | 1      |
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Blog Landing":
+      | field_c_p_type     | page                      |
+      | field_c_p_theme    | dark                      |
+      | field_c_p_subtitle | [TEST] Blog               |
+      | field_c_p_title    | [TEST] Practical insights |
+    And I am an anonymous user
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Blog Landing"
+    Then I should see an "article .component-hero.component-hero--page" element
+    And I should see an "article .component-hero--page .component-hero-eyebrow" element
+    And I should see "[TEST] Practical insights"
+    And I should not see an ".ct-banner" element

--- a/tests/behat/features/blog_post.feature
+++ b/tests/behat/features/blog_post.feature
@@ -6,9 +6,11 @@ Feature: Blog post assembly
   So that I can read DrevOps articles in context
 
   Background:
+    # The "Blog" topic is provisioned by a deploy hook and shared across the
+    # listing tests, so it is referenced rather than created here to avoid its
+    # teardown removing the seeded term.
     Given the following "civictheme_topics" terms:
       | name           |
-      | Blog           |
       | [TEST] Topic A |
       | [TEST] Topic B |
 
@@ -59,6 +61,7 @@ Feature: Blog post assembly
     And I should see an "article .component-hero__tags .ct-tag" element
     And I should see "[TEST] Topic A"
     And I should see "[TEST] Topic B"
+    And I should not see "Blog" in the "article .component-hero__tags" element
 
   @api
   Scenario: The article body and the closing call to action render in the dark scheme

--- a/tests/behat/features/blog_post.feature
+++ b/tests/behat/features/blog_post.feature
@@ -1,0 +1,83 @@
+@p1 @civictheme @drevops @blog
+Feature: Blog post assembly
+
+  As a site visitor
+  I want a blog post to open with an image hero and read through to a closing call to action
+  So that I can read DrevOps articles in context
+
+  Background:
+    Given the following "civictheme_topics" terms:
+      | name           |
+      | Blog           |
+      | [TEST] Topic A |
+      | [TEST] Topic B |
+
+    And the following managed files:
+      | path      | uri                        | status |
+      | image.jpg | public://do_test/image.jpg | 1      |
+
+    And the following media "civictheme_image" exist:
+      | name              | field_c_m_image |
+      | [TEST] Post Image | image.jpg       |
+
+    And the following "civictheme_page" content:
+      | title                 | status | field_c_n_topics                     | field_read_time |
+      | [TEST] Assembled Post | 1      | Blog, [TEST] Topic A, [TEST] Topic B | 6 min read      |
+      | [TEST] Plain Page     | 1      |                                      |                 |
+
+    And the following fields for the paragraph "hero" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Assembled Post":
+      | field_c_p_type  | article           |
+      | field_c_p_theme | dark              |
+      | field_c_p_image | [TEST] Post Image |
+
+    And the "civictheme_page" "node" "[TEST] Assembled Post" has a "civictheme_rich_text" content paragraph:
+      """
+      <p class="ct-text-large">[TEST] The lead paragraph of the assembled post.</p>
+      <p>[TEST] A body paragraph that follows the hero.</p>
+      """
+
+    And the following fields for the paragraph "cta" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Assembled Post":
+      | field_c_p_type   | display                     |
+      | field_c_p_theme  | dark                        |
+      | field_title      | [TEST] Ship faster          |
+      | field_subtitle   | [TEST] Get a free review    |
+      | field_link:title | [TEST] Start a conversation |
+      | field_link:uri   | https://example.com/contact |
+
+  @api
+  Scenario: The post opens with an image hero carrying its date, read time, title and tags
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] Assembled Post"
+    Then I should see an "article .component-hero.component-hero--article" element
+    And I should see an "article .component-hero--article.ct-theme-dark" element
+    And I should see an "article .component-hero--article .component-hero__image img" element
+    And I should see an "article .component-hero--article .component-hero__overlay" element
+    And I should see an "article .component-hero__title" element
+    And I should see "[TEST] Assembled Post"
+    And I should see an "article .component-hero__meta time" element
+    And I should see "6 min read"
+    And I should see an "article .component-hero__tags .ct-tag" element
+    And I should see "[TEST] Topic A"
+    And I should see "[TEST] Topic B"
+
+  @api
+  Scenario: The article body and the closing call to action render in the dark scheme
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] Assembled Post"
+    Then I should see an "article .ct-basic-content" element
+    And I should see "[TEST] The lead paragraph of the assembled post."
+    And I should see an "article .ct-cta" element
+    And I should see an "article .ct-cta.ct-theme-dark" element
+    And I should see "[TEST] Ship faster"
+
+  @api
+  Scenario: A page that opens with a hero hides the legacy banner
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] Assembled Post"
+    Then I should not see an ".ct-banner" element
+
+  @api
+  Scenario: A page without a hero still shows the banner
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] Plain Page"
+    Then I should see an ".ct-banner" element

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -16,6 +16,7 @@ use Drupal\civictheme\CivicthemeColorManager;
 use Drupal\civictheme\CivicthemeConstants;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
+use Drupal\media\MediaInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
@@ -815,14 +816,213 @@ function _do_base_build_contact_components(): array {
 }
 
 /**
+ * Add the page hero to the top of the blog landing page when it is missing.
+ */
+function do_base_deploy_blog_landing_hero(): string {
+  $path = \Drupal::service('path_alias.manager')->getPathByAlias('/blog');
+
+  if (!preg_match('#^/node/(\d+)$#', $path, $matches)) {
+    return 'The /blog alias does not resolve to a node; skipped the blog landing hero.';
+  }
+
+  $node = \Drupal::entityTypeManager()->getStorage('node')->load((int) $matches[1]);
+
+  if (!$node instanceof FieldableEntityInterface || !$node->hasField('field_c_n_components')) {
+    return 'The blog landing page has no components field; skipped the blog landing hero.';
+  }
+
+  // Idempotency guard: the hero always leads the stack once added.
+  $components = $node->get('field_c_n_components')->referencedEntities();
+
+  if (isset($components[0]) && $components[0]->bundle() === 'hero') {
+    return 'The blog landing hero is already present.';
+  }
+
+  $hero = Paragraph::create([
+    'type' => 'hero',
+    'field_c_p_type' => 'page',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_subtitle' => 'Blog',
+    'field_c_p_title' => 'Practical engineering insights from the teams we work with.',
+  ]);
+  $hero->save();
+
+  // The hero opens the page, so it is prepended ahead of the existing list.
+  $items = $node->get('field_c_n_components')->getValue();
+  array_unshift($items, ['target_id' => $hero->id(), 'target_revision_id' => $hero->getRevisionId()]);
+  $node->set('field_c_n_components', $items);
+  $node->save();
+
+  return 'Added the page hero to the blog landing page.';
+}
+
+/**
+ * Seed a sample blog post that demonstrates the assembled post layout.
+ */
+function do_base_deploy_blog_sample_post(): string {
+  $title = 'Why Your Drupal CI Pipeline Is Slower Than It Should Be';
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  // Idempotency guard: identify the seeded post by its title.
+  $existing = $node_storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('type', 'civictheme_page')
+    ->condition('title', $title)
+    ->execute();
+
+  if (!empty($existing)) {
+    return 'The sample blog post is already present.';
+  }
+
+  $blog = _do_base_ensure_blog_term();
+
+  if (!$blog instanceof TermInterface) {
+    return 'The Blog topic term is unavailable; skipped the sample blog post.';
+  }
+
+  // The Blog term marks the page for the listing; the rest render as content
+  // tags in the article hero.
+  $topics = [['target_id' => $blog->id()]];
+
+  foreach (['Drupal', 'DevOps', 'CI/CD', 'Performance'] as $name) {
+    $term = _do_base_ensure_topic_term($name);
+
+    if ($term instanceof TermInterface) {
+      $topics[] = ['target_id' => $term->id()];
+    }
+  }
+
+  $image = _do_base_first_image_media();
+
+  $hero = Paragraph::create([
+    'type' => 'hero',
+    'field_c_p_type' => 'article',
+    'field_c_p_theme' => 'dark',
+  ]);
+
+  if ($image instanceof MediaInterface) {
+    $hero->set('field_c_p_image', ['target_id' => $image->id()]);
+  }
+
+  $hero->save();
+
+  $body = Paragraph::create([
+    'type' => 'civictheme_content',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_vertical_spacing' => 'both',
+    'field_c_p_content' => [
+      'value' => _do_base_sample_post_body(),
+      'format' => 'civictheme_rich_text',
+    ],
+  ]);
+  $body->save();
+
+  $cta = Paragraph::create([
+    'type' => 'cta',
+    'field_c_p_type' => 'display',
+    'field_c_p_theme' => 'dark',
+    'field_title' => 'Ship faster with a pipeline that keeps up.',
+    'field_subtitle' => 'Get a free 30-minute review of your Drupal CI configuration.',
+    'field_link' => [
+      ['uri' => 'internal:/contact', 'title' => 'Start a conversation'],
+      ['uri' => 'mailto:info@drevops.com', 'title' => 'info@drevops.com'],
+    ],
+  ]);
+  $cta->save();
+
+  $created = (new \DateTimeImmutable('2026-03-18 09:00:00'))->getTimestamp();
+
+  $node = Node::create([
+    'type' => 'civictheme_page',
+    'title' => $title,
+    'status' => 1,
+    'created' => $created,
+    'changed' => $created,
+    'field_c_n_topics' => $topics,
+    'field_c_n_summary' => 'We measured 24 Drupal CI pipelines and found the same fixable problems everywhere. Here is how to cut build times from 18 minutes to under 5.',
+    'field_read_time' => '8 min read',
+    'field_c_n_components' => [$hero, $body, $cta],
+  ]);
+
+  if ($image instanceof MediaInterface) {
+    $node->set('field_c_n_thumbnail', ['target_id' => $image->id()]);
+  }
+
+  $node->save();
+
+  return sprintf('Created the sample blog post (node %d).', $node->id());
+}
+
+/**
+ * Load an existing image media item to use as seeded hero imagery.
+ */
+function _do_base_first_image_media(): ?MediaInterface {
+  $storage = \Drupal::entityTypeManager()->getStorage('media');
+
+  $ids = $storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('bundle', 'civictheme_image')
+    ->condition('status', 1)
+    ->sort('mid')
+    ->range(0, 1)
+    ->execute();
+
+  if (empty($ids)) {
+    return NULL;
+  }
+
+  $media = $storage->load(reset($ids));
+
+  return $media instanceof MediaInterface ? $media : NULL;
+}
+
+/**
+ * The rich body of the seeded sample blog post, taken from the prototype.
+ */
+function _do_base_sample_post_body(): string {
+  return <<<'HTML'
+<p class="ct-text-large">Most Drupal teams accept slow CI pipelines as a fact of life. Builds that take fifteen minutes, test suites that time out, and deployments that need a coffee break. It does not have to be this way.</p>
+<p>We have audited dozens of Drupal CI pipelines across government, education and enterprise organisations. The same problems come up repeatedly. Here is what we find and how to fix it.</p>
+<h2>The usual suspects</h2>
+<p>Before reaching for solutions, it helps to understand where the time actually goes in a typical Drupal CI build. What you genuinely need for CI is smaller than most teams assume:</p>
+<ul>
+<li>Schema and configuration, usually under five megabytes.</li>
+<li>A small set of representative content nodes.</li>
+<li>User accounts for the test roles.</li>
+<li>Taxonomy terms and menu structures.</li>
+</ul>
+<h2>Stop pulling full Docker images on every build</h2>
+<p>The single biggest time sink is rebuilding or pulling Docker images on every run. Build a dedicated CI image with your PHP extensions and system dependencies baked in, push it to your registry, and reference it directly:</p>
+<pre><code class="language-yaml">jobs:
+  test:
+    docker:
+      - image: ghcr.io/your-org/drupal-ci:php8.3
+    steps:
+      - checkout
+      - run: composer install --no-interaction --prefer-dist
+      - run: vendor/bin/phpunit</code></pre>
+<p>This alone typically cuts two to four minutes off every build.</p>
+<blockquote><p>Fast CI is not a luxury. It is the difference between developers who test before merging and developers who push to main and hope for the best.</p></blockquote>
+<p>If your Drupal CI pipeline takes more than five minutes, there is room to improve.</p>
+HTML;
+}
+
+/**
  * Load the Blog topic term, creating it when the vocabulary allows.
  */
 function _do_base_ensure_blog_term(): ?TermInterface {
+  return _do_base_ensure_topic_term('Blog');
+}
+
+/**
+ * Load a topic term by name, creating it when the vocabulary allows.
+ */
+function _do_base_ensure_topic_term(string $name): ?TermInterface {
   $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
 
   $existing = $storage->loadByProperties([
     'vid' => 'civictheme_topics',
-    'name' => 'Blog',
+    'name' => $name,
   ]);
 
   if (!empty($existing)) {
@@ -833,7 +1033,7 @@ function _do_base_ensure_blog_term(): ?TermInterface {
     return NULL;
   }
 
-  $term = $storage->create(['vid' => 'civictheme_topics', 'name' => 'Blog']);
+  $term = $storage->create(['vid' => 'civictheme_topics', 'name' => $name]);
   $term->save();
 
   return $term;

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -930,7 +930,7 @@ function do_base_deploy_blog_sample_post(): string {
   ]);
   $cta->save();
 
-  $created = (new \DateTimeImmutable('2026-03-18 09:00:00'))->getTimestamp();
+  $created = new \DateTimeImmutable('2026-03-18 09:00:00')->getTimestamp();
 
   $node = Node::create([
     'type' => 'civictheme_page',

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -90,7 +90,7 @@ function _do_base_node_leads_with_hero(NodeInterface $node): bool {
     return FALSE;
   }
 
-  $first = $node->get('field_c_n_components')->referencedEntities()[0] ?? NULL;
+  $first = $node->get('field_c_n_components')->first()?->entity;
 
   return $first instanceof ParagraphInterface && $first->bundle() === 'hero';
 }

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -83,7 +83,7 @@ function do_base_block_access(BlockInterface $block, string $operation, AccountI
 }
 
 /**
- * Check whether a node's first component is a hero paragraph.
+ * Checks whether a node's first layout component is a hero paragraph.
  */
 function _do_base_node_leads_with_hero(NodeInterface $node): bool {
   if (!$node->hasField('field_c_n_components')) {

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -90,7 +90,7 @@ function _do_base_node_leads_with_hero(NodeInterface $node): bool {
     return FALSE;
   }
 
-  $first = $node->get('field_c_n_components')->first()?->entity;
+  $first = $node->get('field_c_n_components')->referencedEntities()[0] ?? NULL;
 
   return $first instanceof ParagraphInterface && $first->bundle() === 'hero';
 }

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -83,7 +83,7 @@ function do_base_block_access(BlockInterface $block, string $operation, AccountI
 }
 
 /**
- * Checks whether a node's first layout component is a hero paragraph.
+ * Check whether a node's first component is a hero paragraph.
  */
 function _do_base_node_leads_with_hero(NodeInterface $node): bool {
   if (!$node->hasField('field_c_n_components')) {

--- a/web/themes/custom/drevops/includes/hero.inc
+++ b/web/themes/custom/drevops/includes/hero.inc
@@ -7,6 +7,9 @@
 
 declare(strict_types=1);
 
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
+
 /**
  * Implements template_preprocess_paragraph().
  */
@@ -20,6 +23,7 @@ function drevops_preprocess_paragraph__hero(array &$variables): void {
   _drevops_preprocess_paragraph__hero_field__eyebrow($variables);
   _drevops_preprocess_paragraph__hero_field__lead($variables);
   _drevops_preprocess_paragraph__hero_field__actions($variables);
+  _drevops_preprocess_paragraph__hero__article($variables);
 
   // CivicTheme's image helper exposes the media as 'image'; the hero renders it
   // as the article variant's full-bleed background.
@@ -67,4 +71,60 @@ function _drevops_preprocess_paragraph__hero_field__actions(array &$variables): 
   }
 
   $variables['actions'] = $actions;
+}
+
+/**
+ * Source the article hero's heading, meta and tags from the post it opens.
+ */
+function _drevops_preprocess_paragraph__hero__article(array &$variables): void {
+  if (($variables['type'] ?? NULL) !== 'article') {
+    return;
+  }
+
+  $paragraph = $variables['paragraph'] ?? NULL;
+  $node = $paragraph instanceof ParagraphInterface ? $paragraph->getParentEntity() : NULL;
+
+  // The post's date, read time, title and topics live on the node, not on the
+  // hero paragraph, so a post is described in one place. Skip when there is no
+  // node parent, such as a paragraphs library preview.
+  if (!$node instanceof NodeInterface) {
+    return;
+  }
+
+  if (empty($variables['title'])) {
+    $variables['title'] = $node->label();
+  }
+
+  $variables['article_date'] = _civictheme_node_get_updated_date($node, 'civictheme_short_date');
+  $variables['article_date_iso'] = _civictheme_node_get_updated_date($node, 'c');
+
+  if ($node->hasField('field_read_time')) {
+    $variables['read_time'] = civictheme_get_field_value($node, 'field_read_time', TRUE);
+  }
+
+  $variables['article_tags'] = _drevops_hero_article_tags($node);
+}
+
+/**
+ * Build the article hero tag list from a post's topics, minus the Blog marker.
+ */
+function _drevops_hero_article_tags(NodeInterface $node): array {
+  if (!$node->hasField('field_c_n_topics')) {
+    return [];
+  }
+
+  $tags = [];
+
+  // The tag list renders each item as the tag's text, so the topics are passed
+  // as plain label strings. The Blog topic only marks a page as a post for the
+  // listing, so it is not a content tag and is left out of the hero.
+  foreach ($node->get('field_c_n_topics')->referencedEntities() as $term) {
+    if ($term->label() === 'Blog') {
+      continue;
+    }
+
+    $tags[] = $term->label();
+  }
+
+  return $tags;
 }

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
@@ -7,7 +7,7 @@
  * are assembled from the parent post in the paragraph preprocess.
  */
 #}
-{% set has_date = article_date is defined and article_date is not empty %}
+{% set has_date = article_date is defined and article_date is not empty and article_date_iso is defined and article_date_iso is not empty %}
 {% set has_read_time = read_time is defined and read_time is not empty %}
 {% set has_tags = article_tags is defined and article_tags is not empty %}
 

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
@@ -18,7 +18,7 @@
 {% endset %}
 
 {% set tags_slot %}
-  {% if has_tags %}{% include 'civictheme:tag-list' with { theme: theme, tags: article_tags } only %}{% endif %}
+  {% if has_tags %}{% include 'civictheme:tag-list' with {theme: theme, tags: article_tags} only %}{% endif %}
 {% endset %}
 
 {{ include('drevops:hero', {

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--hero.html.twig
@@ -2,8 +2,25 @@
 /**
  * @file
  * Theme implementation to display the Hero component.
+ *
+ * For the article variant the meta line (date and read time) and the tag list
+ * are assembled from the parent post in the paragraph preprocess.
  */
 #}
+{% set has_date = article_date is defined and article_date is not empty %}
+{% set has_read_time = read_time is defined and read_time is not empty %}
+{% set has_tags = article_tags is defined and article_tags is not empty %}
+
+{% set meta_slot %}
+  {%- if has_date -%}<time datetime="{{ article_date_iso }}">{{ article_date }}</time>{%- endif -%}
+  {%- if has_date and has_read_time -%}<span class="component-hero__meta-sep" aria-hidden="true"> / </span>{%- endif -%}
+  {%- if has_read_time -%}<span>{{ read_time }}</span>{%- endif -%}
+{% endset %}
+
+{% set tags_slot %}
+  {% if has_tags %}{% include 'civictheme:tag-list' with { theme: theme, tags: article_tags } only %}{% endif %}
+{% endset %}
+
 {{ include('drevops:hero', {
   theme: theme,
   type: type,
@@ -12,5 +29,7 @@
   eyebrow: eyebrow,
   heading: title,
   lead: lead,
+  meta: has_date or has_read_time ? meta_slot : null,
+  tags: has_tags ? tags_slot : null,
   attributes: component_attributes,
 }, with_context: false) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#202] Verb in past tense.`
- [x] Ticket number `#202` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

Closes #202

## Changed

**Theme - article hero (`web/themes/custom/drevops/`)**

- Added `_drevops_preprocess_paragraph__hero__article()` in `includes/hero.inc` to source an article hero's heading, date, read time, and topic tags directly from the parent post node, so a post is described in one place rather than duplicated onto the hero paragraph. It is skipped for non-article variants and for previews with no node parent.
- Added `_drevops_hero_article_tags()` to build the tag list from `field_c_n_topics`, excluding the "Blog" term, which marks a page for the listing rather than being a content tag.
- Extended `templates/paragraphs/paragraph--hero.html.twig` to compose a `meta_slot` (date / read time) and a `tags_slot` (CivicTheme `tag-list`) and pass them into the `drevops:hero` component for the `article` variant.

**Content seeding - deploy hooks (`web/modules/custom/do_base/do_base.deploy.php`)**

- `do_base_deploy_blog_landing_hero()` - idempotent hook that prepends a page-type hero to the `/blog` landing page when one is absent, leaving the existing automated list (which already renders a featured post and grid) in place below it.
- `do_base_deploy_blog_sample_post()` - idempotent hook that creates a sample blog post (`civictheme_page` tagged with the Blog topic) with an article hero, a rich article body, and a closing CTA band, so the assembled post layout is demonstrated end to end.
- Generalised `_do_base_ensure_blog_term()` to delegate to a new `_do_base_ensure_topic_term($name)` helper, used to seed the sample post's display topics (Drupal, DevOps, CI/CD, Performance).
- Added `_do_base_first_image_media()` to reuse an existing image media item for the hero background and thumbnail without hard-coding an ID, degrading gracefully to no image when none exists.

**Banner handling**

- The blog landing and the sample post both lead with a hero paragraph, so the shared hero-led banner rule already in the base hides the legacy CivicTheme title banner for them automatically. No new banner code is added by this change.

**Tests (`tests/behat/features/`)**

- `blog.feature` - added a scenario that creates a page leading with a page hero, visits it, asserts the hero structure renders, and confirms the legacy `.ct-banner` is absent.
- `blog_post.feature` (new) - four scenarios covering: the article hero carrying the post's image, date, read time, title and topic tags (with the Blog term excluded); the article body and CTA band rendering in the dark scheme; the banner hidden when a node leads with a hero; and the banner still present on a page without a hero.

## Screenshots

![Blog post assembled layout](https://raw.githubusercontent.com/drevops/website/7b18e172b7a12fa967fa794257f1290f7829f90d/feature-202-blog-assembly/7d68b29168d82e7bf13642cefc7a13f82a456867.png)

## Before / After

```
BEFORE
──────────────────────────────────────────────
Blog landing (/blog)
┌─────────────────────────────────────────────┐
│ ct-banner (site-wide CivicTheme banner)     │
├─────────────────────────────────────────────┤
│ Uniform card grid (all posts, same size)    │
└─────────────────────────────────────────────┘

Blog post
┌─────────────────────────────────────────────┐
│ ct-banner (site-wide CivicTheme banner)     │
├─────────────────────────────────────────────┤
│ Article body (rich text)                    │
└─────────────────────────────────────────────┘

AFTER
──────────────────────────────────────────────
Blog landing (/blog)
┌─────────────────────────────────────────────┐
│ component-hero--page (dark)                 │
│  eyebrow: "Blog"                            │
│  heading: "Practical engineering insights…" │
├─────────────────────────────────────────────┤
│ Featured post (large promo card)            │
├─────────────────────────────────────────────┤
│ Card grid (remaining posts)                 │
└─────────────────────────────────────────────┘
  ↳ ct-banner hidden (node leads with hero)

Blog post
┌─────────────────────────────────────────────┐
│ component-hero--article (dark, full-bleed)  │
│  background image                           │
│  meta: <date> / <read time>                 │
│  heading: node title                        │
│  tags: [Drupal] [DevOps] [CI/CD] …          │
│  (Blog tag excluded from display)           │
├─────────────────────────────────────────────┤
│ Article body (rich text, dark scheme)       │
├─────────────────────────────────────────────┤
│ CTA band (dark): "Ship faster…"             │
└─────────────────────────────────────────────┘
  ↳ ct-banner hidden (node leads with hero)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog landing page now displays with hero component featuring dark theme styling.
  * Blog posts render with article metadata including read time, date, and topic tags.
  * Hero component extended to support article-style presentation with improved visual hierarchy.
  * Sample blog content automatically seeded during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->