### PR TITLE
[#246] Added focal-point image style for banner featured image.

### DIFF
--- a/config/default/image.style.civictheme_banner_featured.yml
+++ b/config/default/image.style.civictheme_banner_featured.yml
@@ -1,0 +1,23 @@
+uuid: 1ca889fe-b7a4-4fb9-922e-76e9463b280f
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: civictheme_banner_featured
+label: 'Banner Featured Image'
+effects:
+  00a742ba-c206-45ad-a0aa-3ec6424ab498:
+    uuid: 00a742ba-c206-45ad-a0aa-3ec6424ab498
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 800
+      height: 800
+      crop_type: focal_point
+  de1c7da0-031e-4b2e-9dec-384198b5d6e3:
+    uuid: de1c7da0-031e-4b2e-9dec-384198b5d6e3
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/web/themes/custom/drevops/includes/banner.inc
+++ b/web/themes/custom/drevops/includes/banner.inc
@@ -66,10 +66,6 @@ function _drevops_preprocess_block__civictheme_banner(array &$variables): void {
  * @see _civictheme_preprocess_block__civictheme_banner__node()
  */
 function _drevops_preprocess_block__civictheme_banner__featured_image(array &$variables): void {
-  if (empty($variables['featured_image'])) {
-    return;
-  }
-
   $block = $variables['elements']['content']['#block_content'] ?? NULL;
 
   $route_match = \Drupal::routeMatch();

--- a/web/themes/custom/drevops/includes/banner.inc
+++ b/web/themes/custom/drevops/includes/banner.inc
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use Drupal\civictheme\CivicthemeConstants;
 use Drupal\Component\Render\MarkupInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\media\MediaInterface;
 
 /**
  * Pre-process for Banner block.
@@ -26,6 +27,8 @@ function _drevops_preprocess_block__civictheme_banner(array &$variables): void {
   if ($block->bundle() !== 'civictheme_banner' || ($block->hasField('field_c_b_type') && $block->field_c_b_type->isEmpty())) {
     return;
   }
+
+  _drevops_preprocess_block__civictheme_banner__featured_image($variables);
 
   // Finds a banner type.
   $type = civictheme_get_field_value($block, 'field_c_b_banner_type', TRUE, CivicthemeConstants::BANNER_TYPE_DEFAULT);
@@ -48,6 +51,44 @@ function _drevops_preprocess_block__civictheme_banner(array &$variables): void {
   // @phpstan-ignore-next-line instanceof.alwaysFalse
   if (!empty($variables['title']) && is_string($variables['title']) && !($variables['title'] instanceof MarkupInterface)) {
     $variables['title'] = Markup::create($variables['title']);
+  }
+}
+
+/**
+ * Apply a focal-point image style to the banner featured image.
+ *
+ * The base theme serves the original featured image file, leaving the browser
+ * to crop it with object-fit, which ignores the editor-defined focal point.
+ * Re-resolving the same media through a focal-point image style moves the crop
+ * server-side so the focal point is honoured.
+ *
+ * @see _civictheme_preprocess_block__civictheme_banner()
+ * @see _civictheme_preprocess_block__civictheme_banner__node()
+ */
+function _drevops_preprocess_block__civictheme_banner__featured_image(array &$variables): void {
+  if (empty($variables['featured_image'])) {
+    return;
+  }
+
+  $block = $variables['elements']['content']['#block_content'] ?? NULL;
+
+  $route_match = \Drupal::routeMatch();
+  $node = $route_match->getParameter('node_revision') ?: $route_match->getParameter('node');
+
+  // A per-node featured image overrides the block-level one, mirroring the base
+  // theme's resolution order.
+  $media = !empty($node) ? civictheme_get_field_value($node, 'field_c_n_banner_featured_image', TRUE) : NULL;
+  if (empty($media) && !empty($block)) {
+    $media = civictheme_get_field_value($block, 'field_c_b_featured_image', TRUE);
+  }
+
+  if (!$media instanceof MediaInterface) {
+    return;
+  }
+
+  $featured_image = civictheme_media_image_get_variables($media, 'civictheme_banner_featured');
+  if (!empty($featured_image)) {
+    $variables['featured_image'] = $featured_image;
   }
 }
 

--- a/web/themes/custom/drevops/includes/banner.inc
+++ b/web/themes/custom/drevops/includes/banner.inc
@@ -73,7 +73,7 @@ function _drevops_preprocess_block__civictheme_banner__featured_image(array &$va
 
   // A per-node featured image overrides the block-level one, mirroring the base
   // theme's resolution order.
-  $media = !empty($node) ? civictheme_get_field_value($node, 'field_c_n_banner_featured_image', TRUE, build: $variables) : NULL;
+  $media = empty($node) ? NULL : civictheme_get_field_value($node, 'field_c_n_banner_featured_image', TRUE, build: $variables);
   if (empty($media) && !empty($block)) {
     $media = civictheme_get_field_value($block, 'field_c_b_featured_image', TRUE, build: $variables);
   }

--- a/web/themes/custom/drevops/includes/banner.inc
+++ b/web/themes/custom/drevops/includes/banner.inc
@@ -73,9 +73,9 @@ function _drevops_preprocess_block__civictheme_banner__featured_image(array &$va
 
   // A per-node featured image overrides the block-level one, mirroring the base
   // theme's resolution order.
-  $media = !empty($node) ? civictheme_get_field_value($node, 'field_c_n_banner_featured_image', TRUE) : NULL;
+  $media = !empty($node) ? civictheme_get_field_value($node, 'field_c_n_banner_featured_image', TRUE, build: $variables) : NULL;
   if (empty($media) && !empty($block)) {
-    $media = civictheme_get_field_value($block, 'field_c_b_featured_image', TRUE);
+    $media = civictheme_get_field_value($block, 'field_c_b_featured_image', TRUE, build: $variables);
   }
 
   if (!$media instanceof MediaInterface) {


### PR DESCRIPTION
Closes #246

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#246] Verb in past tense.`
- [x] Ticket number `#246` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added `config/default/image.style.civictheme_banner_featured.yml` — a new `civictheme_banner_featured` image style ("Banner Featured Image") that applies `focal_point_scale_and_crop` at 800×800 with `crop_type: focal_point`, followed by `image_convert` to `webp`. Mirrors the existing focal-point styles (`civictheme_slider_slide`, `civictheme_campaign`) and the webp conversion used by the `wide` style. The `focal_point` module was already enabled.
2. Added `_drevops_preprocess_block__civictheme_banner__featured_image()` in `web/themes/custom/drevops/includes/banner.inc` — resolves the banner featured media (node-level `field_c_n_banner_featured_image` overrides block-level `field_c_b_featured_image`, mirroring CivicTheme's own resolution order) and applies `civictheme_media_image_get_variables($media, 'civictheme_banner_featured')` so the focal-point-cropped derivative URL replaces the original. The `build` render array is passed to field lookups so cacheability metadata bubbles correctly. No-ops when there is no featured image.

Previously the featured image was served at its original upload size and cropped by the browser via CSS `object-fit: cover`, which centre-crops and ignores the editor-defined focal point. Moving the crop server-side via the focal-point style means the focal point is now honoured.

## Screenshots

![Banner featured image with focal-point crop](https://raw.githubusercontent.com/drevops/website/d16cd1c39d7f707a0b6e894b418f7aa339bf4dac/feature-246-banner-focal-image/43063b72243ddce92880650b1c1d4392fb08373a.png)

## Before / After

```
Before
──────────────────────────────────────────────────
Banner featured image rendered at original size,
cropped by browser CSS object-fit: cover
→ focal point ignored, crop always centred

After
──────────────────────────────────────────────────
Banner featured image passed through the new
civictheme_banner_featured image style (800×800
focal_point_scale_and_crop → image_convert webp)
→ crop happens server-side around the focal point
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new banner featured image style for optimized 800×800 cropped images with WebP output.
  * Banner blocks now display a featured image when available, with support for a node-level image override.
* **Bug Fixes**
  * Improved banner image handling to better resolve and apply the correct featured media in the banner area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->