### PR TITLE
Added the 'How We Work' page with a reusable 'steps' component seeded via a deploy hook.

### DIFF
--- a/config/default/core.entity_form_display.paragraph.steps.default.yml
+++ b/config/default/core.entity_form_display.paragraph.steps.default.yml
@@ -1,0 +1,77 @@
+uuid: 48f2ec2d-35d7-447c-a94b-5d58a16123aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.steps.field_c_p_background
+    - field.field.paragraph.steps.field_c_p_content
+    - field.field.paragraph.steps.field_c_p_list_items
+    - field.field.paragraph.steps.field_c_p_theme
+    - field.field.paragraph.steps.field_c_p_title
+    - field.field.paragraph.steps.field_c_p_vertical_spacing
+    - paragraphs.paragraphs_type.steps
+  module:
+    - paragraphs
+    - text
+id: paragraph.steps.default
+targetEntityType: paragraph
+bundle: steps
+mode: default
+content:
+  field_c_p_background:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_c_p_content:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_list_items:
+    type: paragraphs
+    weight: 2
+    region: content
+    settings:
+      title: Step
+      title_plural: Steps
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: steps_item
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_c_p_theme:
+    type: options_buttons
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_p_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_vertical_spacing:
+    type: options_buttons
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_form_display.paragraph.steps_item.default.yml
+++ b/config/default/core.entity_form_display.paragraph.steps_item.default.yml
@@ -1,0 +1,41 @@
+uuid: 047e21ba-a187-4dba-bee1-7e16fa9dc1aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.steps_item.field_c_p_summary
+    - field.field.paragraph.steps_item.field_c_p_title
+    - field.field.paragraph.steps_item.field_p_receive
+    - paragraphs.paragraphs_type.steps_item
+id: paragraph.steps_item.default
+targetEntityType: paragraph
+bundle: steps_item
+mode: default
+content:
+  field_c_p_summary:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_p_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_p_receive:
+    type: string_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/config/default/core.entity_view_display.paragraph.steps.default.yml
+++ b/config/default/core.entity_view_display.paragraph.steps.default.yml
@@ -1,0 +1,33 @@
+uuid: 17340d30-d03c-4cf3-939a-0e6ac5ee3635
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.steps.field_c_p_background
+    - field.field.paragraph.steps.field_c_p_content
+    - field.field.paragraph.steps.field_c_p_list_items
+    - field.field.paragraph.steps.field_c_p_theme
+    - field.field.paragraph.steps.field_c_p_title
+    - field.field.paragraph.steps.field_c_p_vertical_spacing
+    - paragraphs.paragraphs_type.steps
+  module:
+    - text
+id: paragraph.steps.default
+targetEntityType: paragraph
+bundle: steps
+mode: default
+content:
+  field_c_p_content:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_c_p_background: true
+  field_c_p_list_items: true
+  field_c_p_theme: true
+  field_c_p_title: true
+  field_c_p_vertical_spacing: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.steps_item.default.yml
+++ b/config/default/core.entity_view_display.paragraph.steps_item.default.yml
@@ -1,0 +1,19 @@
+uuid: bd816465-ef87-416a-87f9-da23dacd0c70
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.steps_item.field_c_p_summary
+    - field.field.paragraph.steps_item.field_c_p_title
+    - field.field.paragraph.steps_item.field_p_receive
+    - paragraphs.paragraphs_type.steps_item
+id: paragraph.steps_item.default
+targetEntityType: paragraph
+bundle: steps_item
+mode: default
+content: {  }
+hidden:
+  field_c_p_summary: true
+  field_c_p_title: true
+  field_p_receive: true
+  search_api_excerpt: true

--- a/config/default/field.field.node.civictheme_page.field_c_n_components.yml
+++ b/config/default/field.field.node.civictheme_page.field_c_n_components.yml
@@ -20,6 +20,7 @@ dependencies:
     - paragraphs.paragraphs_type.civictheme_webform
     - paragraphs.paragraphs_type.divider
     - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.steps
   module:
     - entity_reference_revisions
 _core:
@@ -54,6 +55,7 @@ settings:
       divider: divider
       from_library: from_library
       civictheme_message: civictheme_message
+      steps: steps
     negate: 0
     target_bundles_drag_drop:
       civictheme_accordion:
@@ -151,5 +153,8 @@ settings:
         enabled: true
       from_library:
         weight: 62
+        enabled: true
+      steps:
+        weight: 61
         enabled: true
 field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.steps.field_c_p_background.yml
+++ b/config/default/field.field.paragraph.steps.field_c_p_background.yml
@@ -1,0 +1,23 @@
+uuid: 161741a5-f1dd-4191-86c9-9299ef996e0a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_background
+    - paragraphs.paragraphs_type.steps
+id: paragraph.steps.field_c_p_background
+field_name: field_c_p_background
+entity_type: paragraph
+bundle: steps
+label: Background
+description: 'Apply a themed background colour and provide horizontal spacing to the component.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/field.field.paragraph.steps.field_c_p_content.yml
+++ b/config/default/field.field.paragraph.steps.field_c_p_content.yml
@@ -1,0 +1,22 @@
+uuid: 1420e893-0470-4ddb-9aa1-c34d98255821
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_content
+    - paragraphs.paragraphs_type.steps
+  module:
+    - text
+id: paragraph.steps.field_c_p_content
+field_name: field_c_p_content
+entity_type: paragraph
+bundle: steps
+label: Content
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/default/field.field.paragraph.steps.field_c_p_list_items.yml
+++ b/config/default/field.field.paragraph.steps.field_c_p_list_items.yml
@@ -1,0 +1,31 @@
+uuid: b6d32f06-4197-45a9-84a2-856a8399c963
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_list_items
+    - paragraphs.paragraphs_type.steps
+    - paragraphs.paragraphs_type.steps_item
+  module:
+    - entity_reference_revisions
+id: paragraph.steps.field_c_p_list_items
+field_name: field_c_p_list_items
+entity_type: paragraph
+bundle: steps
+label: Steps
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      steps_item: steps_item
+    negate: 0
+    target_bundles_drag_drop:
+      steps_item:
+        weight: 1
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/default/field.field.paragraph.steps.field_c_p_theme.yml
+++ b/config/default/field.field.paragraph.steps.field_c_p_theme.yml
@@ -1,0 +1,23 @@
+uuid: aaac2c8f-a68f-48de-8482-297e935181a7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_theme
+    - paragraphs.paragraphs_type.steps
+  module:
+    - options
+id: paragraph.steps.field_c_p_theme
+field_name: field_c_p_theme
+entity_type: paragraph
+bundle: steps
+label: Theme
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: light
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.steps.field_c_p_title.yml
+++ b/config/default/field.field.paragraph.steps.field_c_p_title.yml
@@ -1,0 +1,19 @@
+uuid: a93712c3-227f-4d77-9fb1-160af6b57905
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_title
+    - paragraphs.paragraphs_type.steps
+id: paragraph.steps.field_c_p_title
+field_name: field_c_p_title
+entity_type: paragraph
+bundle: steps
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.steps.field_c_p_vertical_spacing.yml
+++ b/config/default/field.field.paragraph.steps.field_c_p_vertical_spacing.yml
@@ -1,0 +1,23 @@
+uuid: 58c254ea-2437-4304-8b67-0a41bcfd86fa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_vertical_spacing
+    - paragraphs.paragraphs_type.steps
+  module:
+    - options
+id: paragraph.steps.field_c_p_vertical_spacing
+field_name: field_c_p_vertical_spacing
+entity_type: paragraph
+bundle: steps
+label: 'Vertical spacing'
+description: 'Adds additional vertical spacing to a component'
+required: true
+translatable: false
+default_value:
+  -
+    value: both
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.paragraph.steps_item.field_c_p_summary.yml
+++ b/config/default/field.field.paragraph.steps_item.field_c_p_summary.yml
@@ -1,0 +1,19 @@
+uuid: bd34f213-ce95-4521-b8f0-0f0155cc1b0e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_summary
+    - paragraphs.paragraphs_type.steps_item
+id: paragraph.steps_item.field_c_p_summary
+field_name: field_c_p_summary
+entity_type: paragraph
+bundle: steps_item
+label: Summary
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.field.paragraph.steps_item.field_c_p_title.yml
+++ b/config/default/field.field.paragraph.steps_item.field_c_p_title.yml
@@ -1,0 +1,19 @@
+uuid: 1733b65a-744b-4f46-8e13-c8166226d09c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_c_p_title
+    - paragraphs.paragraphs_type.steps_item
+id: paragraph.steps_item.field_c_p_title
+field_name: field_c_p_title
+entity_type: paragraph
+bundle: steps_item
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.paragraph.steps_item.field_p_receive.yml
+++ b/config/default/field.field.paragraph.steps_item.field_p_receive.yml
@@ -1,0 +1,19 @@
+uuid: 8ad6f768-9766-422f-9dd3-ae43fe7a97fe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_receive
+    - paragraphs.paragraphs_type.steps_item
+id: paragraph.steps_item.field_p_receive
+field_name: field_p_receive
+entity_type: paragraph
+bundle: steps_item
+label: 'You receive'
+description: 'Outcome shown as a highlighted "You receive:" note for the step.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.storage.paragraph.field_p_receive.yml
+++ b/config/default/field.storage.paragraph.field_p_receive.yml
@@ -1,0 +1,19 @@
+uuid: 40ba1856-ea12-473b-a8d5-ac8cc6c19260
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_p_receive
+field_name: field_p_receive
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/paragraphs.paragraphs_type.steps.yml
+++ b/config/default/paragraphs.paragraphs_type.steps.yml
@@ -1,0 +1,10 @@
+uuid: c6517c4b-7171-423d-b862-2b91724e9df9
+langcode: en
+status: true
+dependencies: {  }
+id: steps
+label: Steps
+icon_uuid: null
+icon_default: null
+description: 'Numbered steps rendered as a vertical journey with an outcome for each step.'
+behavior_plugins: {  }

--- a/config/default/paragraphs.paragraphs_type.steps_item.yml
+++ b/config/default/paragraphs.paragraphs_type.steps_item.yml
@@ -1,0 +1,10 @@
+uuid: 8967f05d-b35e-434b-9387-e6aa85f7127b
+langcode: en
+status: true
+dependencies: {  }
+id: steps_item
+label: Step
+icon_uuid: null
+icon_default: null
+description: 'A single step within the Steps component.'
+behavior_plugins: {  }

--- a/static-prototype/how-we-work.html
+++ b/static-prototype/how-we-work.html
@@ -49,7 +49,7 @@
     }
 
     * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; }
+    html { scroll-behavior: smooth; scroll-padding-top: 96px; }
     body { margin: 0; font-family: var(--font-body); font-size: 18px; line-height: 1.6; color: var(--ct-light-body); background: var(--ct-light-bg-light); -webkit-font-smoothing: antialiased; }
     h1, h2, h3, h4 { font-family: var(--font-heading); font-weight: 700; line-height: 1.2; margin: 0; }
     p { margin: 0 0 1.25rem; }

