### PR TITLE
[#203] Assembled the contact page from shared components.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.card_group.default.yml
+++ b/config/default/core.entity_form_display.paragraph.card_group.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.card_group.field_c_p_list_column_count
     - field.field.paragraph.card_group.field_c_p_list_items
     - field.field.paragraph.card_group.field_c_p_theme
+    - field.field.paragraph.card_group.field_c_p_title
     - paragraphs.paragraphs_type.card_group
   module:
     - paragraphs
@@ -43,6 +44,14 @@ content:
     weight: 2
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_c_p_title:
+    type: string_textfield
+    weight: -1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/default/core.entity_form_display.paragraph.contact_area.default.yml
+++ b/config/default/core.entity_form_display.paragraph.contact_area.default.yml
@@ -1,0 +1,72 @@
+uuid: 67c2ea35-8e88-41a4-b29e-9bd48e868c0b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.contact_area.field_c_p_theme
+    - field.field.paragraph.contact_area.field_p_aside
+    - field.field.paragraph.contact_area.field_p_main
+    - paragraphs.paragraphs_type.contact_area
+  module:
+    - paragraphs
+id: paragraph.contact_area.default
+targetEntityType: paragraph
+bundle: contact_area
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_c_p_theme:
+    type: options_buttons
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_p_aside:
+    type: paragraphs
+    weight: 1
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_p_main:
+    type: paragraphs
+    weight: 0
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 4
+    region: hidden
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden: {  }

--- a/config/default/core.entity_view_display.paragraph.card_group.default.yml
+++ b/config/default/core.entity_view_display.paragraph.card_group.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.card_group.field_c_p_list_column_count
     - field.field.paragraph.card_group.field_c_p_list_items
     - field.field.paragraph.card_group.field_c_p_theme
+    - field.field.paragraph.card_group.field_c_p_title
     - paragraphs.paragraphs_type.card_group
 id: paragraph.card_group.default
 targetEntityType: paragraph
@@ -16,4 +17,5 @@ hidden:
   field_c_p_list_column_count: true
   field_c_p_list_items: true
   field_c_p_theme: true
+  field_c_p_title: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.contact_area.default.yml
+++ b/config/default/core.entity_view_display.paragraph.contact_area.default.yml
@@ -1,0 +1,44 @@
+uuid: e2d132d5-8a86-4ad4-ab10-4afd98e25d93
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.contact_area.field_c_p_theme
+    - field.field.paragraph.contact_area.field_p_aside
+    - field.field.paragraph.contact_area.field_p_main
+    - paragraphs.paragraphs_type.contact_area
+  module:
+    - entity_reference_revisions
+    - options
+id: paragraph.contact_area.default
+targetEntityType: paragraph
+bundle: contact_area
+mode: default
+content:
+  field_c_p_theme:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: hidden
+  field_p_aside:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 2
+    region: hidden
+  field_p_main:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: hidden
+hidden:
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -21,6 +21,7 @@ dependencies:
     - paragraphs.paragraphs_type.civictheme_promo
     - paragraphs.paragraphs_type.civictheme_slider
     - paragraphs.paragraphs_type.civictheme_webform
+    - paragraphs.paragraphs_type.contact_area
     - paragraphs.paragraphs_type.contact_detail
     - paragraphs.paragraphs_type.cta
     - paragraphs.paragraphs_type.divider
@@ -69,6 +70,7 @@ settings:
       contact_detail: contact_detail
       card_group: card_group
       cta: cta
+      contact_area: contact_area
     negate: 0
     target_bundles_drag_drop:
       campaign:
@@ -166,6 +168,9 @@ settings:
         enabled: false
       civictheme_webform:
         weight: -46
+        enabled: true
+      contact_area:
+        weight: 64
         enabled: true
       contact_detail:
         weight: 61

--- a/config/default/field.field.paragraph.card_group.field_c_p_title.yml
+++ b/config/default/field.field.paragraph.card_group.field_c_p_title.yml
@@ -1,0 +1,19 @@
+uuid: 8b4bdf82-4b8a-43f5-b764-e26c8d30871e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_title
+    - paragraphs.paragraphs_type.card_group
+id: paragraph.card_group.field_c_p_title
+field_name: field_c_p_title
+entity_type: paragraph
+bundle: card_group
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.contact_area.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.contact_area.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: 4bc31454-73ae-46db-a248-14033dc26d79
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.contact_area
+  module:
+    - options
+id: paragraph.contact_area.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: contact_area
+label: Theme
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: dark
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.contact_area.field_p_aside.yml
+++ b/config/default/field.field.paragraph.contact_area.field_p_aside.yml
@@ -1,0 +1,41 @@
+uuid: 7ffd7f0d-dfe7-47e4-98e4-05aecf1678a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_aside
+    - paragraphs.paragraphs_type.card_group
+    - paragraphs.paragraphs_type.contact_area
+    - paragraphs.paragraphs_type.contact_detail
+    - paragraphs.paragraphs_type.divider
+  module:
+    - entity_reference_revisions
+id: paragraph.contact_area.field_p_aside
+field_name: field_p_aside
+entity_type: paragraph
+bundle: contact_area
+label: 'Aside column'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      contact_detail: contact_detail
+      divider: divider
+      card_group: card_group
+    negate: 0
+    target_bundles_drag_drop:
+      card_group:
+        weight: 2
+        enabled: true
+      contact_detail:
+        weight: 0
+        enabled: true
+      divider:
+        weight: 1
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.contact_area.field_p_main.yml
+++ b/config/default/field.field.paragraph.contact_area.field_p_main.yml
@@ -1,0 +1,31 @@
+uuid: 1211edc8-2fa6-41e8-85f8-7a3c58d32850
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_main
+    - paragraphs.paragraphs_type.civictheme_webform
+    - paragraphs.paragraphs_type.contact_area
+  module:
+    - entity_reference_revisions
+id: paragraph.contact_area.field_p_main
+field_name: field_p_main
+entity_type: paragraph
+bundle: contact_area
+label: 'Main column'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      civictheme_webform: civictheme_webform
+    negate: 0
+    target_bundles_drag_drop:
+      civictheme_webform:
+        weight: 0
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/default/field.storage.paragraph.field_p_aside.yml
+++ b/config/default/field.storage.paragraph.field_p_aside.yml
@@ -1,0 +1,20 @@
+uuid: 2664a2cd-1965-4c9b-9db9-611cdd372fb4
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_p_aside
+field_name: field_p_aside
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_p_main.yml
+++ b/config/default/field.storage.paragraph.field_p_main.yml
@@ -1,0 +1,20 @@
+uuid: 789159f9-78f2-4e3a-9c3e-673d13f7e04b
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_p_main
+field_name: field_p_main
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/paragraphs.paragraphs_type.contact_area.yml
+++ b/config/default/paragraphs.paragraphs_type.contact_area.yml
@@ -1,0 +1,10 @@
+uuid: db42d2c9-ca49-43b3-860b-68fdbbee2773
+langcode: en
+status: true
+dependencies: {  }
+id: contact_area
+label: 'Contact area'
+icon_uuid: null
+icon_default: null
+description: 'A two-column contact area: an enquiry form beside the contact details and steps.'
+behavior_plugins: {  }

--- a/tests/behat/features/contact.feature
+++ b/tests/behat/features/contact.feature
@@ -9,7 +9,7 @@ Feature: Contact form
   Scenario: Anonymous user sees the enquiry form and its fields
     Given I am an anonymous user
     When I go to "/contact"
-    Then I should see the heading "Contact"
+    Then I should see the heading "Let's talk about your platform."
     And I should see "Name"
     And I should see "Email"
     And I should see "Organisation"

--- a/tests/behat/features/contact_page.feature
+++ b/tests/behat/features/contact_page.feature
@@ -1,0 +1,54 @@
+@p1 @drevops @contact
+Feature: Contact page
+
+  As a prospective client
+  I want a contact page with a form and direct contact details
+  So that I can reach DrevOps in whatever way suits me
+
+  @api
+  Scenario: The contact page is assembled from the shared components in order
+    Given I am an anonymous user
+    When I go to "/contact"
+    Then I should see an "article .component-hero.component-hero--contact" element
+    And I should see an "article .component-contact-content" element
+    And I should see an "article .component-grid-contact" element
+    And I should see a ".webform-submission-contact-form" element
+    And I should see 3 ".component-contact-detail" elements
+    And I should see an "article .ct-card-group.ct-card-group--cols-1" element
+    And I should not see a ".ct-banner" element
+    And the element ".component-contact-content" should appear after the element ".component-hero"
+
+  @api
+  Scenario: The contact column lists the direct contact methods
+    Given I am an anonymous user
+    When I go to "/contact"
+    Then I should see the text "Email us directly"
+    And I should see the link "info@drevops.com"
+    And I should see the text "Call us"
+    And I should see the text "04 3009 3538"
+    And I should see the text "Based in"
+    And I should see the text "Melbourne, Australia"
+
+  @api
+  Scenario: The contact column shows the numbered "what to expect" steps
+    Given I am an anonymous user
+    When I go to "/contact"
+    Then I should see the text "What to expect"
+    And I should see the text "We'll review your message and respond within 24 hours."
+    And I should see the text "A 30-minute call to understand your platform and goals."
+    And I should see the text "A clear proposal with fixed-price quoting, no surprises."
+
+  @api
+  Scenario: The contact page leads with the hero in the dark scheme
+    Given I am an anonymous user
+    When I go to "/contact"
+    Then I should see the heading "Let's talk about your platform."
+    And I should see an "article .component-hero.ct-theme-dark" element
+    And I should see an "article .component-contact-detail.ct-theme-dark" element
+    And I should see an "article .ct-card-group.ct-theme-dark" element
+
+  @api @javascript
+  Scenario: The contact page reflows without horizontal scrolling on a phone
+    Given I am an anonymous user
+    When I go to "/contact"
+    Then the page has no horizontal overflow at 375 pixels wide

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -487,35 +487,41 @@ function _do_base_ensure_homepage_icon(string $name, string $filename): ?int {
 }
 
 /**
- * Seed the Services page assembled from the shared components.
+ * Reassemble a civictheme_page from a freshly built component stack.
+ *
+ * The page is located by its title so an existing page keeps its alias and
+ * revision history, and is created at the given alias only when none exists.
+ * Building, attaching and cleaning up the superseded paragraphs run inside one
+ * transaction so a failure part way through rolls back rather than leaving
+ * half-saved paragraphs orphaned instead of attached to the page.
+ *
+ * @param string $title
+ *   The page title used to locate or create the node.
+ * @param string $alias
+ *   The path alias applied when the node is created.
+ * @param callable(): \Drupal\paragraphs\Entity\Paragraph[] $build_components
+ *   Builds and returns the ordered components to attach to the page.
  */
-function do_base_deploy_seed_services_page(): string {
+function _do_base_seed_page(string $title, string $alias, callable $build_components): string {
   $node_storage = \Drupal::entityTypeManager()->getStorage('node');
 
-  // Reassemble the existing Services page when present so its /services alias
-  // and revision history are preserved; create it only on a site that has none.
   $existing = $node_storage->loadByProperties([
     'type' => 'civictheme_page',
-    'title' => 'Services',
+    'title' => $title,
   ]);
   $node = $existing ? reset($existing) : $node_storage->create([
     'type' => 'civictheme_page',
-    'title' => 'Services',
+    'title' => $title,
     'status' => 1,
-    'path' => ['alias' => '/services', 'pathauto' => 0],
+    'path' => ['alias' => $alias, 'pathauto' => 0],
   ]);
 
-  // The components the page carried before the rebuild are deleted afterwards
-  // so swapping the stack does not leave orphaned paragraphs behind.
   $superseded = $node->get('field_c_n_components')->referencedEntities();
 
-  // Building, attaching and cleaning up run inside one transaction so a failure
-  // part way through rolls back rather than leaving half-saved paragraphs
-  // orphaned instead of attached to the page.
   $transaction = \Drupal::database()->startTransaction();
 
   try {
-    $components = _do_base_build_services_components();
+    $components = $build_components();
 
     $node->set('field_c_n_components', array_map(static fn (Paragraph $component): array => [
       'target_id' => $component->id(),
@@ -533,7 +539,14 @@ function do_base_deploy_seed_services_page(): string {
     throw $exception;
   }
 
-  return sprintf('Assembled the Services page (node %s) from %d components.', $node->id(), count($components));
+  return sprintf('Assembled the %s page (node %s) from %d components.', $title, $node->id(), count($components));
+}
+
+/**
+ * Seed the Services page assembled from the shared components.
+ */
+function do_base_deploy_seed_services_page(): string {
+  return _do_base_seed_page('Services', '/services', _do_base_build_services_components(...));
 }
 
 /**
@@ -692,50 +705,7 @@ function _do_base_build_services_components(): array {
  * Seed the Contact page assembled from the shared components.
  */
 function do_base_deploy_seed_contact_page(): string {
-  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
-
-  // Reassemble the existing Contact page when present so its /contact alias and
-  // revision history are preserved; create it only on a site that has none.
-  $existing = $node_storage->loadByProperties([
-    'type' => 'civictheme_page',
-    'title' => 'Contact',
-  ]);
-  $node = $existing ? reset($existing) : $node_storage->create([
-    'type' => 'civictheme_page',
-    'title' => 'Contact',
-    'status' => 1,
-    'path' => ['alias' => '/contact', 'pathauto' => 0],
-  ]);
-
-  // The components the page carried before the rebuild are deleted afterwards
-  // so swapping the stack does not leave orphaned paragraphs behind.
-  $superseded = $node->get('field_c_n_components')->referencedEntities();
-
-  // Building, attaching and cleaning up run inside one transaction so a failure
-  // part way through rolls back rather than leaving half-saved paragraphs
-  // orphaned instead of attached to the page.
-  $transaction = \Drupal::database()->startTransaction();
-
-  try {
-    $components = _do_base_build_contact_components();
-
-    $node->set('field_c_n_components', array_map(static fn (Paragraph $component): array => [
-      'target_id' => $component->id(),
-      'target_revision_id' => $component->getRevisionId(),
-    ], $components));
-    $node->save();
-
-    foreach ($superseded as $paragraph) {
-      $paragraph->delete();
-    }
-  }
-  catch (\Throwable $exception) {
-    $transaction->rollBack();
-
-    throw $exception;
-  }
-
-  return sprintf('Assembled the Contact page (node %s) from %d components.', $node->id(), count($components));
+  return _do_base_seed_page('Contact', '/contact', _do_base_build_contact_components(...));
 }
 
 /**

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -689,6 +689,162 @@ function _do_base_build_services_components(): array {
 }
 
 /**
+ * Seed the Contact page assembled from the shared components.
+ */
+function do_base_deploy_seed_contact_page(): string {
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  // Reassemble the existing Contact page when present so its /contact alias and
+  // revision history are preserved; create it only on a site that has none.
+  $existing = $node_storage->loadByProperties([
+    'type' => 'civictheme_page',
+    'title' => 'Contact',
+  ]);
+  $node = $existing ? reset($existing) : $node_storage->create([
+    'type' => 'civictheme_page',
+    'title' => 'Contact',
+    'status' => 1,
+    'path' => ['alias' => '/contact', 'pathauto' => 0],
+  ]);
+
+  // The components the page carried before the rebuild are deleted afterwards
+  // so swapping the stack does not leave orphaned paragraphs behind.
+  $superseded = $node->get('field_c_n_components')->referencedEntities();
+
+  // Building, attaching and cleaning up run inside one transaction so a failure
+  // part way through rolls back rather than leaving half-saved paragraphs
+  // orphaned instead of attached to the page.
+  $transaction = \Drupal::database()->startTransaction();
+
+  try {
+    $components = _do_base_build_contact_components();
+
+    $node->set('field_c_n_components', array_map(static fn (Paragraph $component): array => [
+      'target_id' => $component->id(),
+      'target_revision_id' => $component->getRevisionId(),
+    ], $components));
+    $node->save();
+
+    foreach ($superseded as $paragraph) {
+      $paragraph->delete();
+    }
+  }
+  catch (\Throwable $exception) {
+    $transaction->rollBack();
+
+    throw $exception;
+  }
+
+  return sprintf('Assembled the Contact page (node %s) from %d components.', $node->id(), count($components));
+}
+
+/**
+ * Build and save the Contact page components in their render order.
+ *
+ * @return \Drupal\paragraphs\Entity\Paragraph[]
+ *   The saved hero and two-column contact-area paragraphs.
+ */
+function _do_base_build_contact_components(): array {
+  $save_paragraph = static function (array $values): Paragraph {
+    $paragraph = Paragraph::create($values);
+    $paragraph->save();
+
+    return $paragraph;
+  };
+
+  $reference = static fn (Paragraph $paragraph): array => [
+    'target_id' => $paragraph->id(),
+    'target_revision_id' => $paragraph->getRevisionId(),
+  ];
+
+  $components = [];
+
+  $components[] = $save_paragraph([
+    'type' => 'hero',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_type' => 'contact',
+    'field_c_p_title' => "Let's talk about your platform.",
+    'field_c_p_summary' => "Whether you need a new website, help upgrading from an end-of-life version, or ongoing support for the site you have, we're happy to have an honest conversation about where things stand.",
+  ]);
+
+  // Left column: the enquiry webform.
+  $main = $save_paragraph([
+    'type' => 'civictheme_webform',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_webform' => ['target_id' => 'contact'],
+  ]);
+
+  // Right column: the direct-contact details, a divider and the numbered steps.
+  $aside = [];
+
+  $details = [
+    [
+      'label' => 'Email us directly',
+      'value' => 'info@drevops.com',
+      'note' => 'We typically respond within one business day.',
+    ],
+    [
+      'label' => 'Call us',
+      'value' => '04 3009 3538',
+      'note' => 'Available weekdays, Melbourne time (AEST).',
+    ],
+    [
+      'label' => 'Based in',
+      'value' => 'Melbourne, Australia',
+      'note' => 'We work with organisations across Australia and New Zealand.',
+    ],
+  ];
+
+  foreach ($details as $detail) {
+    $aside[] = $save_paragraph([
+      'type' => 'contact_detail',
+      'field_c_p_theme' => 'dark',
+      'field_c_p_subtitle' => $detail['label'],
+      'field_c_p_content' => [
+        'value' => $detail['value'],
+        'format' => 'civictheme_plain_text',
+      ],
+      'field_c_p_summary' => $detail['note'],
+    ]);
+  }
+
+  $steps = [
+    "We'll review your message and respond within 24 hours.",
+    'A 30-minute call to understand your platform and goals.',
+    'A clear proposal with fixed-price quoting, no surprises.',
+  ];
+
+  $step_cards = [];
+  foreach ($steps as $step) {
+    $card = $save_paragraph([
+      'type' => 'card',
+      'field_c_p_type' => 'number',
+      'field_c_p_theme' => 'dark',
+      'field_c_p_title' => $step,
+    ]);
+
+    $step_cards[] = $reference($card);
+  }
+
+  $aside[] = $save_paragraph([
+    'type' => 'card_group',
+    'field_c_p_theme' => 'dark',
+    'field_c_p_title' => 'What to expect',
+    'field_c_p_list_column_count' => 1,
+    'field_c_p_list_items' => $step_cards,
+  ]);
+
+  $components[] = $save_paragraph([
+    'type' => 'contact_area',
+    'field_c_p_theme' => 'dark',
+    'field_p_main' => [$reference($main)],
+    'field_p_aside' => array_map($reference, $aside),
+  ]);
+
+  return $components;
+}
+
+/**
  * Load the Blog topic term, creating it when the vocabulary allows.
  */
 function _do_base_ensure_blog_term(): ?TermInterface {

--- a/web/themes/custom/drevops/components/03-organisms/card-group/card-group.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/card-group/card-group.component.yml
@@ -5,6 +5,10 @@ description: A group of cards laid out in one, two or four columns that stack on
 props:
   type: object
   properties:
+    title:
+      type: string
+      title: Title
+      description: Optional heading shown above the grid.
     columns:
       type: integer
       title: Columns

--- a/web/themes/custom/drevops/components/03-organisms/card-group/card-group.scss
+++ b/web/themes/custom/drevops/components/03-organisms/card-group/card-group.scss
@@ -10,6 +10,15 @@
 //
 
 .ct-card-group {
+  &__title {
+    margin: 0 0 ct-particle(3);
+    font-size: 0.6875rem;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: ct-color-constant-dark('tertiary-3');
+  }
+
   &__grid {
     display: grid;
     grid-template-columns: 1fr;

--- a/web/themes/custom/drevops/components/03-organisms/card-group/card-group.twig
+++ b/web/themes/custom/drevops/components/03-organisms/card-group/card-group.twig
@@ -11,6 +11,9 @@
  *
  * Slots:
  * - cards: The rendered list of card components.
+ *
+ * Props:
+ * - title: [string] Optional heading shown above the grid.
  */
 #}
 
@@ -20,6 +23,9 @@
 
 {% if cards is not empty %}
   <div class="{{ modifier_class }}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    {% if title is not empty %}
+      <p class="ct-card-group__title">{{ title }}</p>
+    {% endif %}
     <div class="ct-card-group__grid">
       {{ cards }}
     </div>

--- a/web/themes/custom/drevops/components/03-organisms/contact-content/contact-content.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/contact-content/contact-content.component.yml
@@ -1,0 +1,30 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Contact area
+status: stable
+description: A two-column contact area - the enquiry form beside the direct contact details and steps. Stacks to one column on narrow screens.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: dark
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: Additional HTML attributes.
+    modifier_class:
+      type: string
+      title: Modifier class
+      description: Additional CSS classes.
+slots:
+  main:
+    title: Main column
+    description: The enquiry form column.
+  aside:
+    title: Aside column
+    description: The direct contact details and steps column.

--- a/web/themes/custom/drevops/components/03-organisms/contact-content/contact-content.scss
+++ b/web/themes/custom/drevops/components/03-organisms/contact-content/contact-content.scss
@@ -1,0 +1,58 @@
+//
+// Contact area component styles.
+//
+// Ported from static-prototype (contact). Lays the enquiry form beside the
+// direct-contact column and collapses to a single column on narrow screens.
+// The component sits inside CivicTheme's constrained content column, so it
+// needs no max-width of its own. Spacing uses the prototype's particle scale.
+//
+
+$_contact-divider: ct-color-constant-dark('secondary-6');
+
+.component-contact-content {
+  & {
+    padding: ct-particle(12) 0 ct-particle(16);
+  }
+
+  @media (width <= 768px) {
+    & {
+      padding: ct-particle(8) 0 ct-particle(10);
+    }
+  }
+}
+
+.component-grid-contact {
+  & {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: ct-particle(10);
+    align-items: start;
+  }
+
+  @media (width <= 768px) {
+    & {
+      grid-template-columns: 1fr;
+      gap: ct-particle(8);
+    }
+  }
+}
+
+.component-contact-col {
+  & {
+    padding-top: ct-particle(1);
+  }
+
+  // A subtle gradient rule separates the direct-contact details from the
+  // "what to expect" steps, matching the prototype's contact-column divider.
+  .ct-card-group {
+    margin-top: ct-particle(6);
+  }
+
+  .ct-card-group::before {
+    content: '';
+    display: block;
+    height: 1px;
+    margin-bottom: ct-particle(6);
+    background: linear-gradient(90deg, color-mix(in srgb, #{$_contact-divider} 30%, transparent) 0%, transparent 100%);
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/contact-content/contact-content.twig
+++ b/web/themes/custom/drevops/components/03-organisms/contact-content/contact-content.twig
@@ -1,0 +1,31 @@
+{#
+/**
+ * @file
+ * Contact area component.
+ *
+ * A two-column layout: the enquiry form in the main column and the direct
+ * contact details and steps in the aside column. Stacks to a single column on
+ * narrow screens.
+ *
+ * Props:
+ * - theme: [string] Theme variation (light or dark).
+ * - attributes: [Drupal\Core\Template\Attribute] Additional HTML attributes.
+ * - modifier_class: [string] Additional CSS classes.
+ *
+ * Slots:
+ * - main: The enquiry form column.
+ * - aside: The direct contact details and steps column.
+ */
+#}
+
+{% set theme_class = 'ct-theme-%s'|format(theme|default('dark')) %}
+{% set modifier_class = '%s %s'|format(theme_class, modifier_class|default('')) %}
+
+{% if main is not empty or aside is not empty %}
+  <section class="component-contact-content {{ modifier_class|trim }}"{% if attributes is defined and attributes is not null %} {{ attributes }}{% endif %}>
+    <div class="component-grid-contact">
+      <div class="component-contact-content__main">{{ main }}</div>
+      <div class="component-contact-col">{{ aside }}</div>
+    </div>
+  </section>
+{% endif %}

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -13,6 +13,7 @@ require_once __DIR__ . '/includes/system_main_block.inc';
 require_once __DIR__ . '/includes/banner.inc';
 require_once __DIR__ . '/includes/paragraphs.inc';
 require_once __DIR__ . '/includes/contact_detail.inc';
+require_once __DIR__ . '/includes/contact_area.inc';
 require_once __DIR__ . '/includes/divider.inc';
 require_once __DIR__ . '/includes/hero.inc';
 require_once __DIR__ . '/includes/service_detail.inc';

--- a/web/themes/custom/drevops/includes/cards.inc
+++ b/web/themes/custom/drevops/includes/cards.inc
@@ -56,6 +56,7 @@ function drevops_preprocess_paragraph__card(array &$variables): void {
 function drevops_preprocess_paragraph__card_group(array &$variables): void {
   $paragraph = $variables['paragraph'];
 
+  $variables['title'] = civictheme_get_field_value($paragraph, 'field_c_p_title');
   $variables['column_count'] = (int) (civictheme_get_field_value($paragraph, 'field_c_p_list_column_count') ?? 1);
 
   _civictheme_preprocess_paragraph__paragraph_field__theme($variables);

--- a/web/themes/custom/drevops/includes/contact_area.inc
+++ b/web/themes/custom/drevops/includes/contact_area.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * DrevOps Contact area paragraph component.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__contact_area(array &$variables): void {
+  $paragraph = $variables['paragraph'];
+
+  _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
+
+  $view_builder = \Drupal::entityTypeManager()->getViewBuilder('paragraph');
+
+  // Render each column's child paragraphs into its slot so the two-column SDC
+  // simply prints what the editor placed in the main and aside fields.
+  foreach (['main' => 'field_p_main', 'aside' => 'field_p_aside'] as $slot => $field_name) {
+    $rendered = [];
+
+    foreach (civictheme_get_field_referenced_entities($paragraph, $field_name, $variables) as $child) {
+      $rendered[] = $view_builder->view($child);
+    }
+
+    $variables[$slot] = $rendered;
+  }
+}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--card-group.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--card-group.html.twig
@@ -5,6 +5,7 @@
  */
 #}
 {{ include('drevops:card-group', {
+  title: title,
   columns: column_count,
   theme: theme,
   cards: cards,

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--contact-area.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--contact-area.html.twig
@@ -1,0 +1,12 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Contact area paragraph.
+ */
+#}
+{{ include('drevops:contact-content', {
+  theme: theme,
+  main: main,
+  aside: aside,
+  attributes: component_attributes,
+}, with_context: false) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#203] Verb in past tense.`
- [x] Ticket number `#203` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

Closes #203

## Changed

1. Added a new `contact_area` paragraph type with two entity-reference fields (`field_p_main` for the enquiry form column, `field_p_aside` for the direct-contact column) and a `field_c_p_theme` toggle, along with all required Drupal config (field storage, field instances, form and view display).
2. Added a new `03-organisms/contact-content` SDC (`contact-content.component.yml`, `contact-content.twig`, `contact-content.scss`) that lays out the two columns in a responsive grid - stacking to a single column on screens narrower than 768 px.
3. Added `contact_area.inc` preprocess hook and `paragraph--contact-area.html.twig` template to wire the paragraph's `field_p_main` and `field_p_aside` entities into the SDC's `main` and `aside` slots.
4. Extended `card_group` with an optional `field_c_p_title` text field so the "What to expect" heading can be stored on the paragraph; updated the `card-group` SDC and its twig template to render an uppercase label above the grid when the prop is set.
5. Extracted the shared `civictheme_page` seeding logic from `do_base_deploy_seed_services_page()` into a reusable `_do_base_seed_page()` helper; the services deploy now delegates to it.
6. Added `do_base_deploy_seed_contact_page()` and `_do_base_build_contact_components()` to seed the `/contact` page with: a dark-theme contact-variant hero, then a `contact_area` paragraph holding the `civictheme_webform` on the left and three `contact_detail` paragraphs (email, phone, location) plus a numbered `card_group` ("What to expect") on the right.
7. Added `contact_page.feature` Behat feature with five scenarios covering page structure, direct-contact details, numbered steps, dark-theme classes, and mobile reflow; updated the existing `contact.feature` heading assertion to match the hero title.

## Screenshots

![Contact page](https://raw.githubusercontent.com/drevops/website/ec0d7160bef3ec2e7c8df533466921d0286c85b7/feature-203-contact-page/0ab28196f87d826120e7735299e404e359a7fced.png)

## Before / After

```
Before
┌───────────────────────────────────────────────┐
│ CivicTheme banner: "Contact"                  │
│ Webform (contact enquiry)                     │
└───────────────────────────────────────────────┘

After
┌───────────────────────────────────────────────┐
│ Hero (dark, contact variant)                  │
│   "Let's talk about your platform."           │
├─────────────────────┬─────────────────────────┤
│ contact_area (dark) │                         │
│  Main column        │  Aside column           │
│  ─ webform          │  ─ Email contact_detail │
│                     │  ─ Phone contact_detail │
│                     │  ─ Location detail      │
│                     │  ─ card_group           │
│                     │    "What to expect"     │
│                     │    (3 numbered cards)   │
└─────────────────────┴─────────────────────────┘
```
