### PR TITLE
Reconciled Vortex 1.40.2 template gaps.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
         "drevops/test-private-package": "^1.0",
-        "drevops/vortex-tooling": "^1.3.0",
+        "drevops/vortex-tooling": "~1.3.0",
         "drupal/admin_toolbar": "^3.6.3",
         "drupal/ai_image_alt_text": "^1.0.2",
         "drupal/ai_provider_openai": "^1.2.3",
@@ -86,7 +86,7 @@
         "phpunit/phpunit": "^11.5.56",
         "pyrech/composer-changelogs": "^2.2",
         "rector/rector": "^2.5.8",
-        "vincentlanglet/twig-cs-fixer": "^3.14"
+        "vincentlanglet/twig-cs-fixer": "^4.0.2"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfc884d631217234824fa4f750d9c4bf",
+    "content-hash": "6c853c86554b81f3fc332370e2388387",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -18178,16 +18178,16 @@
         },
         {
             "name": "vincentlanglet/twig-cs-fixer",
-            "version": "3.14.0",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/VincentLanglet/Twig-CS-Fixer.git",
-                "reference": "599f110f192c31af5deb5736d6c1a970afdf51f3"
+                "reference": "1cb75618f7dd0f9bf51924aa6d3aa8c588f51d5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VincentLanglet/Twig-CS-Fixer/zipball/599f110f192c31af5deb5736d6c1a970afdf51f3",
-                "reference": "599f110f192c31af5deb5736d6c1a970afdf51f3",
+                "url": "https://api.github.com/repos/VincentLanglet/Twig-CS-Fixer/zipball/1cb75618f7dd0f9bf51924aa6d3aa8c588f51d5a",
+                "reference": "1cb75618f7dd0f9bf51924aa6d3aa8c588f51d5a",
                 "shasum": ""
             },
             "require": {
@@ -18198,7 +18198,7 @@
                 "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
                 "symfony/finder": "^5.4 || ^6.4 || ^7.0 || ^8.0",
                 "symfony/string": "^5.4.42 || ^6.4.10 || ~7.0.10 || ^7.1.3 || ^8.0",
-                "twig/twig": "^3.4",
+                "twig/twig": "^3.15",
                 "webmozart/assert": "^1.10 || ^2.0"
             },
             "require-dev": {
@@ -18243,7 +18243,7 @@
             "homepage": "https://github.com/VincentLanglet/Twig-CS-Fixer",
             "support": {
                 "issues": "https://github.com/VincentLanglet/Twig-CS-Fixer/issues",
-                "source": "https://github.com/VincentLanglet/Twig-CS-Fixer/tree/3.14.0"
+                "source": "https://github.com/VincentLanglet/Twig-CS-Fixer/tree/4.0.2"
             },
             "funding": [
                 {
@@ -18251,7 +18251,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-23T13:21:35+00:00"
+            "time": "2026-06-29T15:22:14+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Re-ran the Vortex template at 1.40.2, the version the project is already on, to find consumer-facing content that the previous 1.40.2 update (#258) never applied. This is a gap reconciliation, not a version bump. The code change is deliberately small: two composer constraints. The substance is in what was checked, and in two issues raised off the back of it.

### What changed

| Node | Before | After | Why |
|---|---|---|---|
| `vincentlanglet/twig-cs-fixer` | `^3.14` | `^4.0.2` | The template has shipped 4.x since 1.40.0, so the project was a major behind for two releases. `ahoy lint` is green on 4.0.2 - the bump surfaced no new Twig violations. |
| `drevops/vortex-tooling` | `^1.3.0` | `~1.3.0` | Matches the template. That package provides the `vortex-*` binaries, which are coupled to the template version, so `~` stops a 1.4.x minor arriving ahead of the template it belongs to. |

### Method

The installer does not apply a patch - it re-renders the whole template with the project's answers and copies the result over the working tree. That produced 25 modified files and 898 deletions, almost all of which was the installer resetting project customisations rather than anything Vortex changed.

Because the applied version equals the baseline version, the usual "compare baseline to applied" ground truth is empty. The authoritative comparison here is `d3dfcde...1.40.2` - what 1.40.2 *should* have delivered relative to the 1.40.0-line commit the project was pinned to before #258 - cross-referenced against the 20 files #258 actually touched.

That isolated three genuine file-level gaps, all of which were reviewed and declined as Vortex starter scaffolding that does not apply to this site:

- `recipes/page/` (7 config files) - creates a plain "Basic page" content type. This site's content model is CivicTheme (`civictheme_page`, `civictheme_alert`, `civictheme_event`) and it provisions from a demo database.
- `.gitignore` `!recipes/page` - the paired unignore, pointless without the recipe.
- `scripts/provision-10-example.sh` - Vortex's own header calls it an example to clone or remove. It collides at the `10` ordering slot with `provision-10-enable-dev-modules.sh` and re-installs modules the demo database already has enabled.

### Reverted, not accepted

Everything else the installer proposed was project drift. Three groups are worth calling out because taking them would have caused real damage:

- **Version downgrades.** `docker-compose.yml` would have moved `uselagoon/mysql-8.4` and `uselagoon/valkey-8` from `26.7.0` back to `26.6.0`, and `selenium/standalone-chromium` from `150.0` to `149.0`. Renovate keeps this project ahead of the template, so the template proposing older tags is the normal case.
- **A toolchain switch.** `.docker/cli.dockerfile` and `.github/workflows/build-test-deploy.yml` would have switched the theme build from npm to yarn. `web/themes/custom/drevops/` contains `package-lock.json` and no `yarn.lock`, and the upstream patch for that workflow does not contain the npm/yarn line at all - it is pure re-render noise.
- **Project code ahead of the template.** `web/index.php` runs the Drupal 11.4 Symfony-Runtime bootstrap from core 11.4.4; the 1.40.2 template still ships the legacy one. `scripts/vortex-tooling.sh` carries a guard that only landed upstream after 1.40.2. `.lagoon.yml` would have lost the production and dev `routes:` blocks - the real domains.

### Issues raised

Comparing against the installer's *rendered* `composer.json` reported zero missing template packages, which is a false negative. The installer discovers its answers from the codebase, and for modules that means "is the package in `composer.json`" - so a package the project never adopted answers itself "no", gets stripped from the render, and can never show up as a diff. The absence produces the answer and the answer reproduces the absence.

Comparing against the unrendered template at the tag surfaced four packages the render had hidden:

- `drupal/xmlsitemap` `^2.0` - #262. The project uses `drupal/simple_sitemap ^4.2.3`, fully wired. Needs a recorded decision rather than a silent divergence.
- `drupal/reroute_email` `^2.3@RC` - #263. Real exposure: the only mail guard is `suspend_mail_send` scoped to `ENVIRONMENT_CI`, so dev and stage have no interception. Database sanitisation rewrites *user* addresses but not config-held recipients such as webform handler notifications, and the project has `drupal/webform`.
- `drupal/migrate_plus` and `drupal/migrate_tools` - declined as accepted divergences, tied to the deliberate "Migration database: No" answer.

### Validation

| Gate | Result |
|---|---|
| `ahoy build` | pass |
| `ahoy test-unit` | pass |
| `ahoy lint` | pass |

All three passed first time.

## Screenshots

N/A - this change is non-visual, composer constraints only.

## Before / After

Composer constraint state, before this PR vs after:

```
┌──────────────────────────────┬────────┬────────┐
│ Package                      │ Before │ After  │
├──────────────────────────────┼────────┼────────┤
│ vincentlanglet/twig-cs-fixer │ ^3.14  │ ^4.0.2 │
│ drevops/vortex-tooling       │ ^1.3.0 │ ~1.3.0 │
└──────────────────────────────┴────────┴────────┘
```

Template-proposed packages that were considered and declined (not part of this change, tracked separately):

```
┌──────────────────────┬─────────┬─────────────────────────────────┐
│ Package              │ Version │ Status                          │
├──────────────────────┼─────────┼─────────────────────────────────┤
│ drupal/xmlsitemap    │ ^2.0    │ Not adopted, tracked in #262    │
│ drupal/reroute_email │ ^2.3@RC │ Not adopted, tracked in #263    │
│ drupal/migrate_plus  │ -       │ Declined, no migration database │
│ drupal/migrate_tools │ -       │ Declined, no migration database │
└──────────────────────┴─────────┴─────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project package compatibility constraints.
  * Refreshed development tooling requirements to support newer releases.
  * No direct changes to the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->