--- a/static-prototype/how-we-work.html
+++ b/static-prototype/how-we-work.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How We Work - what to expect when you work with us | DrevOps</title>
+  <meta name="description" content="See exactly what working with DrevOps looks like, from the first conversation to go-live: what happens at each step, what you receive, and how we build a price with nothing hidden.">
+
+  <!--
+    DrevOps website page: How We Work.
+    Purpose: let a prospective client see the whole journey and what they receive at each stage,
+    with the pricing walkthrough as transparency proof (no black box).
+    Grounded in Strategy/AIAssistedDelivery.md, the create-project lifecycle + PriceBook process,
+    Commercial/ServicesCatalogue.md, and Branding/CompanyDescription.md.
+    Worked example uses an illustrative $200/hr rate; the real rate is kept off-page. The 20% buffer
+    is framed as a "safety net", never "margin". AI vs hand-built is shown at total level only.
+    Styling matches the CURRENT live drevops.com (CivicTheme "drevops" subtheme tokens, Lexend + Rubik).
+    Hero uses ../HeroBanners/HomepageBanner_5_RightEdge.png (relative), with a dark gradient fallback.
+    Voice: Emma (warm, problem-first). No em dashes.
+  -->
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;600;700&family=Rubik:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --ct-light-heading: #1a2e37;
+      --ct-light-body: #3d4548;
+      --ct-light-bg-light: #fdfefe;
+      --ct-light-bg: #f2f5f8;
+      --ct-light-interaction-text: #fcfdfd;
+      --ct-light-interaction-bg: #2b7099;
+      --ct-light-interaction-hover-bg: #1f5775;
+      --ct-dark-heading: #f9fcfe;
+      --ct-dark-body: #eef7fc;
+      --ct-dark-bg-light: #35485b;
+      --ct-dark-bg: #2b3f53;
+      --ct-dark-bg-dark: #1e2c3a;
+      --ct-dark-border: #405264;
+      --ct-dark-interaction-text: #2b3f53;
+      --ct-dark-interaction-bg: #90cfeb;
+      --ct-dark-interaction-hover-bg: #bce2f3;
+      --ct-highlight: #d16313;
+      --ct-focus: #ff6b6b;
+      --container: 1280px;
+      --font-heading: 'Lexend', sans-serif;
+      --font-body: 'Rubik', sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body { margin: 0; font-family: var(--font-body); font-size: 18px; line-height: 1.6; color: var(--ct-light-body); background: var(--ct-light-bg-light); -webkit-font-smoothing: antialiased; }
+    h1, h2, h3, h4 { font-family: var(--font-heading); font-weight: 700; line-height: 1.2; margin: 0; }
+    p { margin: 0 0 1.25rem; }
+    a { color: var(--ct-light-interaction-bg); }
+
+    .container { max-width: var(--container); margin: 0 auto; padding: 0 24px; }
+    .section { padding: 80px 0; }
+    .section--light { background: var(--ct-light-bg); color: var(--ct-light-body); }
+    .section--white { background: var(--ct-light-bg-light); color: var(--ct-light-body); }
+    .section--dark { background: var(--ct-dark-bg); color: var(--ct-dark-body); }
+    .section--darker { background: var(--ct-dark-bg-dark); color: var(--ct-dark-body); }
+
+    .section__label { font-family: var(--font-heading); font-size: 0.8rem; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ct-highlight); margin: 0 0 12px; }
+    .section--dark .section__label, .section--darker .section__label { color: var(--ct-dark-interaction-bg); }
+    .section__head { max-width: 780px; margin: 0 auto 48px; text-align: center; }
+    .section__head h2 { font-size: 2.1rem; color: var(--ct-light-heading); }
+    .section--dark .section__head h2, .section--darker .section__head h2 { color: var(--ct-dark-heading); }
+    .section__head p { margin-top: 16px; font-size: 1.05rem; }
+    .section__cta { text-align: center; margin-top: 44px; }
+
+    /* Header */
+    .site-header { position: sticky; top: 0; z-index: 50; background: var(--ct-dark-bg-dark); border-bottom: 1px solid var(--ct-dark-border); }
+    .site-header__inner { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 16px 24px; max-width: var(--container); margin: 0 auto; }
+    .site-header__logo img { height: 26px; width: auto; display: block; }
+    .site-nav { display: flex; align-items: center; gap: 26px; }
+    .site-nav a { color: var(--ct-dark-body); text-decoration: none; font-size: 0.95rem; font-weight: 500; }
+    .site-nav a:hover { color: var(--ct-dark-interaction-bg); }
+
+    /* Buttons */
+    .btn { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-heading); font-weight: 600; font-size: 1rem; padding: 14px 36px; border-radius: 4px; border: 2px solid transparent; text-decoration: none; cursor: pointer; transition: background-color 0.2s ease, color 0.2s ease; }
+    .btn svg { width: 20px; height: 20px; fill: currentColor; }
+    .btn--on-dark { background: var(--ct-dark-interaction-bg); color: var(--ct-dark-interaction-text); }
+    .btn--on-dark:hover { background: var(--ct-dark-interaction-hover-bg); }
+    .btn--on-light { background: var(--ct-light-interaction-bg); color: var(--ct-light-interaction-text); }
+    .btn--on-light:hover { background: var(--ct-light-interaction-hover-bg); }
+    .btn--ghost-dark { background: transparent; border-color: var(--ct-dark-interaction-bg); color: var(--ct-dark-interaction-bg); }
+    .btn--ghost-dark:hover { background: var(--ct-dark-interaction-bg); color: var(--ct-dark-interaction-text); }
+
+    /* Hero */
+    .hero { background-color: var(--ct-dark-bg-dark); background-image: linear-gradient(rgba(30, 44, 58, 0.82), rgba(30, 44, 58, 0.92)); background-size: cover; background-position: center right; color: var(--ct-dark-body); padding: 104px 0 96px; }
+    .hero__inner { max-width: 760px; }
+    .hero__eyebrow { font-family: var(--font-heading); font-size: 0.8rem; font-weight: 600; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ct-dark-interaction-bg); margin: 0 0 18px; }
+    .hero h1 { font-size: 3rem; color: var(--ct-dark-heading); margin-bottom: 22px; }
+    .hero__subtitle { font-size: 1.2rem; color: var(--ct-dark-body); margin-bottom: 32px; max-width: 680px; }
+    .hero__actions { display: flex; gap: 16px; flex-wrap: wrap; }
+
+    /* Prose band */
+    .prose { max-width: 820px; margin: 0 auto; text-align: center; }
+    .prose h2 { font-size: 2.1rem; color: var(--ct-light-heading); margin-bottom: 18px; }
+    .section--dark .prose h2, .section--darker .prose h2 { color: var(--ct-dark-heading); }
+    .prose p { font-size: 1.1rem; }
+    .prose--left { text-align: left; }
+
+    /* Journey timeline (the diagram) */
+    .timeline { max-width: 880px; margin: 0 auto; position: relative; }
+    .timeline::before { content: ''; position: absolute; left: 27px; top: 10px; bottom: 10px; width: 2px; background: var(--ct-highlight); opacity: 0.35; }
+    .tl-step { position: relative; padding: 0 0 42px 84px; }
+    .tl-step:last-child { padding-bottom: 0; }
+    .tl-step__num { position: absolute; left: 0; top: 0; width: 56px; height: 56px; border-radius: 50%; background: var(--ct-light-interaction-bg); color: #fff; font-family: var(--font-heading); font-weight: 700; font-size: 1.35rem; display: flex; align-items: center; justify-content: center; box-shadow: 0 2px 8px rgba(26, 46, 55, 0.18); }
+    .tl-step h3 { font-size: 1.3rem; color: var(--ct-light-heading); margin-bottom: 8px; }
+    .tl-step p { margin: 0 0 12px; font-size: 1rem; }
+    .tl-step__receive { font-size: 0.96rem; background: var(--ct-light-bg); border-left: 3px solid var(--ct-highlight); padding: 12px 16px; border-radius: 3px; margin: 0; }
+    .tl-step__receive strong { color: var(--ct-light-heading); }
+
+    /* Tables (transparency proof) */
+    .table-wrap { max-width: 880px; margin: 0 auto 8px; overflow-x: auto; }
+    .rate-table { width: 100%; border-collapse: collapse; font-size: 0.98rem; background: var(--ct-light-bg-light); }
+    .rate-table caption { text-align: left; font-family: var(--font-heading); font-weight: 600; font-size: 0.82rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ct-highlight); margin-bottom: 14px; }
+    .rate-table th, .rate-table td { text-align: left; padding: 12px 18px; border-bottom: 1px solid #e4e9ed; }
+    .rate-table thead th { font-family: var(--font-heading); font-size: 0.74rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ct-light-heading); }
+    .rate-table td:last-child, .rate-table th:last-child { text-align: right; white-space: nowrap; }
+    .rate-table td:nth-child(2), .rate-table th:nth-child(2) { white-space: nowrap; }
+    .rate-table tbody tr.is-total td { font-weight: 700; color: var(--ct-light-heading); border-top: 2px solid var(--ct-light-heading); border-bottom: none; }
+    .rate-table tbody tr.is-highlight td { background: #eef6fb; font-weight: 700; color: var(--ct-light-heading); }
+    .table-note { max-width: 880px; margin: 14px auto 0; font-size: 0.9rem; color: var(--ct-light-body); opacity: 0.85; }
+
+    /* Reassurance cards */
+    .grid { display: grid; gap: 24px; }
+    .grid--3 { grid-template-columns: repeat(3, 1fr); }
+    .card { background: var(--ct-light-bg-light); border-left: 4px solid var(--ct-highlight); border-radius: 4px; padding: 26px 24px; box-shadow: 0 1px 3px rgba(26, 46, 55, 0.08); }
+    .card h3 { font-size: 1.12rem; color: var(--ct-light-heading); margin-bottom: 10px; }
+    .card p { font-size: 0.96rem; margin: 0; color: var(--ct-light-body); }
+
+    /* Bands */
+    .band { text-align: center; }
+    .band__inner { max-width: 780px; margin: 0 auto; }
+    .band h2 { font-size: 2rem; color: var(--ct-dark-heading); margin-bottom: 18px; }
+    .band p { font-size: 1.08rem; color: var(--ct-dark-body); margin-bottom: 26px; }
+    .band__email { display: block; margin-top: 18px; color: var(--ct-dark-interaction-bg); font-weight: 500; text-decoration: none; }
+
+    /* Footer */
+    .site-footer { background: var(--ct-dark-bg-dark); color: var(--ct-dark-body); padding: 56px 0 32px; border-top: 1px solid var(--ct-dark-border); }
+    .site-footer__top { display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; padding-bottom: 28px; border-bottom: 1px solid var(--ct-dark-border); }
+    .site-footer__logo img { height: 24px; width: auto; display: block; }
+    .site-footer__social { display: flex; gap: 18px; }
+    .site-footer__social a { color: var(--ct-dark-body); display: inline-flex; }
+    .site-footer__social a:hover { color: var(--ct-dark-interaction-bg); }
+    .site-footer__social svg { width: 22px; height: 22px; fill: currentColor; }
+    .site-footer__bottom { display: flex; justify-content: space-between; gap: 24px; flex-wrap: wrap; padding-top: 24px; font-size: 0.85rem; }
+    .site-footer__bottom a { color: var(--ct-dark-interaction-bg); }
+    .site-footer__ack { max-width: 640px; opacity: 0.9; }
+
+    @media (max-width: 900px) {
+      .grid--3 { grid-template-columns: 1fr; }
+      .site-nav { display: none; }
+    }
+    @media (max-width: 600px) {
+      .hero h1 { font-size: 2.2rem; }
+      .section { padding: 56px 0; }
+      .tl-step { padding-left: 68px; }
+      .tl-step__num { width: 48px; height: 48px; font-size: 1.15rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- HEADER -->
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-header__logo" href="https://www.drevops.com/"><img src="https://www.drevops.com/themes/custom/drevops/dist/assets/logos/logo_primary_dark_desktop.svg" alt="DrevOps"></a>
+      <nav class="site-nav">
+        <a href="https://www.drevops.com/about">About</a>
+        <a href="https://www.drevops.com/services">Services</a>
+        <a href="https://www.drevops.com/ai-assisted-delivery">AI delivery</a>
+        <a href="https://www.drevops.com/blog">Blog</a>
+        <a href="https://www.drevops.com/contact">Contact</a>
+      </nav>
+      <a href="https://www.drevops.com/contact" class="btn btn--on-dark">Contact us</a>
+    </div>
+  </header>
+
+  <!-- HERO -->
+  <section class="hero">
+    <div class="container">
+      <div class="hero__inner">
+        <p class="hero__eyebrow">How we work</p>
+        <h1>Know exactly what working with us looks like.</h1>
+        <p class="hero__subtitle">From the first conversation to go-live, here is what happens at each step, what you receive along the way, and how we arrive at a price with nothing hidden. So you know what you are getting into before you commit a dollar.</p>
+        <div class="hero__actions">
+          <a href="#journey" class="btn btn--ghost-dark">See the journey</a>
+          <a href="https://www.drevops.com/contact" class="btn btn--on-dark">Start with a free assessment</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INTRO -->
+  <section class="section section--light">
+    <div class="container">
+      <div class="prose">
+        <p class="section__label">Why this page exists</p>
+        <h2>The stressful part is rarely the build.</h2>
+        <p>It is the moment before you commit, when you are handed a single number and asked to trust it, with very little shown above it. Where did it come from? What are you actually paying for? And what happens if the hard parts were guessed wrong?</p>
+        <p>We built our whole process to answer those questions before you have to ask them. Here is exactly what working with us looks like, step by step, and what lands in your hands at each one.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- THE JOURNEY (diagram) -->
+  <section id="journey" class="section section--white">
+    <div class="container">
+      <div class="section__head">
+        <p class="section__label">The journey</p>
+        <h2>Six steps, and what you get at each one.</h2>
+        <p>Every engagement follows the same path. Each step builds on the one before it, and each leaves you with something concrete in hand.</p>
+      </div>
+
+      <div class="timeline">
+        <div class="tl-step">
+          <div class="tl-step__num">1</div>
+          <h3>The first conversation</h3>
+          <p>We listen and map what you actually need, which is often a little different from the initial brief. We do not price anything yet, because we do not know enough yet.</p>
+          <p class="tl-step__receive"><strong>You receive:</strong> a written summary of your goals and scope, confirmed with you before any number exists.</p>
+        </div>
+        <div class="tl-step">
+          <div class="tl-step__num">2</div>
+          <h3>A proper assessment</h3>
+          <p>We review your real platform, the code, the integrations, and the risks, not just the description of it. We name the class of each issue, so it reads as a clear picture rather than a scare document.</p>
+          <p class="tl-step__receive"><strong>You receive:</strong> a clear, honest report you can act on and share. For a straightforward review, this is often free.</p>
+        </div>
+        <div class="tl-step">
+          <div class="tl-step__num">3</div>
+          <h3>A transparent quotation</h3>
+          <p>We price the work from a standard rate card, line by line, adding a buffer only where there are genuine unknowns. One rate, applied the same way for every client.</p>
+          <p class="tl-step__receive"><strong>You receive:</strong> two complete options, hand-built and AI-assisted, with the hours shown and nothing hidden.</p>
+        </div>
+        <div class="tl-step">
+          <div class="tl-step__num">4</div>
+          <h3>Your approval</h3>
+          <p>You review the scope, the timeline, and the price, with a validity window and no pressure. Nothing begins until you have approved the shape of the work.</p>
+          <p class="tl-step__receive"><strong>You receive:</strong> a fixed, agreed number before a single line of code, and a plan you have signed off.</p>
+        </div>
+        <div class="tl-step">
+          <div class="tl-step__num">5</div>
+          <h3>The build</h3>
+          <p>We work in short sprints with a steady rhythm you can follow, testing from day one rather than leaving it to the end. The tooling that keeps us fast is open source, so it can be inspected.</p>
+          <p class="tl-step__receive"><strong>You receive:</strong> a weekly update on hours and budget, and working software you can watch take shape.</p>
+        </div>
+        <div class="tl-step">
+          <div class="tl-step__num">6</div>
+          <h3>Go-live and handover</h3>
+          <p>We handle the release, the go-live, and the handover to your team, so nothing is left dangling once we step back.</p>
+          <p class="tl-step__receive"><strong>You receive:</strong> a platform your team can actually run, with documentation, not just something that works the day we leave.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- TRANSPARENCY PROOF -->
+  <section class="section section--dark">
+    <div class="container">
+      <div class="prose">
+        <p class="section__label">No black box</p>
+        <h2>See how we build the number.</h2>
+        <p>Most agencies keep their pricing hidden. We do the opposite, because a number you can take apart is a number you can trust. Every project is assembled from the same rate card, so the price is just the hours and how confident we are in them. To show you what that means in practice, here is a real kind of project priced in full: a mid-market Drupal 9 site moving to Drupal 11.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- THE ESTIMATE -->
+  <section class="section section--white">
+    <div class="container">
+      <div class="section__head">
+        <p class="section__label">The estimate</p>
+        <h2>Every line, in plain language.</h2>
+        <p>We have grouped the work into plain-English categories rather than internal codes, but the hours and costs are exactly as our process produces them. In this example we price at $200 an hour plus GST. The rate never moves, so the only things that change the price are the hours and the confidence.</p>
+      </div>
+
+      <div class="table-wrap">
+        <table class="rate-table">
+          <caption>What the work takes</caption>
+          <thead>
+            <tr><th>Work</th><th>Hours</th><th>Confidence</th><th>Cost (ex GST)</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Technical assessment</td><td>6</td><td>Very high</td><td>$0 (free)</td></tr>
+            <tr><td>Project setup onto the existing codebase</td><td>14 &rarr; 21</td><td>Moderate (buffered)</td><td>$4,200</td></tr>
+            <tr><td>Feature and template work (19 items, XS to XL)</td><td>84</td><td>Very high</td><td>$16,800</td></tr>
+            <tr><td>Module upgrades and standards cleanup</td><td>25</td><td>Very high</td><td>$5,000</td></tr>
+            <tr><td>Automated tests (15 scenarios)</td><td>40</td><td>Very high</td><td>$8,000</td></tr>
+            <tr><td>Manual integration testing (2 systems)</td><td>16</td><td>Very high</td><td>$3,200</td></tr>
+            <tr><td>Go-live</td><td>12</td><td>Very high</td><td>$2,400</td></tr>
+            <tr><td>Documentation</td><td>8</td><td>Very high</td><td>$1,600</td></tr>
+            <tr class="is-total"><td>Subtotal</td><td>212</td><td></td><td>$41,200</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="table-note">Notice the setup line. It is the only one carrying a buffer. Setting a project up on top of an existing, years-old codebase carries real unknowns, so we rate our confidence as moderate and lift the estimate from 14 hours to 21, openly. Everything else is work we have done many times, so it passes through at face value. Where we are certain, the number stands. Where we are not, you see the buffer instead of a surprise later.</p>
+    </div>
+  </section>
+
+  <!-- FROM WORK TO PRICE -->
+  <section class="section section--light">
+    <div class="container">
+      <div class="section__head">
+        <p class="section__label">From the work to the price</p>
+        <h2>Two things sit on top, and we show you both.</h2>
+      </div>
+
+      <div class="table-wrap">
+        <table class="rate-table">
+          <caption>How the estimate becomes the quote</caption>
+          <tbody>
+            <tr><td>Work subtotal (212 hours)</td><td>$41,200</td></tr>
+            <tr><td>Project oversight (weekly updates and tracking, +10%)</td><td>$45,320</td></tr>
+            <tr><td>Safety net (20%)</td><td>$54,384</td></tr>
+            <tr class="is-highlight"><td>Quoted total (ex GST)</td><td>$54,384</td></tr>
+            <tr><td>GST (10%)</td><td>$59,822</td></tr>
+            <tr class="is-total"><td>Total (inc GST)</td><td>$59,822</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="prose prose--left" style="margin-top: 40px;">
+        <p><strong>Project oversight</strong> is the running of the project: the weekly update that tells you where the hours and the budget stand, the tracking, and the escalation of anything that turns into a risk.</p>
+        <p>The <strong>safety net</strong> is there to protect you as much as us. It is twenty percent, and it is not a markup on the work. It is what lets us hold a fixed price when a project turns up a surprise, the cover for a warranty when something needs a second look after go-live, and the cushion that keeps us a stable business, still here to support you in a year. On a fixed-price project we carry that risk, not you, and the safety net is what makes that promise real. Then GST on top, because we are an Australian business. That is the entire path from hours to the figure on the quote. Nothing else is hiding in there.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- TWO OPTIONS -->
+  <section class="section section--white">
+    <div class="container">
+      <div class="section__head">
+        <p class="section__label">This is what you would receive</p>
+        <h2>Two complete options. You choose.</h2>
+        <p>We can build a project by hand, or AI-assisted, using the testing and review harness we developed ourselves. The rate does not change, so the difference is entirely in the hours, and only on the work that genuinely compresses: the development, the migrations, the automated tests. The assessment, the testing, and the coordination do not move, so we do not pretend they do.</p>
+      </div>
+
+      <div class="table-wrap">
+        <table class="rate-table">
+          <caption>The same project, two ways</caption>
+          <thead>
+            <tr><th>&nbsp;</th><th>Hand-built</th><th>AI-assisted</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Hours</td><td>212</td><td>146</td></tr>
+            <tr><td>Total (ex GST)</td><td>$54,384</td><td>$36,960</td></tr>
+            <tr class="is-total"><td>Total (inc GST)</td><td>$59,822</td><td>$40,656</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="table-note">On this project the AI-assisted path lands about 32 percent below the hand-built one, because a migration is development-heavy and a lot of it compresses. Same rate, same automated tests, same review, same quality bar, roughly a third fewer hours. Every change is reviewed and every build is tested before it ships. You choose the trade-off up front, and we never quietly put your work through the harness to pad the bill.</p>
+    </div>
+  </section>
+
+  <!-- REASSURANCE -->
+  <section class="section section--light">
+    <div class="container">
+      <div class="section__head">
+        <p class="section__label">What holds it together</p>
+        <h2>The habits that keep it honest.</h2>
+      </div>
+      <div class="grid grid--3">
+        <div class="card">
+          <h3>One rate, always</h3>
+          <p>The same hourly rate for every line and every client. It never moves, so the only things that change your price are the hours and how sure we are of them.</p>
+        </div>
+        <div class="card">
+          <h3>We show the risk</h3>
+          <p>Where there are genuine unknowns, you see the buffer openly instead of a change request later. Pretending to be certain is how fixed prices go wrong.</p>
+        </div>
+        <div class="card">
+          <h3>We check our own work</h3>
+          <p>After a project we compare what we quoted against what it took, line by line, and feed the gaps back into the next rate card. The estimates get more honest over time.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- HONESTY BAND -->
+  <section class="section section--darker band">
+    <div class="container">
+      <div class="band__inner">
+        <p class="section__label">The point of all this</p>
+        <h2>A quote should never be a mystery.</h2>
+        <p>When you can see how the number was built, from the first conversation through the assessment, the line items, the confidence calls, the safety net, and the two ways to deliver it, you can trust it. And just as importantly, you can hold us to it.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- FINAL CTA -->
+  <section id="cta" class="section section--dark band">
+    <div class="container">
+      <div class="band__inner">
+        <h2>See what your project would take.</h2>
+        <p>Send us your site and a little about what you need, and we will start with a free assessment. No commitment, just a clear picture of where your platform stands and what the work would involve.</p>
+        <a href="https://www.drevops.com/contact" class="btn btn--on-dark">Start with a free assessment
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17.92 6.62a1 1 0 0 0-.54-.54A1 1 0 0 0 17 6H7a1 1 0 0 0 0 2h7.59l-8.3 8.29a1 1 0 0 0 1.42 1.42L16 9.41V17a1 1 0 0 0 2 0V7a1 1 0 0 0-.08-.38Z"/></svg>
+        </a>
+        <a class="band__email" href="mailto:info@drevops.com">info@drevops.com</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="site-footer">
+    <div class="container">
+      <div class="site-footer__top">
+        <a class="site-footer__logo" href="https://www.drevops.com/"><img src="https://www.drevops.com/themes/custom/drevops/dist/assets/logos/logo_primary_dark_desktop.svg" alt="DrevOps"></a>
+        <div class="site-footer__social">
+          <a href="https://github.com/drevops" target="_blank" rel="noopener" title="GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.25a9.75 9.75 0 0 0-3.08 19c.49.09.67-.21.67-.47v-1.86c-2.51.46-3.16-.61-3.36-1.17-.11-.29-.6-1.17-1.03-1.41-.35-.19-.85-.65-.01-.66.79-.01 1.35.73 1.54 1.03.9 1.52 2.34 1.09 2.91.83.09-.65.35-1.09.64-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.28.1-2.67 0 0 .84-.27 2.75 1.02a9.3 9.3 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.39.2 2.42.1 2.67.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.69-4.57 4.94.36.31.68.91.68 1.85v2.74c0 .26.18.57.68.47A9.75 9.75 0 0 0 12 2.25Z"/></svg></a>
+          <a href="https://www.linkedin.com/company/drevops" target="_blank" rel="noopener" title="LinkedIn"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.47 2H3.53a1.45 1.45 0 0 0-1.47 1.43v17.14A1.45 1.45 0 0 0 3.53 22h16.94a1.45 1.45 0 0 0 1.47-1.43V3.43A1.45 1.45 0 0 0 20.47 2ZM8.09 18.74h-3v-9h3ZM6.59 8.48a1.56 1.56 0 1 1 0-3.12 1.56 1.56 0 0 1 0 3.12Zm12.32 10.26h-3v-4.83c0-1.21-.43-2-1.51-2a1.65 1.65 0 0 0-1.54 1.1 2 2 0 0 0-.1.73v5h-3v-9h3v1.27a3 3 0 0 1 2.71-1.5c2 0 3.46 1.29 3.46 4.06Z"/></svg></a>
+          <a href="https://x.com/drev_ops" target="_blank" rel="noopener" title="X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.24 2.25h3.31l-7.23 8.26 8.5 11.24h-6.66l-5.21-6.82-5.97 6.82H1.68l7.73-8.84L1.25 2.25H8.08l4.71 6.23ZM17.08 19.77h1.83L7.08 4.13H5.12Z"/></svg></a>
+        </div>
+      </div>
+      <div class="site-footer__bottom">
+        <p class="site-footer__ack">DrevOps&reg; is located on the traditional lands of the Wurundjeri-willam people of the Kulin Nation. We pay our respects to Elders both past and present and recognise Aboriginal and Torres Strait Islander people as the Traditional Custodians of the land.</p>
+        <p>&copy;2026 DrevOps&reg;<br><a href="https://www.drevops.com/responsible-ai">Responsible AI</a> policy</p>
+      </div>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/tests/behat/features/paragraph_steps_render.feature
+++ b/tests/behat/features/paragraph_steps_render.feature
@@ -63,6 +63,7 @@ Feature: Steps render
     And I should see an "article .ct-steps.ct-theme-dark" element
     And I should not see an "article .ct-steps.ct-theme-light" element
     And I should see an "article .ct-steps.ct-steps--with-background" element
+    And I should see an "article .ct-steps.ct-vertical-spacing-inset--both" element
     And I should see 1 ".ct-steps__item" elements
     And I should see the text "[TEST] Dark step title"
     And I should see the text "[TEST] Dark step outcome."

--- a/tests/behat/features/paragraph_steps_render.feature
+++ b/tests/behat/features/paragraph_steps_render.feature
@@ -1,0 +1,69 @@
+@p1 @civictheme @drevops @steps
+Feature: Steps render
+
+  As a site visitor
+  I want to see the steps component rendered on a page
+  So that I can follow a numbered journey and what I receive at each step
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                    | status |
+      | [TEST] Page Steps test 1 | 1      |
+      | [TEST] Page Steps test 2 | 1      |
+
+  @api
+  Scenario: CivicTheme page renders light Steps with numbered items and receive notes
+    Given I am an anonymous user
+    And the following fields for the paragraph "steps" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Steps test 1":
+      | field_c_p_title            | [TEST] Steps title |
+      | field_c_p_theme            | light              |
+      | field_c_p_vertical_spacing | both               |
+      | field_c_p_background       | 0                  |
+    And the following fields for the paragraph "steps_item" exist in the field "field_c_p_list_items" within the "steps" "paragraph" identified by the field "field_c_p_title" and the value "[TEST] Steps title":
+      | field_c_p_title   | [TEST] Step one title    |
+      | field_c_p_summary | [TEST] Step one body.    |
+      | field_p_receive   | [TEST] Step one outcome. |
+    And the following fields for the paragraph "steps_item" exist in the field "field_c_p_list_items" within the "steps" "paragraph" identified by the field "field_c_p_title" and the value "[TEST] Steps title":
+      | field_c_p_title   | [TEST] Step two title |
+      | field_c_p_summary | [TEST] Step two body. |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Steps test 1"
+    Then I should see an "article .ct-steps" element
+    And I should see an "article .ct-steps.ct-theme-light" element
+    And I should not see an "article .ct-steps.ct-theme-dark" element
+    And I should see an "article .ct-steps.ct-vertical-spacing-inset--both" element
+    And I should not see an "article .ct-steps.ct-steps--with-background" element
+    And I should see 2 ".ct-steps__item" elements
+    And I should see 2 ".ct-steps__item-number" elements
+    And I should see 1 ".ct-steps__item-receive" elements
+    And I should see the text "[TEST] Steps title"
+    And I should see the text "[TEST] Step one title"
+    And I should see the text "[TEST] Step one body."
+    And I should see the text "You receive:"
+    And I should see the text "[TEST] Step one outcome."
+    And I should see the text "[TEST] Step two title"
+    And I should see the text "[TEST] Step two body."
+    And save screenshot
+
+  @api
+  Scenario: CivicTheme page renders dark Steps with a background
+    Given I am an anonymous user
+    And the following fields for the paragraph "steps" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Page Steps test 2":
+      | field_c_p_title            | [TEST] Steps dark title |
+      | field_c_p_theme            | dark                    |
+      | field_c_p_vertical_spacing | both                    |
+      | field_c_p_background       | 1                       |
+    And the following fields for the paragraph "steps_item" exist in the field "field_c_p_list_items" within the "steps" "paragraph" identified by the field "field_c_p_title" and the value "[TEST] Steps dark title":
+      | field_c_p_title   | [TEST] Dark step title    |
+      | field_c_p_summary | [TEST] Dark step body.    |
+      | field_p_receive   | [TEST] Dark step outcome. |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Page Steps test 2"
+    Then I should see an "article .ct-steps" element
+    And I should see an "article .ct-steps.ct-theme-dark" element
+    And I should not see an "article .ct-steps.ct-theme-light" element
+    And I should see an "article .ct-steps.ct-steps--with-background" element
+    And I should see 1 ".ct-steps__item" elements
+    And I should see the text "[TEST] Dark step title"
+    And I should see the text "[TEST] Dark step outcome."
+    And save screenshot

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -40,284 +40,295 @@ function do_base_deploy_populate_how_we_work_page(): string {
     return ['value' => $html, 'format' => 'civictheme_rich_text'];
   };
 
-  $banner_content = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<p class="ct-text-large">From the first conversation to go-live, here is what happens at each step, what you receive along the way, and how we arrive at a price'
-      . ' with nothing hidden. So you know what you are getting into before you commit a dollar.</p>'
-      . '<p><a class="ct-button ct-theme-light ct-theme-dark ct-button--secondary ct-button--regular" href="#journey"><strong>See the journey</strong></a> '
-      . '<a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular" href="/contact"><strong>Start with a free assessment</strong></a></p>'
-    ),
-    'field_c_p_theme' => 'dark',
-    'field_c_p_background' => FALSE,
-    'field_c_p_vertical_spacing' => 'bottom',
-  ]);
+  // A failed save mid-way must not leave orphaned paragraphs behind, so the
+  // whole assembly commits or rolls back as one unit.
+  $transaction = \Drupal::database()->startTransaction();
 
