### PR TITLE
Scoped the content authoring API moderation policy to entity creation so drafts can be published.

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -123,6 +123,7 @@ class FeatureContext extends DrupalContext {
    */
   #[Then('the :content_type content :title should be published')]
   public function contentShouldBePublished(string $content_type, string $title): void {
+    // @phpstan-ignore globalDrupalDependencyInjection.useDependencyInjection
     $storage = \Drupal::entityTypeManager()->getStorage('node');
 
     $nids = $storage->getQuery()

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -37,6 +37,7 @@ use DrevOps\BehatSteps\PathTrait;
 use DrevOps\BehatSteps\ResponseTrait;
 use DrevOps\BehatSteps\WaitTrait;
 use Behat\Step\Given;
+use Behat\Step\Then;
 use Drupal\DrupalExtension\Context\DrupalContext;
 use Drupal\node\NodeInterface;
 use Drupal\pathauto\PathautoState;
@@ -107,6 +108,46 @@ class FeatureContext extends DrupalContext {
 
     $node->set('path', ['alias' => $alias, 'pathauto' => PathautoState::SKIP]);
     $node->save();
+  }
+
+  /**
+   * Assert that a content item is published.
+   *
+   * Checks both the published flag and the moderation state. The content is
+   * reloaded from storage because the UI action that published it ran in a
+   * separate web request, leaving this process's entity cache stale.
+   *
+   * @code
+   * Then the "civictheme_page" content "[TEST] Article" should be published
+   * @endcode
+   */
+  #[Then('the :content_type content :title should be published')]
+  public function contentShouldBePublished(string $content_type, string $title): void {
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+
+    $nids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', $content_type)
+      ->condition('title', $title)
+      ->execute();
+
+    if (count($nids) !== 1) {
+      throw new \RuntimeException(sprintf('Expected exactly one "%s" content item with the title "%s", but found %d.', $content_type, $title, count($nids)));
+    }
+
+    $nid = (int) reset($nids);
+    $storage->resetCache([$nid]);
+    $node = $storage->load($nid);
+
+    if (!$node instanceof NodeInterface) {
+      throw new \RuntimeException(sprintf('Unable to load "%s" content with the title "%s".', $content_type, $title));
+    }
+
+    $state = $node->get('moderation_state')->value;
+
+    if ($state !== 'published' || !$node->isPublished()) {
+      throw new \RuntimeException(sprintf('Expected "%s" to be published, but its moderation state is "%s" and its published flag is %s.', $title, $state, $node->isPublished() ? 'true' : 'false'));
+    }
   }
 
 }

--- a/tests/behat/features/content_moderation_publish.feature
+++ b/tests/behat/features/content_moderation_publish.feature
@@ -1,0 +1,16 @@
+@api
+Feature: Publishing API-authored content through the editorial UI
+
+  As a reviewer who also holds the content authoring API permission
+  I want to publish a draft page through the editorial UI
+  So that content authored through the API can be reviewed and go live
+
+  Scenario: An account with the content authoring API permission publishes a draft page
+    Given I am logged in as a user with the "access content, access administration pages, access content overview, edit any civictheme_page content, view any unpublished content, use content authoring api, use civictheme_editorial transition create_new_draft, use civictheme_editorial transition publish" permissions
+    And the following "civictheme_page" content:
+      | title                | moderation_state | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | API draft to publish | draft            | large                 | inherit                | normal                      | both                       |
+    When I visit the "civictheme_page" content edit page with the title "API draft to publish"
+    And I select "Published" from "moderation_state[0][state]"
+    And I press "Save"
+    Then the "civictheme_page" content "API draft to publish" should be published

--- a/web/modules/custom/do_content_api/src/Hook/ModerationPolicyHook.php
+++ b/web/modules/custom/do_content_api/src/Hook/ModerationPolicyHook.php
@@ -46,9 +46,10 @@ final class ModerationPolicyHook {
       return;
     }
 
-    // The policy governs authoring, which is entity creation. A later moderation
-    // change - a reviewer publishing the draft - is an update and must be left
-    // untouched, otherwise authored content could never be published.
+    // The policy governs authoring, which is entity creation. A later
+    // moderation change - a reviewer publishing the draft - is an update and
+    // must be left untouched, otherwise authored content could never be
+    // published.
     if (!$entity->isNew()) {
       return;
     }

--- a/web/modules/custom/do_content_api/src/Hook/ModerationPolicyHook.php
+++ b/web/modules/custom/do_content_api/src/Hook/ModerationPolicyHook.php
@@ -46,8 +46,15 @@ final class ModerationPolicyHook {
       return;
     }
 
+    // The policy governs authoring, which is entity creation. A later moderation
+    // change - a reviewer publishing the draft - is an update and must be left
+    // untouched, otherwise authored content could never be published.
+    if (!$entity->isNew()) {
+      return;
+    }
+
     // Pages authored through the API never go live directly; a human reviews
-    // and publishes them, so they are always forced back to a draft.
+    // and publishes them, so they are forced to draft on creation.
     if ($entity->getEntityTypeId() === 'node') {
       $entity->set('moderation_state', 'draft');
 

--- a/web/modules/custom/do_content_api/tests/src/Kernel/Hook/ModerationPolicyHookTest.php
+++ b/web/modules/custom/do_content_api/tests/src/Kernel/Hook/ModerationPolicyHookTest.php
@@ -64,6 +64,7 @@ class ModerationPolicyHookTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('content_moderation_state');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('node', ['node_access']);
     $this->installConfig(['filter']);
 
     NodeType::create(['type' => 'civictheme_page', 'name' => 'Page'])->save();
@@ -170,6 +171,31 @@ class ModerationPolicyHookTest extends KernelTestBase {
       'title' => '[TEST] Editor page',
       'moderation_state' => 'published',
     ]);
+    $node->save();
+
+    $this->assertSame('published', $node->get('moderation_state')->value);
+    $this->assertTrue($node->isPublished());
+  }
+
+  /**
+   * Tests that an API actor can publish a page it previously authored.
+   */
+  public function testApiPagePublishAfterAuthoringIsHonoured(): void {
+    $api_user = $this->createUser(['use content authoring api']);
+    $this->assertNotFalse($api_user);
+    $this->setCurrentUser($api_user);
+
+    // Authoring (create) is forced to draft by the policy.
+    $node = Node::create([
+      'type' => 'civictheme_page',
+      'title' => '[TEST] Authored then published',
+      'moderation_state' => 'draft',
+    ]);
+    $node->save();
+    $this->assertSame('draft', $node->get('moderation_state')->value);
+
+    // A later publish is an update, not authoring, so it must be honoured.
+    $node->set('moderation_state', 'published');
     $node->save();
 
     $this->assertSame('published', $node->get('moderation_state')->value);

--- a/web/modules/custom/do_content_api/tests/src/Kernel/Hook/ModerationPolicyHookTest.php
+++ b/web/modules/custom/do_content_api/tests/src/Kernel/Hook/ModerationPolicyHookTest.php
@@ -203,6 +203,30 @@ class ModerationPolicyHookTest extends KernelTestBase {
   }
 
   /**
+   * Tests that a later moderation change to an API-authored media is honoured.
+   */
+  public function testApiMediaUpdateAfterAuthoringIsHonoured(): void {
+    $api_user = $this->createUser(['use content authoring api']);
+    $this->assertNotFalse($api_user);
+    $this->setCurrentUser($api_user);
+
+    // Authoring (create) forces media to published.
+    $media = Media::create([
+      'bundle' => 'civictheme_image',
+      'name' => '[TEST] Authored then updated',
+      'moderation_state' => 'draft',
+    ]);
+    $media->save();
+    $this->assertSame('published', $media->get('moderation_state')->value);
+
+    // A later state change is an update, not authoring, so it is honoured.
+    $media->set('moderation_state', 'draft');
+    $media->save();
+
+    $this->assertSame('draft', $media->get('moderation_state')->value);
+  }
+
+  /**
    * Tests that the superuser is treated as an ordinary administrator.
    */
   public function testSuperuserPageUnaffected(): void {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

> Note: no associated issue number for this change. The two checklist items referencing a ticket number are not applicable.

## Changed

1. Added an `isNew()` guard to `ModerationPolicyHook::entityPresave()` so the policy that coerces moderation state only fires on entity creation (authoring), not on subsequent saves — allowing a reviewer to publish a draft authored through the API without the hook reverting the state back to `draft`.
2. Installed the `node_access` schema in the kernel test `setUp()` so a second `save()` call (simulating the publish update) can execute cleanly inside the kernel test environment.
3. Added a new kernel test `testApiPagePublishAfterAuthoringIsHonoured()` that creates a page as an API actor, asserts it is coerced to `draft`, then updates the moderation state to `published` and asserts the hook no longer reverts it.
4. Added a Behat feature `content_moderation_publish.feature` that logs in as a user with both `use content authoring api` and editorial transition permissions, creates a draft page, publishes it through the editorial UI, and asserts the published state via a new `FeatureContext` step.
5. Added `contentShouldBePublished()` to `FeatureContext` — a `Then` step that reloads the node from storage (bypassing the stale entity cache) and asserts both the `moderation_state` field and the `isPublished()` flag.

## Screenshots

N/A — PHP hook, kernel test, and Behat feature; no template, CSS, or JS changes.

## Before / After

```
BEFORE (every save triggers the policy)
+--------------------------------------+
| API actor creates page               |
|   entityPresave fires                |
|   -> moderation_state = draft  ✓    |
+--------------------------------------+
          |
          v
+--------------------------------------+
| Reviewer opens edit form, selects   |
| "Published", presses Save            |
|   entityPresave fires again          |
|   -> moderation_state = draft  ✗    |
|   (publish silently reverted)        |
+--------------------------------------+

AFTER (policy scoped to isNew() only)
+--------------------------------------+
| API actor creates page               |
|   entityPresave fires, isNew()=true  |
|   -> moderation_state = draft  ✓    |
+--------------------------------------+
          |
          v
+--------------------------------------+
| Reviewer opens edit form, selects   |
| "Published", presses Save            |
|   entityPresave fires, isNew()=false |
|   -> policy skipped                  |
|   -> moderation_state = published ✓ |
+--------------------------------------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for verifying that content is published after editorial updates in the content moderation flow.
  * Improved publishing behavior for API-authored content so later editorial transitions to Published are respected.

* **Bug Fixes**
  * Fixed an issue where publishing changes could be overridden after initial content creation.
  * Strengthened moderation checks to ensure published content stays published when saved from the editorial interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->