### PR TITLE
[#240] Enabled path-based active trail so blog posts highlight Blog in navigation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/highlight_js": "^1.3",
         "drupal/key_auth": "^2.2",
         "drupal/lagoon_logs": "^3.0.1",
+        "drupal/menu_trail_by_path": "^2.2",
         "drupal/metatag": "^2.2",
         "drupal/pathauto": "^1.15",
         "drupal/purge": "^3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cbe9923a0291bf3d8f8432f7583faedf",
+    "content-hash": "39d153685157cef636ea2de3d6672121",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4454,6 +4454,66 @@
             "homepage": "https://www.drupal.org/project/menu_block",
             "support": {
                 "source": "https://git.drupalcode.org/project/menu_block"
+            }
+        },
+        {
+            "name": "drupal/menu_trail_by_path",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/menu_trail_by_path.git",
+                "reference": "2.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/menu_trail_by_path-2.2.0.zip",
+                "reference": "2.2.0",
+                "shasum": "aba140af80ad217b6543c10bde312c85d75f945a"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.2.0",
+                    "datestamp": "1747319648",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "davy-r",
+                    "homepage": "https://www.drupal.org/user/3278771"
+                },
+                {
+                    "name": "mbovan",
+                    "homepage": "https://www.drupal.org/user/3149657"
+                },
+                {
+                    "name": "redndahead",
+                    "homepage": "https://www.drupal.org/user/160320"
+                },
+                {
+                    "name": "SeriousMatters",
+                    "homepage": "https://www.drupal.org/user/290439"
+                }
+            ],
+            "description": "Expand menus and set active-trail according to the current path.",
+            "homepage": "https://www.drupal.org/project/menu_trail_by_path",
+            "support": {
+                "source": "https://git.drupalcode.org/project/menu_trail_by_path"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -68,6 +68,7 @@ module:
   media_library: 0
   menu_block: 0
   menu_link_content: 0
+  menu_trail_by_path: 0
   menu_ui: 0
   metatag: 0
   metatag_dc: 0

--- a/config/default/menu_trail_by_path.settings.yml
+++ b/config/default/menu_trail_by_path.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: ZgwJ8bM6k-25MIqJjDtxAs94eahFxWfBq2IuHf-qh_I
+max_path_parts: 0
+trail_source: path

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -94,10 +94,15 @@ class FeatureContext extends DrupalContext {
       'type' => $content_type,
       'title' => $title,
     ]);