-  $intro = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">Why this page exists</p>'
-      . '<h2 class="text-align-center"><strong>The stressful part is rarely the build.</strong></h2>'
-      . '<p class="text-align-center ct-text-large">It is the moment before you commit, when you are handed a single number and asked to trust it, with very little'
-      . ' shown above it. Where did it come from? What are you actually paying for? And what happens if the hard parts were guessed wrong?</p>'
-      . '<p class="text-align-center ct-text-large">We built our whole process to answer those questions before you have to ask them. Here is exactly what working'
-      . ' with us looks like, step by step, and what lands in your hands at each one.</p>'
-    ),
-    'field_c_p_theme' => 'light',
-    'field_c_p_background' => TRUE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $journey_steps = [
-    [
-      'title' => 'The first conversation',
-      'body' => 'We listen and map what you actually need, which is often a little different from the initial brief. We do not price anything yet, because we do not know enough yet.',
-      'receive' => 'a written summary of your goals and scope, confirmed with you before any number exists.',
-    ],
-    [
-      'title' => 'A proper assessment',
-      'body' => 'We review your real platform, the code, the integrations, and the risks, not just the description of it. We name the class of each issue, so it reads as a clear picture rather than a scare document.',
-      'receive' => 'a clear, honest report you can act on and share. For a straightforward review, this is often free.',
-    ],
-    [
-      'title' => 'A transparent quotation',
-      'body' => 'We price the work from a standard rate card, line by line, adding a buffer only where there are genuine unknowns. One rate, applied the same way for every client.',
-      'receive' => 'two complete options, hand-built and AI-assisted, with the hours shown and nothing hidden.',
-    ],
-    [
-      'title' => 'Your approval',
-      'body' => 'You review the scope, the timeline, and the price, with a validity window and no pressure. Nothing begins until you have approved the shape of the work.',
-      'receive' => 'a fixed, agreed number before a single line of code, and a plan you have signed off.',
-    ],
-    [
-      'title' => 'The build',
-      'body' => 'We work in short sprints with a steady rhythm you can follow, testing from day one rather than leaving it to the end. The tooling that keeps us fast is open source, so it can be inspected.',
-      'receive' => 'a weekly update on hours and budget, and working software you can watch take shape.',
-    ],
-    [
-      'title' => 'Go-live and handover',
-      'body' => 'We handle the release, the go-live, and the handover to your team, so nothing is left dangling once we step back.',
-      'receive' => 'a platform your team can actually run, with documentation, not just something that works the day we leave.',
-    ],
-  ];
-
-  $journey_items = [];
-
-  foreach ($journey_steps as $journey_step) {
-    $journey_items[] = $component('steps_item', [
-      'field_c_p_title' => $journey_step['title'],
-      'field_c_p_summary' => $journey_step['body'],
-      'field_p_receive' => $journey_step['receive'],
+  try {
+    $banner_content = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<p class="ct-text-large">From the first conversation to go-live, here is what happens at each step, what you receive along the way, and how we arrive at a'
+        . ' price with nothing hidden. So you know what you are getting into before you commit a dollar.</p>'
+        . '<p><a class="ct-button ct-theme-light ct-theme-dark ct-button--secondary ct-button--regular" href="#journey"><strong>See the journey</strong></a> '
+        . '<a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular" href="/contact"><strong>Start with a free assessment</strong></a></p>'
+      ),
+      'field_c_p_theme' => 'dark',
+      'field_c_p_background' => FALSE,
+      'field_c_p_vertical_spacing' => 'bottom',
     ]);
-  }
 
