### PR TITLE
Excluded the superuser from the content authoring API moderation policy so drafts can be published.

### DIFF
--- a/web/modules/custom/do_content_api/src/Hook/ModerationPolicyHook.php
+++ b/web/modules/custom/do_content_api/src/Hook/ModerationPolicyHook.php
@@ -26,6 +26,14 @@ final class ModerationPolicyHook {
    */
   #[Hook('entity_presave', order: new OrderBefore(['content_moderation']))]
   public function entityPresave(EntityInterface $entity): void {
+    // User 1 bypasses every permission check, so the authoring-permission gate
+    // below would also match the superuser and force its content into the API
+    // moderation policy. The policy targets the dedicated API service account
+    // only, so the superuser is excluded explicitly.
+    if ((int) $this->account->id() === 1) {
+      return;
+    }
+
     if (!$this->account->hasPermission('use content authoring api')) {
       return;
     }

--- a/web/modules/custom/do_content_api/tests/src/Kernel/Hook/ModerationPolicyHookTest.php
+++ b/web/modules/custom/do_content_api/tests/src/Kernel/Hook/ModerationPolicyHookTest.php
@@ -8,6 +8,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\User;
 use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
 use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
@@ -167,6 +168,28 @@ class ModerationPolicyHookTest extends KernelTestBase {
     $node = Node::create([
       'type' => 'civictheme_page',
       'title' => '[TEST] Editor page',
+      'moderation_state' => 'published',
+    ]);
+    $node->save();
+
+    $this->assertSame('published', $node->get('moderation_state')->value);
+    $this->assertTrue($node->isPublished());
+  }
+
+  /**
+   * Tests that the superuser is treated as an ordinary administrator.
+   */
+  public function testSuperuserPageUnaffected(): void {
+    // User 1 holds no authoring permission but bypasses every permission
+    // check, so without an explicit guard the policy would force its content
+    // to draft and silently block an administrator from publishing.
+    $superuser = User::load(1);
+    $this->assertInstanceOf(User::class, $superuser);
+    $this->setCurrentUser($superuser);
+
+    $node = Node::create([
+      'type' => 'civictheme_page',
+      'title' => '[TEST] Superuser page',
       'moderation_state' => 'published',
     ]);
     $node->save();


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added an early `return` in `ModerationPolicyHook::entityPresave()` when the current user is uid 1 (`$this->account->id() === 1`), so the API moderation policy (force nodes to `draft`, media to `published`) is skipped entirely for the superuser. Drupal user 1 bypasses every permission check, which meant the `use content authoring api` gate also matched the superuser and silently reverted any admin-published node back to `draft`, making it impossible to publish content through the admin UI.
2. Added kernel test `testSuperuserPageUnaffected` in `ModerationPolicyHookTest` that loads user 1, sets it as the current user, creates a page node with `moderation_state = published`, saves it, and asserts the node remains `published` after `entity_presave` fires.

## Screenshots

N/A — PHP hook and kernel test change only; no templates, CSS, JS, or UI components modified.

## Before / After

```
BEFORE (uid 1 publishing via admin UI)
┌─────────────────────────────────────────────────────────────┐
│  Admin saves node → state = "published"                     │
│        ↓                                                    │
│  entity_presave fires                                       │
│        ↓                                                    │
│  hasPermission('use content authoring api') — BYPASSED      │
│  by uid 1 → evaluates TRUE                                  │
│        ↓                                                    │
│  Hook forces moderation_state = "draft"          ← BUG      │
│        ↓                                                    │
│  Node saved as Draft (admin intent ignored)                 │
└─────────────────────────────────────────────────────────────┘

AFTER (uid 1 publishing via admin UI)
┌─────────────────────────────────────────────────────────────┐
│  Admin saves node → state = "published"                     │
│        ↓                                                    │
│  entity_presave fires                                       │
│        ↓                                                    │
│  account->id() === 1 → TRUE → early return        ← FIX     │
│        ↓                                                    │
│  Hook exits without touching moderation state               │
│        ↓                                                    │
│  Node saved as Published (admin intent preserved)           │
└─────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Content saved by the superuser now keeps its existing moderation state instead of being forced into draft.
  * Publishing behavior remains unchanged for superuser-authored pages, so published content stays published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->