+
+    if (count($nodes) !== 1) {
+      throw new \RuntimeException(sprintf('Expected exactly one "%s" content item with the title "%s", but found %d.', $content_type, $title, count($nodes)));
+    }
+
     $node = reset($nodes);
 
     if (!$node instanceof NodeInterface) {
-      throw new \RuntimeException(sprintf('Unable to find "%s" content with the title "%s".', $content_type, $title));
+      throw new \RuntimeException(sprintf('The "%s" content with the title "%s" is not a node.', $content_type, $title));
     }
 
     $node->set('path', ['alias' => $alias, 'pathauto' => PathautoState::SKIP]);

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -89,6 +89,7 @@ class FeatureContext extends DrupalContext {
    */
   #[Given('the :content_type content :title has the path alias :alias')]
   public function contentSetPathAlias(string $content_type, string $title, string $alias): void {
+    // @phpstan-ignore globalDrupalDependencyInjection.useDependencyInjection
     $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties([
       'type' => $content_type,
       'title' => $title,

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -36,7 +36,10 @@ use DrevOps\BehatSteps\LinkTrait;
 use DrevOps\BehatSteps\PathTrait;
 use DrevOps\BehatSteps\ResponseTrait;
 use DrevOps\BehatSteps\WaitTrait;
+use Behat\Step\Given;
 use Drupal\DrupalExtension\Context\DrupalContext;
+use Drupal\node\NodeInterface;
+use Drupal\pathauto\PathautoState;
 
 /**
  * Defines application features from the specific context.
@@ -72,5 +75,32 @@ class FeatureContext extends DrupalContext {
   use UserTrait;
   use WaitTrait;
   use WatchdogTrait;
+
+  /**
+   * Set an explicit path alias for a node, bypassing pathauto.
+   *
+   * Pathauto regenerates the alias from the configured pattern on save, so a
+   * nested alias cannot be created through the standard content steps. Skipping
+   * pathauto for this node preserves the explicit alias.
+   *
+   * @code
+   * Given the "civictheme_page" content "[TEST] Article" has the path alias "/section/article"
+   * @endcode
+   */
+  #[Given('the :content_type content :title has the path alias :alias')]
+  public function contentSetPathAlias(string $content_type, string $title, string $alias): void {
+    $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties([
+      'type' => $content_type,
+      'title' => $title,
+    ]);
+    $node = reset($nodes);
+
+    if (!$node instanceof NodeInterface) {
+      throw new \RuntimeException(sprintf('Unable to find "%s" content with the title "%s".', $content_type, $title));
+    }
+
+    $node->set('path', ['alias' => $alias, 'pathauto' => PathautoState::SKIP]);
+    $node->save();
+  }
 
 }

--- a/tests/behat/features/navigation_active_trail.feature
+++ b/tests/behat/features/navigation_active_trail.feature
@@ -1,0 +1,36 @@
+@navigation @p1 @drevops
+Feature: Navigation active trail
+
+  As a site visitor
+  I want the navigation to highlight the section I am viewing
+  So that I can orient myself within the site
+
+  # The primary, side and mobile navigations all render the same
+  # "Primary Navigation" menu and share one active trail. A page nested under a
+  # section landing page (for example a blog post under "/blog") is a separate
+  # node from the landing page, so without a path-based active trail the section
+  # link is never highlighted. These scenarios assert the path-based active trail
+  # via the always-present primary navigation.
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                   | status |
+      | [TEST] Navtrail Section | 1      |
+      | [TEST] Navtrail Article | 1      |
+    And the "civictheme_page" content "[TEST] Navtrail Section" has the path alias "/test-navtrail-section"
+    And the "civictheme_page" content "[TEST] Navtrail Article" has the path alias "/test-navtrail-section/test-navtrail-article"
+    And the following menu links exist in the menu "Primary Navigation":
+      | title                   | enabled | uri                             |
+      | [TEST] Navtrail Section | 1       | internal:/test-navtrail-section |
+
+  @api
+  Scenario: Section parent is highlighted when viewing a nested child page
+    Given I am an anonymous user
+    When I go to "/test-navtrail-section/test-navtrail-article"
+    Then I should see "[TEST] Navtrail Section" in the ".ct-primary-navigation .ct-menu__item--active-trail" element
+
+  @api
+  Scenario: Section parent is not highlighted on an unrelated page
+    Given I am an anonymous user
+    When I go to the homepage
+    Then I should not see a ".ct-primary-navigation .ct-menu__item--active-trail" element


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#240] Verb in past tense.`
- [x] Ticket number `#240` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

Closes #240

1. Added `drupal/menu_trail_by_path` 2.2.0 to `composer.json` and `composer.lock`.
2. Enabled `menu_trail_by_path` in `config/default/core.extension.yml` and exported its default settings to `config/default/menu_trail_by_path.settings.yml` (`trail_source: path`).
3. Added a custom Behat step `contentSetPathAlias` to `FeatureContext.php` that sets an explicit URL alias on a node while skipping pathauto regeneration - needed because pathauto would overwrite a hand-crafted nested alias on save.
4. Added `tests/behat/features/navigation_active_trail.feature` with two `@api` scenarios: one asserts the parent section link carries the `ct-menu__item--active-trail` class when a nested child page is viewed; the other asserts no active-trail class appears on an unrelated page.

**Why this was broken:** Blog posts are `civictheme_page` nodes served at `/blog/<slug>`, separate from the `/blog` landing node that owns the "Blog" menu link. Drupal's default active-trail logic only marks a menu link active when the current route matches the link's target node directly. Because blog post nodes do not share a route with the "Blog" menu link, the link was never included in the active trail. `menu_trail_by_path` replaces that logic with a URL-path prefix check, so any page whose path starts with `/blog` marks the "Blog" menu link active in the primary, side, and mobile navigations (all three render the same `civictheme-primary-navigation` menu).

## Screenshots

![Side navigation highlighting Blog on a blog post](https://raw.githubusercontent.com/drevops/website/259846d65fbc1d25a74f9826b4781df57ca81301/feature-240-blog-nav-active/5882948be05a98502f41bde0dcc284cd85008ed7.png)

## Before / After

```
BEFORE (blog post page)
┌─────────────────────────────────────────────────┐
│ Side Navigation                                  │
│                                                  │
│  Home                                            │
│  Blog          ← ct-menu__item--level-0          │
│                  (no active class)               │
│  About                                           │
└─────────────────────────────────────────────────┘

AFTER (blog post page)
┌─────────────────────────────────────────────────┐
│ Side Navigation                                  │
│                                                  │
│  Home                                            │
│  Blog          ← ct-menu__item--level-0          │
│                  ct-menu__item--active-trail     │
│                  aria-current="page"             │
│  About                                           │
└─────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation active-trail so the correct section remains highlighted when visiting nested pages, including cases that use custom path aliases.
* **Tests**
  * Added end-to-end coverage to verify section highlighting on child pages and confirm it does not appear on the homepage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->