-  $journey = $component('steps', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">The journey</p>'
-      . '<h2 class="text-align-center" id="journey"><strong>Six steps, and what you get at each one.</strong></h2>'
-      . '<p class="text-align-center ct-text-large">Every engagement follows the same path. Each step builds on the one before it, and each leaves you with something'
-      . ' concrete in hand.</p>'
-    ),
-    'field_c_p_list_items' => $journey_items,
-    'field_c_p_theme' => 'light',
-    'field_c_p_background' => FALSE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $no_black_box = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">No black box</p>'
-      . '<h2 class="text-align-center"><strong>See how we build the number.</strong></h2>'
-      . '<p class="text-align-center ct-text-large">Most agencies keep their pricing hidden. We do the opposite, because a number you can take apart is a number you'
-      . ' can trust. Every project is assembled from the same rate card, so the price is just the hours and how confident we are in them. To show you what that means'
-      . ' in practice, here is a real kind of project priced in full: a mid-market Drupal 9 site moving to Drupal 11.</p>'
-    ),
-    'field_c_p_theme' => 'dark',
-    'field_c_p_background' => TRUE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $estimate = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">The estimate</p>'
-      . '<h2 class="text-align-center"><strong>Every line, in plain language.</strong></h2>'
-      . '<p class="text-align-center ct-text-large">We have grouped the work into plain-English categories rather than internal codes, but the hours and costs are'
-      . ' exactly as our process produces them. In this example we price at $200 an hour plus GST. The rate never moves, so the only things that change the price are'
-      . ' the hours and the confidence.</p>'
-      . '<table class="ct-table ct-table--striped"><caption>What the work takes</caption>'
-      . '<thead><tr><th>Work</th><th>Hours</th><th>Confidence</th><th>Cost (ex GST)</th></tr></thead>'
-      . '<tbody>'
-      . '<tr><td>Technical assessment</td><td>6</td><td>Very high</td><td>$0 (free)</td></tr>'
-      . '<tr><td>Project setup onto the existing codebase</td><td>14 &rarr; 21</td><td>Moderate (buffered)</td><td>$4,200</td></tr>'
-      . '<tr><td>Feature and template work (19 items, XS to XL)</td><td>84</td><td>Very high</td><td>$16,800</td></tr>'
-      . '<tr><td>Module upgrades and standards cleanup</td><td>25</td><td>Very high</td><td>$5,000</td></tr>'
-      . '<tr><td>Automated tests (15 scenarios)</td><td>40</td><td>Very high</td><td>$8,000</td></tr>'
-      . '<tr><td>Manual integration testing (2 systems)</td><td>16</td><td>Very high</td><td>$3,200</td></tr>'
-      . '<tr><td>Go-live</td><td>12</td><td>Very high</td><td>$2,400</td></tr>'
-      . '<tr><td>Documentation</td><td>8</td><td>Very high</td><td>$1,600</td></tr>'
-      . '<tr><td><strong>Subtotal</strong></td><td><strong>212</strong></td><td></td><td><strong>$41,200</strong></td></tr>'
-      . '</tbody></table>'
-      . '<p class="ct-text-small">Notice the setup line. It is the only one carrying a buffer. Setting a project up on top of an existing, years-old codebase carries'
-      . ' real unknowns, so we rate our confidence as moderate and lift the estimate from 14 hours to 21, openly. Everything else is work we have done many times, so'
-      . ' it passes through at face value. Where we are certain, the number stands. Where we are not, you see the buffer instead of a surprise later.</p>'
-    ),
-    'field_c_p_theme' => 'light',
-    'field_c_p_background' => FALSE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $work_to_price = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">From the work to the price</p>'
-      . '<h2 class="text-align-center"><strong>Two things sit on top, and we show you both.</strong></h2>'
-      . '<table class="ct-table ct-table--striped"><caption>How the estimate becomes the quote</caption>'
-      . '<tbody>'
-      . '<tr><td>Work subtotal (212 hours)</td><td>$41,200</td></tr>'
-      . '<tr><td>Project oversight (weekly updates and tracking, +10%)</td><td>$45,320</td></tr>'
-      . '<tr><td>Safety net (20%)</td><td>$54,384</td></tr>'
-      . '<tr><td><strong>Quoted total (ex GST)</strong></td><td><strong>$54,384</strong></td></tr>'
-      . '<tr><td>GST (10%)</td><td>$59,822</td></tr>'
-      . '<tr><td><strong>Total (inc GST)</strong></td><td><strong>$59,822</strong></td></tr>'
-      . '</tbody></table>'
-      . '<p><strong>Project oversight</strong> is the running of the project: the weekly update that tells you where the hours and the budget stand, the tracking,'
-      . ' and the escalation of anything that turns into a risk.</p>'
-      . '<p>The <strong>safety net</strong> is there to protect you as much as us. It is twenty percent, and it is not a markup on the work. It is what lets us hold'
-      . ' a fixed price when a project turns up a surprise, the cover for a warranty when something needs a second look after go-live, and the cushion that keeps us'
-      . ' a stable business, still here to support you in a year. On a fixed-price project we carry that risk, not you, and the safety net is what makes that promise'
-      . ' real. Then GST on top, because we are an Australian business. That is the entire path from hours to the figure on the quote. Nothing else is hiding in'
-      . ' there.</p>'
-    ),
-    'field_c_p_theme' => 'light',
-    'field_c_p_background' => TRUE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $two_options = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">This is what you would receive</p>'
-      . '<h2 class="text-align-center"><strong>Two complete options. You choose.</strong></h2>'
-      . '<p class="text-align-center ct-text-large">We can build a project by hand, or AI-assisted, using the testing and review harness we developed ourselves. The'
-      . ' rate does not change, so the difference is entirely in the hours, and only on the work that genuinely compresses: the development, the migrations, the'
-      . ' automated tests. The assessment, the testing, and the coordination do not move, so we do not pretend they do.</p>'
-      . '<table class="ct-table ct-table--striped"><caption>The same project, two ways</caption>'
-      . '<thead><tr><th>&nbsp;</th><th>Hand-built</th><th>AI-assisted</th></tr></thead>'
-      . '<tbody>'
-      . '<tr><td>Hours</td><td>212</td><td>146</td></tr>'
-      . '<tr><td>Total (ex GST)</td><td>$54,384</td><td>$36,960</td></tr>'
-      . '<tr><td><strong>Total (inc GST)</strong></td><td><strong>$59,822</strong></td><td><strong>$40,656</strong></td></tr>'
-      . '</tbody></table>'
-      . '<p class="ct-text-small">On this project the AI-assisted path lands about 32 percent below the hand-built one, because a migration is development-heavy and'
-      . ' a lot of it compresses. Same rate, same automated tests, same review, same quality bar, roughly a third fewer hours. Every change is reviewed and every'
-      . ' build is tested before it ships. You choose the trade-off up front, and we never quietly put your work through the harness to pad the bill.</p>'
-    ),
-    'field_c_p_theme' => 'light',
-    'field_c_p_background' => FALSE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $reassurance_cards = [
-    [
-      'title' => 'One rate, always',
-      'summary' => 'The same hourly rate for every line and every client. It never moves, so the only things that change your price are the hours and how sure we are of them.',
-    ],
-    [
-      'title' => 'We show the risk',
-      'summary' => 'Where there are genuine unknowns, you see the buffer openly instead of a change request later. Pretending to be certain is how fixed prices go wrong.',
-    ],
-    [
-      'title' => 'We check our own work',
-      'summary' => 'After a project we compare what we quoted against what it took, line by line, and feed the gaps back into the next rate card. The estimates get more honest over time.',
-    ],
-  ];
-
-  $reassurance_items = [];
-
-  foreach ($reassurance_cards as $reassurance_card) {
-    $reassurance_items[] = $component('civictheme_promo_card', [
-      'field_c_p_title' => $reassurance_card['title'],
-      'field_c_p_summary' => $reassurance_card['summary'],
+    $intro = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">Why this page exists</p>'
+        . '<h2 class="text-align-center"><strong>The stressful part is rarely the build.</strong></h2>'
+        . '<p class="text-align-center ct-text-large">It is the moment before you commit, when you are handed a single number and asked to trust it, with very little'
+        . ' shown above it. Where did it come from? What are you actually paying for? And what happens if the hard parts were guessed wrong?</p>'
+        . '<p class="text-align-center ct-text-large">We built our whole process to answer those questions before you have to ask them. Here is exactly what working'
+        . ' with us looks like, step by step, and what lands in your hands at each one.</p>'
+      ),
       'field_c_p_theme' => 'light',
+      'field_c_p_background' => TRUE,
+      'field_c_p_vertical_spacing' => 'both',
     ]);
+
+    $journey_steps = [
+      [
+        'title' => 'The first conversation',
+        'body' => 'We listen and map what you actually need, which is often a little different from the initial brief. We do not price anything yet, because we do not know enough yet.',
+        'receive' => 'a written summary of your goals and scope, confirmed with you before any number exists.',
+      ],
+      [
+        'title' => 'A proper assessment',
+        'body' => 'We review your real platform, the code, the integrations, and the risks, not just the description of it. We name the class of each issue, so it reads as a clear picture rather than a scare document.',
+        'receive' => 'a clear, honest report you can act on and share. For a straightforward review, this is often free.',
+      ],
+      [
+        'title' => 'A transparent quotation',
+        'body' => 'We price the work from a standard rate card, line by line, adding a buffer only where there are genuine unknowns. One rate, applied the same way for every client.',
+        'receive' => 'two complete options, hand-built and AI-assisted, with the hours shown and nothing hidden.',
+      ],
+      [
+        'title' => 'Your approval',
+        'body' => 'You review the scope, the timeline, and the price, with a validity window and no pressure. Nothing begins until you have approved the shape of the work.',
+        'receive' => 'a fixed, agreed number before a single line of code, and a plan you have signed off.',
+      ],
+      [
+        'title' => 'The build',
+        'body' => 'We work in short sprints with a steady rhythm you can follow, testing from day one rather than leaving it to the end. The tooling that keeps us fast is open source, so it can be inspected.',
+        'receive' => 'a weekly update on hours and budget, and working software you can watch take shape.',
+      ],
+      [
+        'title' => 'Go-live and handover',
+        'body' => 'We handle the release, the go-live, and the handover to your team, so nothing is left dangling once we step back.',
+        'receive' => 'a platform your team can actually run, with documentation, not just something that works the day we leave.',
+      ],
+    ];
+
+    $journey_items = [];
+
+    foreach ($journey_steps as $journey_step) {
+      $journey_items[] = $component('steps_item', [
+        'field_c_p_title' => $journey_step['title'],
+        'field_c_p_summary' => $journey_step['body'],
+        'field_p_receive' => $journey_step['receive'],
+      ]);
+    }
+
+    $journey = $component('steps', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">The journey</p>'
+        . '<h2 class="text-align-center" id="journey"><strong>Six steps, and what you get at each one.</strong></h2>'
+        . '<p class="text-align-center ct-text-large">Every engagement follows the same path. Each step builds on the one before it, and each leaves you with'
+        . ' something concrete in hand.</p>'
+      ),
+      'field_c_p_list_items' => $journey_items,
+      'field_c_p_theme' => 'light',
+      'field_c_p_background' => FALSE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $no_black_box = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">No black box</p>'
+        . '<h2 class="text-align-center"><strong>See how we build the number.</strong></h2>'
+        . '<p class="text-align-center ct-text-large">Most agencies keep their pricing hidden. We do the opposite, because a number you can take apart is a number you'
+        . ' can trust. Every project is assembled from the same rate card, so the price is just the hours and how confident we are in them. To show you what that'
+        . ' means in practice, here is a real kind of project priced in full: a mid-market Drupal 9 site moving to Drupal 11.</p>'
+      ),
+      'field_c_p_theme' => 'dark',
+      'field_c_p_background' => TRUE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $estimate = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">The estimate</p>'
+        . '<h2 class="text-align-center"><strong>Every line, in plain language.</strong></h2>'
+        . '<p class="text-align-center ct-text-large">We have grouped the work into plain-English categories rather than internal codes, but the hours and costs are'
+        . ' exactly as our process produces them. In this example we price at $200 an hour plus GST. The rate never moves, so the only things that change the price'
+        . ' are the hours and the confidence.</p>'
+        . '<table class="ct-table ct-table--striped"><caption>What the work takes</caption>'
+        . '<thead><tr><th>Work</th><th>Hours</th><th>Confidence</th><th>Cost (ex GST)</th></tr></thead>'
+        . '<tbody>'
+        . '<tr><td>Technical assessment</td><td>6</td><td>Very high</td><td>$0 (free)</td></tr>'
+        . '<tr><td>Project setup onto the existing codebase</td><td>14 &rarr; 21</td><td>Moderate (buffered)</td><td>$4,200</td></tr>'
+        . '<tr><td>Feature and template work (19 items, XS to XL)</td><td>84</td><td>Very high</td><td>$16,800</td></tr>'
+        . '<tr><td>Module upgrades and standards cleanup</td><td>25</td><td>Very high</td><td>$5,000</td></tr>'
+        . '<tr><td>Automated tests (15 scenarios)</td><td>40</td><td>Very high</td><td>$8,000</td></tr>'
+        . '<tr><td>Manual integration testing (2 systems)</td><td>16</td><td>Very high</td><td>$3,200</td></tr>'
+        . '<tr><td>Go-live</td><td>12</td><td>Very high</td><td>$2,400</td></tr>'
+        . '<tr><td>Documentation</td><td>8</td><td>Very high</td><td>$1,600</td></tr>'
+        . '<tr><td><strong>Subtotal</strong></td><td><strong>212</strong></td><td></td><td><strong>$41,200</strong></td></tr>'
+        . '</tbody></table>'
+        . '<p class="ct-text-small">Notice the setup line. It is the only one carrying a buffer. Setting a project up on top of an existing, years-old codebase'
+        . ' carries real unknowns, so we rate our confidence as moderate and lift the estimate from 14 hours to 21, openly. Everything else is work we have done many'
+        . ' times, so it passes through at face value. Where we are certain, the number stands. Where we are not, you see the buffer instead of a surprise later.</p>'
+      ),
+      'field_c_p_theme' => 'light',
+      'field_c_p_background' => FALSE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $work_to_price = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">From the work to the price</p>'
+        . '<h2 class="text-align-center"><strong>Two things sit on top, and we show you both.</strong></h2>'
+        . '<table class="ct-table ct-table--striped"><caption>How the estimate becomes the quote</caption>'
+        . '<tbody>'
+        . '<tr><td>Work subtotal (212 hours)</td><td>$41,200</td></tr>'
+        . '<tr><td>Project oversight (weekly updates and tracking, +10%)</td><td>$45,320</td></tr>'
+        . '<tr><td>Safety net (20%)</td><td>$54,384</td></tr>'
+        . '<tr><td><strong>Quoted total (ex GST)</strong></td><td><strong>$54,384</strong></td></tr>'
+        . '<tr><td>GST (10%)</td><td>$59,822</td></tr>'
+        . '<tr><td><strong>Total (inc GST)</strong></td><td><strong>$59,822</strong></td></tr>'
+        . '</tbody></table>'
+        . '<p><strong>Project oversight</strong> is the running of the project: the weekly update that tells you where the hours and the budget stand, the tracking,'
+        . ' and the escalation of anything that turns into a risk.</p>'
+        . '<p>The <strong>safety net</strong> is there to protect you as much as us. It is twenty percent, and it is not a markup on the work. It is what lets us hold'
+        . ' a fixed price when a project turns up a surprise, the cover for a warranty when something needs a second look after go-live, and the cushion that keeps us'
+        . ' a stable business, still here to support you in a year. On a fixed-price project we carry that risk, not you, and the safety net is what makes that'
+        . ' promise real. Then GST on top, because we are an Australian business. That is the entire path from hours to the figure on the quote. Nothing else is'
+        . ' hiding in there.</p>'
+      ),
+      'field_c_p_theme' => 'light',
+      'field_c_p_background' => TRUE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $two_options = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">This is what you would receive</p>'
+        . '<h2 class="text-align-center"><strong>Two complete options. You choose.</strong></h2>'
+        . '<p class="text-align-center ct-text-large">We can build a project by hand, or AI-assisted, using the testing and review harness we developed ourselves.'
+        . ' The rate does not change, so the difference is entirely in the hours, and only on the work that genuinely compresses: the development, the migrations,'
+        . ' the automated tests. The assessment, the testing, and the coordination do not move, so we do not pretend they do.</p>'
+        . '<table class="ct-table ct-table--striped"><caption>The same project, two ways</caption>'
+        . '<thead><tr><th>&nbsp;</th><th>Hand-built</th><th>AI-assisted</th></tr></thead>'
+        . '<tbody>'
+        . '<tr><td>Hours</td><td>212</td><td>146</td></tr>'
+        . '<tr><td>Total (ex GST)</td><td>$54,384</td><td>$36,960</td></tr>'
+        . '<tr><td><strong>Total (inc GST)</strong></td><td><strong>$59,822</strong></td><td><strong>$40,656</strong></td></tr>'
+        . '</tbody></table>'
+        . '<p class="ct-text-small">On this project the AI-assisted path lands about 32 percent below the hand-built one, because a migration is development-heavy'
+        . ' and a lot of it compresses. Same rate, same automated tests, same review, same quality bar, roughly a third fewer hours. Every change is reviewed and'
+        . ' every build is tested before it ships. You choose the trade-off up front, and we never quietly put your work through the harness to pad the bill.</p>'
+      ),
+      'field_c_p_theme' => 'light',
+      'field_c_p_background' => FALSE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $reassurance_cards = [
+      [
+        'title' => 'One rate, always',
+        'summary' => 'The same hourly rate for every line and every client. It never moves, so the only things that change your price are the hours and how sure we are of them.',
+      ],
+      [
+        'title' => 'We show the risk',
+        'summary' => 'Where there are genuine unknowns, you see the buffer openly instead of a change request later. Pretending to be certain is how fixed prices go wrong.',
+      ],
+      [
+        'title' => 'We check our own work',
+        'summary' => 'After a project we compare what we quoted against what it took, line by line, and feed the gaps back into the next rate card. The estimates get more honest over time.',
+      ],
+    ];
+
+    $reassurance_items = [];
+
+    foreach ($reassurance_cards as $reassurance_card) {
+      $reassurance_items[] = $component('civictheme_promo_card', [
+        'field_c_p_title' => $reassurance_card['title'],
+        'field_c_p_summary' => $reassurance_card['summary'],
+        'field_c_p_theme' => 'light',
+      ]);
+    }
+
+    $reassurance = $component('civictheme_manual_list', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">What holds it together</p>'
+        . '<h2 class="text-align-center"><strong>The habits that keep it honest.</strong></h2>'
+      ),
+      'field_c_p_list_items' => $reassurance_items,
+      'field_c_p_list_column_count' => 3,
+      'field_c_p_list_fill_width' => FALSE,
+      'field_p_list_layout' => 'grid',
+      'field_c_p_theme' => 'light',
+      'field_c_p_background' => TRUE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $honesty = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<p class="text-align-center eyebrow">The point of all this</p>'
+        . '<h2 class="text-align-center"><strong>A quote should never be a mystery.</strong></h2>'
+        . '<p class="text-align-center ct-text-large">When you can see how the number was built, from the first conversation through the assessment, the line items,'
+        . ' the confidence calls, the safety net, and the two ways to deliver it, you can trust it. And just as importantly, you can hold us to it.</p>'
+      ),
+      'field_c_p_theme' => 'dark',
+      'field_c_p_background' => TRUE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $final_cta = $component('civictheme_content', [
+      'field_c_p_content' => $rich_text(
+        '<h2 class="text-align-center"><strong>See what your project would take.</strong></h2>'
+        . '<p class="text-align-center ct-text-large">Send us your site and a little about what you need, and we will start with a free assessment. No commitment,'
+        . ' just a clear picture of where your platform stands and what the work would involve.</p>'
+        . '<p class="text-align-center"><a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular" href="/contact"><strong>Start with a'
+        . ' free assessment</strong></a></p>'
+        . '<p class="text-align-center ct-text-large"><a href="mailto:info@drevops.com">info@drevops.com</a></p>'
+      ),
+      'field_c_p_theme' => 'dark',
+      'field_c_p_background' => TRUE,
+      'field_c_p_vertical_spacing' => 'both',
+    ]);
+
+    $values = [
+      'type' => 'civictheme_page',
+      'uuid' => $node_uuid,
+      'title' => 'How We Work',
+      'status' => 1,
+      'moderation_state' => 'published',
+      'field_c_n_summary' => 'See exactly what working with DrevOps looks like, from the first conversation to go-live: what happens at each step, what you receive,'
+      . ' and how we build a price with nothing hidden.',
+      'field_c_n_banner_theme' => 'dark',
+      'field_c_n_banner_type' => 'large',
+      'field_c_n_banner_title' => 'Know exactly what working with us looks like.',
+      'field_c_n_banner_blend_mode' => 'normal',
+      'field_c_n_banner_hide_breadcrumb' => FALSE,
+      'field_c_n_banner_components' => [$banner_content],
+      'field_c_n_hide_sidebar' => TRUE,
+      'field_c_n_show_last_updated' => FALSE,
+      'field_c_n_vertical_spacing' => 'none',
+      'field_c_n_components' => [
+        $intro,
+        $journey,
+        $no_black_box,
+        $estimate,
+        $work_to_price,
+        $two_options,
+        $reassurance,
+        $honesty,
+        $final_cta,
+      ],
+    ];
+
+    // The homepage banner media is reused; the page still works without it.
+    $banner_media = $entity_type_manager->getStorage('media')->loadByProperties(['uuid' => 'f23d0cc6-1581-4a1b-88c7-a60a8a6e9bc4']);
+    $banner_media = reset($banner_media);
+
+    if ($banner_media instanceof MediaInterface) {
+      $values['field_c_n_banner_background'] = ['target_id' => $banner_media->id()];
+    }
+
+    $node = $node_storage->create($values);
+    $node->save();
   }
+  catch (\Throwable $throwable) {
+    $transaction->rollBack();
 
-  $reassurance = $component('civictheme_manual_list', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">What holds it together</p>'
-      . '<h2 class="text-align-center"><strong>The habits that keep it honest.</strong></h2>'
-    ),
-    'field_c_p_list_items' => $reassurance_items,
-    'field_c_p_list_column_count' => 3,
-    'field_c_p_list_fill_width' => FALSE,
-    'field_p_list_layout' => 'grid',
-    'field_c_p_theme' => 'light',
-    'field_c_p_background' => TRUE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $honesty = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<p class="text-align-center eyebrow">The point of all this</p>'
-      . '<h2 class="text-align-center"><strong>A quote should never be a mystery.</strong></h2>'
-      . '<p class="text-align-center ct-text-large">When you can see how the number was built, from the first conversation through the assessment, the line items,'
-      . ' the confidence calls, the safety net, and the two ways to deliver it, you can trust it. And just as importantly, you can hold us to it.</p>'
-    ),
-    'field_c_p_theme' => 'dark',
-    'field_c_p_background' => TRUE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $final_cta = $component('civictheme_content', [
-    'field_c_p_content' => $rich_text(
-      '<h2 class="text-align-center"><strong>See what your project would take.</strong></h2>'
-      . '<p class="text-align-center ct-text-large">Send us your site and a little about what you need, and we will start with a free assessment. No commitment,'
-      . ' just a clear picture of where your platform stands and what the work would involve.</p>'
-      . '<p class="text-align-center"><a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular" href="/contact"><strong>Start with a'
-      . ' free assessment</strong></a></p>'
-      . '<p class="text-align-center ct-text-large"><a href="mailto:info@drevops.com">info@drevops.com</a></p>'
-    ),
-    'field_c_p_theme' => 'dark',
-    'field_c_p_background' => TRUE,
-    'field_c_p_vertical_spacing' => 'both',
-  ]);
-
-  $values = [
-    'type' => 'civictheme_page',
-    'uuid' => $node_uuid,
-    'title' => 'How We Work',
-    'status' => 1,
-    'moderation_state' => 'published',
-    'field_c_n_summary' => 'See exactly what working with DrevOps looks like, from the first conversation to go-live: what happens at each step, what you receive,'
-    . ' and how we build a price with nothing hidden.',
-    'field_c_n_banner_theme' => 'dark',
-    'field_c_n_banner_type' => 'large',
-    'field_c_n_banner_title' => 'Know exactly what working with us looks like.',
-    'field_c_n_banner_blend_mode' => 'normal',
-    'field_c_n_banner_hide_breadcrumb' => FALSE,
-    'field_c_n_banner_components' => [$banner_content],
-    'field_c_n_hide_sidebar' => TRUE,
-    'field_c_n_show_last_updated' => FALSE,
-    'field_c_n_vertical_spacing' => 'none',
-    'field_c_n_components' => [
-      $intro,
-      $journey,
-      $no_black_box,
-      $estimate,
-      $work_to_price,
-      $two_options,
-      $reassurance,
-      $honesty,
-      $final_cta,
-    ],
-  ];
-
-  // The homepage banner media is reused; the page still works without it.
-  $banner_media = $entity_type_manager->getStorage('media')->loadByProperties(['uuid' => 'f23d0cc6-1581-4a1b-88c7-a60a8a6e9bc4']);
-  $banner_media = reset($banner_media);
-
-  if ($banner_media instanceof MediaInterface) {
-    $values['field_c_n_banner_background'] = ['target_id' => $banner_media->id()];
+    throw $throwable;
   }
-
-  $node = $node_storage->create($values);
-  $node->save();
 
   return sprintf('Created the How We Work page (node %s).', $node->id());
 }

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -8,3 +8,316 @@
  */
 
 declare(strict_types=1);
+
+use Drupal\media\MediaInterface;
+
+/**
+ * Creates the How We Work page from the static prototype.
+ */
+function do_base_deploy_populate_how_we_work_page(): string {
+  $node_uuid = '74fcf1d0-245c-4027-acee-5ef95bca9912';
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $node_storage = $entity_type_manager->getStorage('node');
+
+  // Idempotency guard: the page is created once per environment.
+  $existing = $node_storage->loadByProperties(['uuid' => $node_uuid]);
+
+  if ($existing) {
+    return 'The How We Work page already exists.';
+  }
+
+  $paragraph_storage = $entity_type_manager->getStorage('paragraph');
+
+  $component = function (string $type, array $fields) use ($paragraph_storage): array {
+    $paragraph = $paragraph_storage->create(['type' => $type] + $fields);
+    $paragraph->save();
+
+    return ['target_id' => $paragraph->id(), 'target_revision_id' => $paragraph->getRevisionId()];
+  };
+
+  $rich_text = function (string $html): array {
+    return ['value' => $html, 'format' => 'civictheme_rich_text'];
+  };
+
+  $banner_content = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<p class="ct-text-large">From the first conversation to go-live, here is what happens at each step, what you receive along the way, and how we arrive at a price'
+      . ' with nothing hidden. So you know what you are getting into before you commit a dollar.</p>'
+      . '<p><a class="ct-button ct-theme-light ct-theme-dark ct-button--secondary ct-button--regular" href="#journey"><strong>See the journey</strong></a> '
+      . '<a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular" href="/contact"><strong>Start with a free assessment</strong></a></p>'
+    ),
+    'field_c_p_theme' => 'dark',
+    'field_c_p_background' => FALSE,
+    'field_c_p_vertical_spacing' => 'bottom',
+  ]);
+
+  $intro = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">Why this page exists</p>'
+      . '<h2 class="text-align-center"><strong>The stressful part is rarely the build.</strong></h2>'
+      . '<p class="text-align-center ct-text-large">It is the moment before you commit, when you are handed a single number and asked to trust it, with very little'
+      . ' shown above it. Where did it come from? What are you actually paying for? And what happens if the hard parts were guessed wrong?</p>'
+      . '<p class="text-align-center ct-text-large">We built our whole process to answer those questions before you have to ask them. Here is exactly what working'
+      . ' with us looks like, step by step, and what lands in your hands at each one.</p>'
+    ),
+    'field_c_p_theme' => 'light',
+    'field_c_p_background' => TRUE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $journey_steps = [
+    [
+      'title' => 'The first conversation',
+      'body' => 'We listen and map what you actually need, which is often a little different from the initial brief. We do not price anything yet, because we do not know enough yet.',
+      'receive' => 'a written summary of your goals and scope, confirmed with you before any number exists.',
+    ],
+    [
+      'title' => 'A proper assessment',
+      'body' => 'We review your real platform, the code, the integrations, and the risks, not just the description of it. We name the class of each issue, so it reads as a clear picture rather than a scare document.',
+      'receive' => 'a clear, honest report you can act on and share. For a straightforward review, this is often free.',
+    ],
+    [
+      'title' => 'A transparent quotation',
+      'body' => 'We price the work from a standard rate card, line by line, adding a buffer only where there are genuine unknowns. One rate, applied the same way for every client.',
+      'receive' => 'two complete options, hand-built and AI-assisted, with the hours shown and nothing hidden.',
+    ],
+    [
+      'title' => 'Your approval',
+      'body' => 'You review the scope, the timeline, and the price, with a validity window and no pressure. Nothing begins until you have approved the shape of the work.',
+      'receive' => 'a fixed, agreed number before a single line of code, and a plan you have signed off.',
+    ],
+    [
+      'title' => 'The build',
+      'body' => 'We work in short sprints with a steady rhythm you can follow, testing from day one rather than leaving it to the end. The tooling that keeps us fast is open source, so it can be inspected.',
+      'receive' => 'a weekly update on hours and budget, and working software you can watch take shape.',
+    ],
+    [
+      'title' => 'Go-live and handover',
+      'body' => 'We handle the release, the go-live, and the handover to your team, so nothing is left dangling once we step back.',
+      'receive' => 'a platform your team can actually run, with documentation, not just something that works the day we leave.',
+    ],
+  ];
+
+  $journey_items = [];
+
+  foreach ($journey_steps as $journey_step) {
+    $journey_items[] = $component('steps_item', [
+      'field_c_p_title' => $journey_step['title'],
+      'field_c_p_summary' => $journey_step['body'],
+      'field_p_receive' => $journey_step['receive'],
+    ]);
+  }
+
+  $journey = $component('steps', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">The journey</p>'
+      . '<h2 class="text-align-center" id="journey"><strong>Six steps, and what you get at each one.</strong></h2>'
+      . '<p class="text-align-center ct-text-large">Every engagement follows the same path. Each step builds on the one before it, and each leaves you with something'
+      . ' concrete in hand.</p>'
+    ),
+    'field_c_p_list_items' => $journey_items,
+    'field_c_p_theme' => 'light',
+    'field_c_p_background' => FALSE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $no_black_box = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">No black box</p>'
+      . '<h2 class="text-align-center"><strong>See how we build the number.</strong></h2>'
+      . '<p class="text-align-center ct-text-large">Most agencies keep their pricing hidden. We do the opposite, because a number you can take apart is a number you'
+      . ' can trust. Every project is assembled from the same rate card, so the price is just the hours and how confident we are in them. To show you what that means'
+      . ' in practice, here is a real kind of project priced in full: a mid-market Drupal 9 site moving to Drupal 11.</p>'
+    ),
+    'field_c_p_theme' => 'dark',
+    'field_c_p_background' => TRUE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $estimate = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">The estimate</p>'
+      . '<h2 class="text-align-center"><strong>Every line, in plain language.</strong></h2>'
+      . '<p class="text-align-center ct-text-large">We have grouped the work into plain-English categories rather than internal codes, but the hours and costs are'
+      . ' exactly as our process produces them. In this example we price at $200 an hour plus GST. The rate never moves, so the only things that change the price are'
+      . ' the hours and the confidence.</p>'
+      . '<table class="ct-table ct-table--striped"><caption>What the work takes</caption>'
+      . '<thead><tr><th>Work</th><th>Hours</th><th>Confidence</th><th>Cost (ex GST)</th></tr></thead>'
+      . '<tbody>'
+      . '<tr><td>Technical assessment</td><td>6</td><td>Very high</td><td>$0 (free)</td></tr>'
+      . '<tr><td>Project setup onto the existing codebase</td><td>14 &rarr; 21</td><td>Moderate (buffered)</td><td>$4,200</td></tr>'
+      . '<tr><td>Feature and template work (19 items, XS to XL)</td><td>84</td><td>Very high</td><td>$16,800</td></tr>'
+      . '<tr><td>Module upgrades and standards cleanup</td><td>25</td><td>Very high</td><td>$5,000</td></tr>'
+      . '<tr><td>Automated tests (15 scenarios)</td><td>40</td><td>Very high</td><td>$8,000</td></tr>'
+      . '<tr><td>Manual integration testing (2 systems)</td><td>16</td><td>Very high</td><td>$3,200</td></tr>'
+      . '<tr><td>Go-live</td><td>12</td><td>Very high</td><td>$2,400</td></tr>'
+      . '<tr><td>Documentation</td><td>8</td><td>Very high</td><td>$1,600</td></tr>'
+      . '<tr><td><strong>Subtotal</strong></td><td><strong>212</strong></td><td></td><td><strong>$41,200</strong></td></tr>'
+      . '</tbody></table>'
+      . '<p class="ct-text-small">Notice the setup line. It is the only one carrying a buffer. Setting a project up on top of an existing, years-old codebase carries'
+      . ' real unknowns, so we rate our confidence as moderate and lift the estimate from 14 hours to 21, openly. Everything else is work we have done many times, so'
+      . ' it passes through at face value. Where we are certain, the number stands. Where we are not, you see the buffer instead of a surprise later.</p>'
+    ),
+    'field_c_p_theme' => 'light',
+    'field_c_p_background' => FALSE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $work_to_price = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">From the work to the price</p>'
+      . '<h2 class="text-align-center"><strong>Two things sit on top, and we show you both.</strong></h2>'
+      . '<table class="ct-table ct-table--striped"><caption>How the estimate becomes the quote</caption>'
+      . '<tbody>'
+      . '<tr><td>Work subtotal (212 hours)</td><td>$41,200</td></tr>'
+      . '<tr><td>Project oversight (weekly updates and tracking, +10%)</td><td>$45,320</td></tr>'
+      . '<tr><td>Safety net (20%)</td><td>$54,384</td></tr>'
+      . '<tr><td><strong>Quoted total (ex GST)</strong></td><td><strong>$54,384</strong></td></tr>'
+      . '<tr><td>GST (10%)</td><td>$59,822</td></tr>'
+      . '<tr><td><strong>Total (inc GST)</strong></td><td><strong>$59,822</strong></td></tr>'
+      . '</tbody></table>'
+      . '<p><strong>Project oversight</strong> is the running of the project: the weekly update that tells you where the hours and the budget stand, the tracking,'
+      . ' and the escalation of anything that turns into a risk.</p>'
+      . '<p>The <strong>safety net</strong> is there to protect you as much as us. It is twenty percent, and it is not a markup on the work. It is what lets us hold'
+      . ' a fixed price when a project turns up a surprise, the cover for a warranty when something needs a second look after go-live, and the cushion that keeps us'
+      . ' a stable business, still here to support you in a year. On a fixed-price project we carry that risk, not you, and the safety net is what makes that promise'
+      . ' real. Then GST on top, because we are an Australian business. That is the entire path from hours to the figure on the quote. Nothing else is hiding in'
+      . ' there.</p>'
+    ),
+    'field_c_p_theme' => 'light',
+    'field_c_p_background' => TRUE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $two_options = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">This is what you would receive</p>'
+      . '<h2 class="text-align-center"><strong>Two complete options. You choose.</strong></h2>'
+      . '<p class="text-align-center ct-text-large">We can build a project by hand, or AI-assisted, using the testing and review harness we developed ourselves. The'
+      . ' rate does not change, so the difference is entirely in the hours, and only on the work that genuinely compresses: the development, the migrations, the'
+      . ' automated tests. The assessment, the testing, and the coordination do not move, so we do not pretend they do.</p>'
+      . '<table class="ct-table ct-table--striped"><caption>The same project, two ways</caption>'
+      . '<thead><tr><th>&nbsp;</th><th>Hand-built</th><th>AI-assisted</th></tr></thead>'
+      . '<tbody>'
+      . '<tr><td>Hours</td><td>212</td><td>146</td></tr>'
+      . '<tr><td>Total (ex GST)</td><td>$54,384</td><td>$36,960</td></tr>'
+      . '<tr><td><strong>Total (inc GST)</strong></td><td><strong>$59,822</strong></td><td><strong>$40,656</strong></td></tr>'
+      . '</tbody></table>'
+      . '<p class="ct-text-small">On this project the AI-assisted path lands about 32 percent below the hand-built one, because a migration is development-heavy and'
+      . ' a lot of it compresses. Same rate, same automated tests, same review, same quality bar, roughly a third fewer hours. Every change is reviewed and every'
+      . ' build is tested before it ships. You choose the trade-off up front, and we never quietly put your work through the harness to pad the bill.</p>'
+    ),
+    'field_c_p_theme' => 'light',
+    'field_c_p_background' => FALSE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $reassurance_cards = [
+    [
+      'title' => 'One rate, always',
+      'summary' => 'The same hourly rate for every line and every client. It never moves, so the only things that change your price are the hours and how sure we are of them.',
+    ],
+    [
+      'title' => 'We show the risk',
+      'summary' => 'Where there are genuine unknowns, you see the buffer openly instead of a change request later. Pretending to be certain is how fixed prices go wrong.',
+    ],
+    [
+      'title' => 'We check our own work',
+      'summary' => 'After a project we compare what we quoted against what it took, line by line, and feed the gaps back into the next rate card. The estimates get more honest over time.',
+    ],
+  ];
+
+  $reassurance_items = [];
+
+  foreach ($reassurance_cards as $reassurance_card) {
+    $reassurance_items[] = $component('civictheme_promo_card', [
+      'field_c_p_title' => $reassurance_card['title'],
+      'field_c_p_summary' => $reassurance_card['summary'],
+      'field_c_p_theme' => 'light',
+    ]);
+  }
+
+  $reassurance = $component('civictheme_manual_list', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">What holds it together</p>'
+      . '<h2 class="text-align-center"><strong>The habits that keep it honest.</strong></h2>'
+    ),
+    'field_c_p_list_items' => $reassurance_items,
+    'field_c_p_list_column_count' => 3,
+    'field_c_p_list_fill_width' => FALSE,
+    'field_p_list_layout' => 'grid',
+    'field_c_p_theme' => 'light',
+    'field_c_p_background' => TRUE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $honesty = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<p class="text-align-center eyebrow">The point of all this</p>'
+      . '<h2 class="text-align-center"><strong>A quote should never be a mystery.</strong></h2>'
+      . '<p class="text-align-center ct-text-large">When you can see how the number was built, from the first conversation through the assessment, the line items,'
+      . ' the confidence calls, the safety net, and the two ways to deliver it, you can trust it. And just as importantly, you can hold us to it.</p>'
+    ),
+    'field_c_p_theme' => 'dark',
+    'field_c_p_background' => TRUE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $final_cta = $component('civictheme_content', [
+    'field_c_p_content' => $rich_text(
+      '<h2 class="text-align-center"><strong>See what your project would take.</strong></h2>'
+      . '<p class="text-align-center ct-text-large">Send us your site and a little about what you need, and we will start with a free assessment. No commitment,'
+      . ' just a clear picture of where your platform stands and what the work would involve.</p>'
+      . '<p class="text-align-center"><a class="ct-button ct-theme-light ct-theme-dark ct-button--primary ct-button--regular" href="/contact"><strong>Start with a'
+      . ' free assessment</strong></a></p>'
+      . '<p class="text-align-center ct-text-large"><a href="mailto:info@drevops.com">info@drevops.com</a></p>'
+    ),
+    'field_c_p_theme' => 'dark',
+    'field_c_p_background' => TRUE,
+    'field_c_p_vertical_spacing' => 'both',
+  ]);
+
+  $values = [
+    'type' => 'civictheme_page',
+    'uuid' => $node_uuid,
+    'title' => 'How We Work',
+    'status' => 1,
+    'moderation_state' => 'published',
+    'field_c_n_summary' => 'See exactly what working with DrevOps looks like, from the first conversation to go-live: what happens at each step, what you receive,'
+    . ' and how we build a price with nothing hidden.',
+    'field_c_n_banner_theme' => 'dark',
+    'field_c_n_banner_type' => 'large',
+    'field_c_n_banner_title' => 'Know exactly what working with us looks like.',
+    'field_c_n_banner_blend_mode' => 'normal',
+    'field_c_n_banner_hide_breadcrumb' => FALSE,
+    'field_c_n_banner_components' => [$banner_content],
+    'field_c_n_hide_sidebar' => TRUE,
+    'field_c_n_show_last_updated' => FALSE,
+    'field_c_n_vertical_spacing' => 'none',
+    'field_c_n_components' => [
+      $intro,
+      $journey,
+      $no_black_box,
+      $estimate,
+      $work_to_price,
+      $two_options,
+      $reassurance,
+      $honesty,
+      $final_cta,
+    ],
+  ];
+
+  // The homepage banner media is reused; the page still works without it.
+  $banner_media = $entity_type_manager->getStorage('media')->loadByProperties(['uuid' => 'f23d0cc6-1581-4a1b-88c7-a60a8a6e9bc4']);
+  $banner_media = reset($banner_media);
+
+  if ($banner_media instanceof MediaInterface) {
+    $values['field_c_n_banner_background'] = ['target_id' => $banner_media->id()];
+  }
+
+  $node = $node_storage->create($values);
+  $node->save();
+
+  return sprintf('Created the How We Work page (node %s).', $node->id());
+}

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -10,6 +10,7 @@
 declare(strict_types=1);
 
 use Drupal\media\MediaInterface;
+use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Creates the How We Work page from the static prototype.
@@ -31,14 +32,17 @@ function do_base_deploy_populate_how_we_work_page(): string {
 
   $component = function (string $type, array $fields) use ($paragraph_storage): array {
     $paragraph = $paragraph_storage->create(['type' => $type] + $fields);
+
+    if (!$paragraph instanceof ParagraphInterface) {
+      throw new \RuntimeException(sprintf('Failed to create a "%s" paragraph.', $type));
+    }
+
     $paragraph->save();
 
     return ['target_id' => $paragraph->id(), 'target_revision_id' => $paragraph->getRevisionId()];
   };
 
-  $rich_text = function (string $html): array {
-    return ['value' => $html, 'format' => 'civictheme_rich_text'];
-  };
+  $rich_text = (fn(string $html): array => ['value' => $html, 'format' => 'civictheme_rich_text']);
 
   // A failed save mid-way must not leave orphaned paragraphs behind, so the
   // whole assembly commits or rolls back as one unit.
@@ -290,7 +294,7 @@ function do_base_deploy_populate_how_we_work_page(): string {
       'status' => 1,
       'moderation_state' => 'published',
       'field_c_n_summary' => 'See exactly what working with DrevOps looks like, from the first conversation to go-live: what happens at each step, what you receive,'
-      . ' and how we build a price with nothing hidden.',
+        . ' and how we build a price with nothing hidden.',
       'field_c_n_banner_theme' => 'dark',
       'field_c_n_banner_type' => 'large',
       'field_c_n_banner_title' => 'Know exactly what working with us looks like.',

--- a/web/themes/custom/drevops/assets/sass/_eyebrow.scss
+++ b/web/themes/custom/drevops/assets/sass/_eyebrow.scss
@@ -9,6 +9,10 @@
 
 $ct-eyebrow-color: #c1430a !default;
 
+// The orange reads too dark against dark bands, so those flip to the
+// palette's light-blue interaction accent, which clears WCAG AA there.
+$ct-eyebrow-color-dark: #90cfeb !default;
+
 .eyebrow {
   display: block;
   margin-block-end: 0.5rem;
@@ -17,4 +21,8 @@ $ct-eyebrow-color: #c1430a !default;
   line-height: 1.2;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.ct-theme-dark .eyebrow {
+  color: $ct-eyebrow-color-dark;
 }

--- a/web/themes/custom/drevops/assets/sass/_tables.scss
+++ b/web/themes/custom/drevops/assets/sass/_tables.scss
@@ -13,6 +13,10 @@
   --ct-table-light-caption-color: #{$ct-eyebrow-color};
 }
 
+.ct-theme-dark .ct-table {
+  --ct-table-dark-caption-color: #{$ct-eyebrow-color-dark};
+}
+
 .ct-table caption {
   caption-side: top;
   margin-block-end: 0.875rem;

--- a/web/themes/custom/drevops/assets/sass/_tables.scss
+++ b/web/themes/custom/drevops/assets/sass/_tables.scss
@@ -1,0 +1,25 @@
+//
+// Tables.
+//
+// Rich-text table captions use the same label voice as the eyebrow kicker.
+// Relies on `$ct-eyebrow-color` from `_eyebrow.scss`, imported before this
+// file in `theme.scss`.
+//
+
+.ct-table {
+  // CivicTheme colours captions through this variable with a more specific
+  // selector than a plain descendant rule, so the override targets the
+  // variable rather than fighting the specificity.
+  --ct-table-light-caption-color: #{$ct-eyebrow-color};
+}
+
+.ct-table caption {
+  caption-side: top;
+  margin-block-end: 0.875rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.1em;
+  text-align: left;
+  text-transform: uppercase;
+}

--- a/web/themes/custom/drevops/assets/sass/page/_page.scss
+++ b/web/themes/custom/drevops/assets/sass/page/_page.scss
@@ -6,7 +6,10 @@ html {
   // stylelint-disable property-no-vendor-prefix
   -webkit-text-size-adjust: 100%;
 
-  scroll-padding-top: ct-spacing(12);
+  // Plain value: this file compiles without the CivicTheme sass functions,
+  // so a ct-spacing() call would pass through unevaluated and be dropped by
+  // the browser as invalid CSS. 6rem clears the sticky header (89px tall).
+  scroll-padding-top: 6rem;
   scroll-behavior: smooth;
 
   @media (prefers-reduced-motion: reduce) {

--- a/web/themes/custom/drevops/assets/sass/theme.scss
+++ b/web/themes/custom/drevops/assets/sass/theme.scss
@@ -9,3 +9,4 @@
 @import 'page/page';
 @import 'block/local-tasks';
 @import 'eyebrow';
+@import 'tables';

--- a/web/themes/custom/drevops/components/03-organisms/steps/steps.component.yml
+++ b/web/themes/custom/drevops/components/03-organisms/steps/steps.component.yml
@@ -1,0 +1,61 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/11.x/core/modules/sdc/src/metadata.schema.json
+name: Steps
+status: stable
+description: Numbered steps rendered as a vertical journey with an outcome for each step.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: light
+    items:
+      type: array
+      title: Steps
+      description: Step items rendered in order.
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+            title: Title
+            description: Step title.
+          body:
+            type: string
+            title: Body
+            description: Step description.
+          receive:
+            type: string
+            title: You receive
+            description: Outcome shown as a "You receive:" note.
+    vertical_spacing:
+      type: string
+      title: Vertical spacing
+      description: Controls vertical spacing (top, bottom, or both).
+      enum:
+        - top
+        - bottom
+        - both
+    with_background:
+      type: boolean
+      title: With background
+      description: Whether to display with a themed background.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Additional HTML attributes
+      description: Additional HTML attributes to add to the component.
+    modifier_class:
+      type: string
+      title: Additional CSS classes
+      description: Additional CSS classes to add to the component.
+slots:
+  title:
+    title: Title
+    description: Optional heading shown above the steps.
+  content:
+    title: Content
+    description: Optional intro content shown above the steps.

--- a/web/themes/custom/drevops/components/03-organisms/steps/steps.scss
+++ b/web/themes/custom/drevops/components/03-organisms/steps/steps.scss
@@ -60,6 +60,10 @@
     width: ct-particle(6);
     height: ct-particle(6);
     border-radius: 50%;
+
+    // A bare span inherits no typography, so the numeral takes the same
+    // runtime face as the step titles beside it.
+    font-family: var(--ct-typography-heading-3-font-name, sans-serif);
     font-size: 1.15rem;
     font-weight: 700;
 

--- a/web/themes/custom/drevops/components/03-organisms/steps/steps.scss
+++ b/web/themes/custom/drevops/components/03-organisms/steps/steps.scss
@@ -8,6 +8,9 @@
   #{$root}__header {
     text-align: center;
     margin-bottom: ct-spacing(6);
+    max-width: ct-particle(97.5);
+    margin-left: auto;
+    margin-right: auto;
   }
 
   #{$root}__items {

--- a/web/themes/custom/drevops/components/03-organisms/steps/steps.scss
+++ b/web/themes/custom/drevops/components/03-organisms/steps/steps.scss
@@ -1,0 +1,105 @@
+//
+// Steps component.
+//
+
+.ct-steps {
+  $root: &;
+
+  #{$root}__header {
+    text-align: center;
+    margin-bottom: ct-spacing(6);
+  }
+
+  #{$root}__items {
+    list-style: none;
+    position: relative;
+    max-width: ct-particle(110);
+    margin: 0 auto;
+    padding: 0;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: ct-spacing(1);
+      bottom: ct-spacing(1);
+      left: ct-particle(3);
+      transform: translateX(-50%);
+      width: ct-particle(0.25);
+    }
+
+    @include ct-breakpoint(m) {
+      &::before {
+        left: ct-particle(3.5);
+      }
+    }
+  }
+
+  #{$root}__item {
+    position: relative;
+    padding: 0 0 ct-spacing(5) ct-particle(8.5);
+
+    &:last-child {
+      padding-bottom: 0;
+    }
+
+    @include ct-breakpoint(m) {
+      padding-left: ct-particle(10.5);
+    }
+  }
+
+  #{$root}__item-number {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: ct-particle(6);
+    height: ct-particle(6);
+    border-radius: 50%;
+    font-size: 1.15rem;
+    font-weight: 700;
+
+    @include ct-breakpoint(m) {
+      width: ct-particle(7);
+      height: ct-particle(7);
+      font-size: 1.35rem;
+    }
+  }
+
+  #{$root}__item-title {
+    margin: 0 0 ct-spacing(1);
+  }
+
+  #{$root}__item-body {
+    margin: 0 0 ct-spacing(2);
+  }
+
+  #{$root}__item-receive {
+    margin: 0;
+    padding: ct-spacing(2);
+    border-left-style: solid;
+    border-left-width: ct-particle(0.375);
+    border-radius: ct-particle(0.375);
+  }
+
+  @include ct-component-theme($root) using($root, $theme) {
+    &#{$root}--with-background {
+      background-color: if($theme == 'light', $ct-steps-light-background-color, $ct-steps-dark-background-color);
+    }
+
+    #{$root}__items::before {
+      background-color: if($theme == 'light', $ct-steps-light-rail-color, $ct-steps-dark-rail-color);
+    }
+
+    #{$root}__item-number {
+      background-color: if($theme == 'light', $ct-steps-light-number-background-color, $ct-steps-dark-number-background-color);
+      color: if($theme == 'light', $ct-steps-light-number-color, $ct-steps-dark-number-color);
+    }
+
+    #{$root}__item-receive {
+      background-color: if($theme == 'light', $ct-steps-light-receive-background-color, $ct-steps-dark-receive-background-color);
+      border-left-color: if($theme == 'light', $ct-steps-light-receive-border-color, $ct-steps-dark-receive-border-color);
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/03-organisms/steps/steps.stories.js
+++ b/web/themes/custom/drevops/components/03-organisms/steps/steps.stories.js
@@ -20,7 +20,7 @@ const meta = {
     },
     vertical_spacing: {
       control: { type: 'radio' },
-      options: ['none', 'top', 'bottom', 'both'],
+      options: ['top', 'bottom', 'both'],
     },
     with_background: {
       control: { type: 'boolean' },

--- a/web/themes/custom/drevops/components/03-organisms/steps/steps.stories.js
+++ b/web/themes/custom/drevops/components/03-organisms/steps/steps.stories.js
@@ -1,0 +1,69 @@
+// phpcs:ignoreFile
+import Component from './steps.twig';
+
+const meta = {
+  title: 'Organisms/Steps',
+  component: Component,
+  argTypes: {
+    theme: {
+      control: { type: 'radio' },
+      options: ['light', 'dark'],
+    },
+    title: {
+      control: { type: 'text' },
+    },
+    content: {
+      control: { type: 'text' },
+    },
+    items: {
+      control: { type: 'object' },
+    },
+    vertical_spacing: {
+      control: { type: 'radio' },
+      options: ['none', 'top', 'bottom', 'both'],
+    },
+    with_background: {
+      control: { type: 'boolean' },
+    },
+    modifier_class: {
+      control: { type: 'text' },
+    },
+    attributes: {
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const Steps = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    theme: 'light',
+    title: 'Six steps, and what you get at each one.',
+    content: '<p>Every engagement follows the same path. Each step builds on the one before it.</p>',
+    items: [
+      {
+        title: 'The first conversation',
+        body: 'We listen and map what you actually need, which is often a little different from the initial brief.',
+        receive: 'A written summary of your goals and scope, confirmed with you before any number exists.',
+      },
+      {
+        title: 'A proper assessment',
+        body: 'We review your real platform, the code, the integrations, and the risks, not just the description of it.',
+        receive: 'A clear, honest report you can act on and share.',
+      },
+      {
+        title: 'A transparent quotation',
+        body: 'We price the work from a standard rate card, line by line, adding a buffer only where there are genuine unknowns.',
+        receive: 'Two complete options, hand-built and AI-assisted, with the hours shown and nothing hidden.',
+      },
+    ],
+    vertical_spacing: 'both',
+    with_background: false,
+    modifier_class: '',
+    attributes: '',
+  },
+};

--- a/web/themes/custom/drevops/components/03-organisms/steps/steps.twig
+++ b/web/themes/custom/drevops/components/03-organisms/steps/steps.twig
@@ -1,0 +1,71 @@
+{#
+/**
+ * @file
+ * Steps component.
+ *
+ * Variables:
+ * - theme: [string] Theme: light, dark.
+ * - title: [string] Optional heading shown above the steps.
+ * - content: [string] Optional intro content shown above the steps.
+ * - items: [array] Step items:
+ *   - title: [string] Step title.
+ *   - body: [string] Step description.
+ *   - receive: [string] Outcome shown as a "You receive:" note.
+ * - vertical_spacing: [string] With top, bottom or both vertical spaces.
+ * - with_background: [boolean] Whether to display with a themed background.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ */
+#}
+
+{% set with_background_class = with_background ? 'ct-steps--with-background' : '' %}
+{% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set modifier_class = '%s %s %s %s'|format(theme_class, with_background_class, vertical_spacing_class, modifier_class|default('')) %}
+
+{% if items is not empty %}
+  <div class="ct-steps {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="container">
+      {% if title is not empty or content is not empty %}
+        <div class="row">
+          <div class="col-xxs-12">
+            <div class="ct-steps__header">
+              {% if title is not empty %}
+                {% include 'civictheme:heading' with {
+                  content: title,
+                  level: 2,
+                  theme: theme,
+                  modifier_class: 'ct-steps__title',
+                } only %}
+              {% endif %}
+              {% if content is not empty %}
+                <div class="ct-steps__content">{{ content }}</div>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+
+      <div class="row">
+        <div class="col-xxs-12">
+          <ol class="ct-steps__items" role="list">
+            {% for item in items %}
+              <li class="ct-steps__item">
+                <span class="ct-steps__item-number" aria-hidden="true">{{ loop.index }}</span>
+                {% if item.title is not empty %}
+                  <h3 class="ct-steps__item-title">{{ item.title }}</h3>
+                {% endif %}
+                {% if item.body is not empty %}
+                  <p class="ct-steps__item-body">{{ item.body }}</p>
+                {% endif %}
+                {% if item.receive is not empty %}
+                  <p class="ct-steps__item-receive"><strong>{{ 'You receive:'|t }}</strong> {{ item.receive }}</p>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/components/variables.components.scss
+++ b/web/themes/custom/drevops/components/variables.components.scss
@@ -120,3 +120,19 @@ $ct-divider-dark-border-color: transparent;
 //
 
 $ct-header-sticky-zindex: 500;
+
+//
+// Steps.
+//
+$ct-steps-light-background-color: ct-color-light('background') !default;
+$ct-steps-dark-background-color: ct-color-dark('background') !default;
+$ct-steps-light-rail-color: rgba(ct-color-light('highlight'), 0.35) !default;
+$ct-steps-dark-rail-color: rgba(ct-color-dark('highlight'), 0.35) !default;
+$ct-steps-light-number-background-color: ct-color-light('interaction-background') !default;
+$ct-steps-dark-number-background-color: ct-color-dark('interaction-background') !default;
+$ct-steps-light-number-color: ct-color-light('interaction-text') !default;
+$ct-steps-dark-number-color: ct-color-dark('interaction-text') !default;
+$ct-steps-light-receive-background-color: ct-color-light('background') !default;
+$ct-steps-dark-receive-background-color: ct-color-dark('background-light') !default;
+$ct-steps-light-receive-border-color: ct-color-light('highlight') !default;
+$ct-steps-dark-receive-border-color: ct-color-dark('highlight') !default;

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -14,6 +14,7 @@ require_once __DIR__ . '/includes/banner.inc';
 require_once __DIR__ . '/includes/paragraphs.inc';
 require_once __DIR__ . '/includes/divider.inc';
 require_once __DIR__ . '/includes/manual_list.inc';
+require_once __DIR__ . '/includes/steps.inc';
 require_once __DIR__ . '/includes/page.inc';
 require_once __DIR__ . '/includes/node.inc';
 require_once __DIR__ . '/includes/cards.inc';

--- a/web/themes/custom/drevops/includes/steps.inc
+++ b/web/themes/custom/drevops/includes/steps.inc
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Steps paragraph preprocessing.
+ */
+
+declare(strict_types=1);
+
+use Drupal\paragraphs\ParagraphInterface;
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function drevops_preprocess_paragraph__steps(array &$variables): void {
+  _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__vertical_spacing($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__background($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__title($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__content($variables);
+  _drevops_preprocess_paragraph__paragraph_field__steps($variables);
+}
+
+/**
+ * Pre-process for Steps items paragraph field.
+ */
+function _drevops_preprocess_paragraph__paragraph_field__steps(array &$variables): void {
+  $variables['items'] = [];
+
+  $steps = civictheme_get_field_value($variables['paragraph'], 'field_c_p_list_items', build: $variables) ?? [];
+
+  foreach ($steps as $step) {
+    if (!$step instanceof ParagraphInterface) {
+      continue;
+    }
+
+    $variables['items'][] = [
+      'title' => civictheme_get_field_value($step, 'field_c_p_title'),
+      'body' => civictheme_get_field_value($step, 'field_c_p_summary'),
+      'receive' => civictheme_get_field_value($step, 'field_p_receive'),
+    ];
+  }
+}

--- a/web/themes/custom/drevops/templates/paragraphs/paragraph--steps.html.twig
+++ b/web/themes/custom/drevops/templates/paragraphs/paragraph--steps.html.twig
@@ -1,0 +1,9 @@
+{#
+/**
+ * @file
+ * Theme implementation to display the Steps component.
+ */
+#}
+{{ include('drevops:steps', {
+  attributes: component_attributes,
+}) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added a reusable `steps` paragraph component (`steps` and `steps_item` bundles) with hand-authored config for field storage (`field_p_receive`), field instances reusing existing `field_c_p_*` storages, form displays, and view displays, allow-listed in `field.field.node.civictheme_page.field_c_n_components.yml` so editors can add it to any `civictheme_page`.
2. Added the `drevops:steps` theme SDC at `web/themes/custom/drevops/components/03-organisms/steps/` with a twig template rendering auto-numbered circles, a timeline rail, and "You receive:" callouts, light and dark theme support, a Storybook story, and SCSS using CivicTheme tokens (`$ct-steps-*` variables added to `variables.components.scss`); the number circles use the theme's generated heading typography variable so the numerals render in the heading typeface instead of the browser default a bare span would inherit.
3. Wired the component with a new `steps.inc` preprocess file (loaded via `drevops.theme`) and a `paragraph--steps.html.twig` template override that mirrors the existing `divider` wiring pattern.
4. Added `static-prototype/how-we-work.html` as the tracked, self-contained source of truth for the new page design, carrying the same sticky-header anchor offset the live theme uses so its in-page smooth scrolling behaves like the build.
5. Added the `do_base_deploy_populate_how_we_work_page()` deploy hook in `web/modules/custom/do_base/do_base.deploy.php` that assembles the full `How We Work` page from the prototype copy verbatim: banner fields plus 9 body paragraphs (intro, the steps journey with 6 items, a dark "no black box" band, 3 striped pricing tables as rich text, a promo-card reassurance grid, an honesty band, and a final CTA).
6. Made the deploy hook idempotent via a fixed node UUID guard (a second run no-ops), guarded paragraph creation with an `instanceof` check, and wrapped the whole assembly in a database transaction so a failed save cannot leave orphaned paragraphs behind; the page is published on deploy, the `/how-we-work` alias comes from pathauto, the hero reuses the existing homepage banner media looked up by UUID and is gracefully skipped if absent, and the meta description is set via `field_c_n_summary`.
7. Added Behat coverage in `tests/behat/features/paragraph_steps_render.feature` with light and dark render scenarios for the `steps` paragraph.
8. Fixed `scroll-padding-top` in `web/themes/custom/drevops/assets/sass/page/_page.scss` being emitted as an unevaluated `ct-spacing()` call because that compilation unit has no CivicTheme sass functions, so browsers dropped the declaration and in-page anchors landed under the sticky header; replaced with a plain `6rem`.
9. Flipped `.eyebrow` labels to the light-blue accent on dark bands in `_eyebrow.scss` so the label clears WCAG AA contrast there.
10. Styled `ct-table` captions as uppercase kicker labels via a new `_tables.scss`, reusing the eyebrow colour through the CivicTheme caption CSS variables with both light and dark counterparts.
11. Constrained the `steps` header to the prototype's 780px text pocket.

Deliberate divergences from the prototype, reviewed and approved: pricing tables render as plain `ct-table ct-table--striped` without per-row total or highlight classes because the rich-text filter does not allow classes on `<tr>` (totals are bolded instead); the hero reuses the homepage banner image because the prototype's image asset does not exist; the hero eyebrow is dropped because CivicTheme banners render the title first.

## Screenshots

![How We Work page](https://raw.githubusercontent.com/drevops/website/8868c347c4a350513b4501826d0bcfbf58f0563e/feature-how-we-work-page/2cb4d53ec9262517c280742e037f54265f363a00.png)

## Before / After

```
BEFORE
┌───────────────────────────────────────────────────────┐
│ do_base.deploy.php ......... no deploy hooks           │
│ theme components/ ........... no steps/ directory      │
│ static-prototype/ ........... how-we-work.html absent  │
└───────────────────────────────────────────────────────┘
     No /how-we-work page exists on any environment

AFTER
┌─────────────────────────────────────────────────────────┐
│ static-prototype/how-we-work.html (tracked source)      │
│ config/*.paragraph.steps*.yml (steps, steps_item)       │
│ steps.inc (preprocess) -> drevops:steps SDC (twig+scss) │
│ do_base.deploy.php: populate_how_we_work_page()         │
│   - idempotent via a fixed node UUID guard              │
│   - wrapped in a DB transaction                         │
└─────────────────────────────────────────────────────────┘
   /how-we-work is seeded and published on every deploy
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **“Steps”** content block/component with configurable title/content, numbered step items, an optional “You receive” note, and spacing/background/theme controls.
  * Enabled **“Steps”** as a reusable paragraph option and added Storybook documentation for the component.
  * Published the **“How We Work”** page with a full workflow overview, pricing breakdowns, and calls to action.
* **Bug Fixes**
  * Improved anchor scrolling offset so sticky headers no longer cover targeted content.
* **Tests**
  * Added automated rendering coverage for Steps in light and dark variants.
* **Documentation**
  * Added a static prototype page for “How We Work”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
