### PR TITLE
[#255] Replaced the Admin Toolbar stack with the core Navigation module.

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -56,7 +56,7 @@ default:
       drush:
         root: web
       regions:
-        primary_tabs: '#block-drevops-primary-local-tasks'
+        page_actions: '.top-bar__actions'
         header_top_1: '.ct-header__content-top1'
         header_top_2: '.ct-header__content-top2'
         header_top_3: '.ct-header__content-top3'

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "drupal/lagoon_logs": "^3.0.1",
         "drupal/menu_trail_by_path": "^2.2",
         "drupal/metatag": "^2.2",
+        "drupal/navigation_extra_tools": "^1.3.2",
         "drupal/pathauto": "^1.15",
         "drupal/purge": "^3.7",
         "drupal/purge_control": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f31ec6a625d1f561a9bdd4e0727abd1",
+    "content-hash": "1e368a357f152272679e97491f6f1a1c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4614,6 +4614,63 @@
                 "source": "https://git.drupalcode.org/project/metatag",
                 "issues": "https://www.drupal.org/project/issues/metatag",
                 "docs": "https://www.drupal.org/docs/8/modules/metatag"
+            }
+        },
+        {
+            "name": "drupal/navigation_extra_tools",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/navigation_extra_tools.git",
+                "reference": "1.3.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/navigation_extra_tools-1.3.2.zip",
+                "reference": "1.3.2",
+                "shasum": "376e6638a064ba319b0af9672ae325e1c580180f"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11 || ^12",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "drupal/automatic_updates": "^3.1 || ^4.0@alpha",
+                "drupal/devel": "^5.1",
+                "drupal/project_browser": "^2.0-beta3 || ^2.1-beta3",
+                "drush/drush": ">=11.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.3.2",
+                    "datestamp": "1770243935",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "James Shields",
+                    "homepage": "https://www.drupal.org/u/lostcarpark",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "ultimike",
+                    "homepage": "https://www.drupal.org/user/51132"
+                }
+            ],
+            "description": "Provide useful tools to Drupal Navigation.",
+            "homepage": "https://www.drupal.org/project/navigation_extra_tools",
+            "support": {
+                "source": "https://git.drupalcode.org/project/navigation_extra_tools",
+                "issues": "https://www.drupal.org/project/issues/navigation_extra_tools"
             }
         },
         {

--- a/config/default/admin_toolbar.settings.yml
+++ b/config/default/admin_toolbar.settings.yml
@@ -1,7 +1,0 @@
-_core:
-  default_config_hash: jvTSppzcgH5wnzBhX5xnAExcp2I1CzkQ_aky65XNfYI
-menu_depth: 4
-hoverintent_behavior:
-  enabled: true
-  timeout: 500
-enable_toggle_shortcut: false

--- a/config/default/admin_toolbar_tools.settings.yml
+++ b/config/default/admin_toolbar_tools.settings.yml
@@ -1,4 +1,0 @@
-_core:
-  default_config_hash: WgdZsrd_5w9jlmcHV4R9dD2tG9OZEkYo4I_O8h7Gq8Q
-max_bundle_number: 20
-show_local_tasks: false

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -1,8 +1,6 @@
 _core:
   default_config_hash: 4GIX5Esnc_umpXUBj4IIocRX7Mt5fPhm4AgXfE3E56E
 module:
-  admin_toolbar: 0
-  admin_toolbar_tools: 0
   ai: 0
   ai_image_alt_text: 0
   automated_cron: 0
@@ -47,7 +45,6 @@ module:
   filter: 0
   focal_point: 0
   gemini_provider: 0
-  gin_toolbar: 0
   google_tag: 0
   help: 0
   highlight_js: 0
@@ -77,6 +74,8 @@ module:
   metatag_open_graph: 0
   metatag_twitter_cards: 0
   mysql: 0
+  navigation: 0
+  navigation_extra_tools: 0
   node: 0
   options: 0
   page_cache: 0
@@ -106,7 +105,6 @@ module:
   taxonomy: 0
   text: 0
   token: 0
-  toolbar: 0
   user: 0
   views_bulk_operations: 0
   views_ui: 0

--- a/config/default/navigation.block_layout.yml
+++ b/config/default/navigation.block_layout.yml
@@ -1,0 +1,68 @@
+_core:
+  default_config_hash: P5Y3iMx85NwT445BpYIe9fME9nXDF1AXmOJ_QmTnF34
+langcode: en
+sections:
+  -
+    layout_id: navigation_layout
+    layout_settings:
+      label: ''
+    components:
+      2622e40b-8786-4b8c-8883-19e49da53023:
+        uuid: 2622e40b-8786-4b8c-8883-19e49da53023
+        region: content
+        configuration:
+          id: navigation_shortcuts
+          label: Shortcuts
+          label_display: '0'
+          provider: navigation
+        weight: 0
+        additional: {  }
+      3ff7be01-c8b0-4444-88f3-2364d7a8054e:
+        uuid: 3ff7be01-c8b0-4444-88f3-2364d7a8054e
+        region: content
+        configuration:
+          id: 'navigation_menu:content'
+          label: Content
+          label_display: '0'
+          provider: navigation
+          level: 1
+          depth: 2
+        weight: 1
+        additional: {  }
+      3f2f743f-856f-404a-9c28-57ee83af4691:
+        uuid: 3f2f743f-856f-404a-9c28-57ee83af4691
+        region: content
+        configuration:
+          id: 'navigation_menu:admin'
+          label: Administration
+          label_display: '0'
+          provider: navigation
+          level: 2
+          depth: 2
+        weight: 2
+        additional: {  }
+      283da777-e051-4571-8089-47633a9ce706:
+        uuid: 283da777-e051-4571-8089-47633a9ce706
+        region: footer
+        configuration:
+          id: navigation_user
+          label: User
+          label_display: '0'
+          provider: navigation
+        weight: 0
+        additional: {  }
+      6d7080a7-abab-4bad-b960-2459ca892a54:
+        uuid: 6d7080a7-abab-4bad-b960-2459ca892a54
+        region: footer
+        configuration:
+          id: navigation_link
+          label: Help
+          label_display: '0'
+          provider: navigation
+          context_mapping: {  }
+          title: Help
+          uri: 'internal:/admin/help'
+          icon_class: help
+        weight: -2
+        additional: {  }
+    third_party_settings: {  }

--- a/config/default/navigation.settings.yml
+++ b/config/default/navigation.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: FeJ38-AShWZUh_NwJprQueefcE06zSnUa3cw1lOdjTY
+logo:
+  provider: default
+  path: ''
+  max:
+    filesize: 1048576
+    height: 40
+    width: 40

--- a/config/default/system.menu.content.yml
+++ b/config/default/system.menu.content.yml
@@ -1,0 +1,13 @@
+uuid: 690452cf-f4ae-4cdc-a51c-8b342e65953a
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - navigation
+_core:
+  default_config_hash: nqVwm91Uyib_rvFaNPF1MdYqHlmZ38w5rsOVVy4uWDw
+id: content
+label: Content
+description: 'Content task links'
+locked: true

--- a/config/default/system.menu.navigation-user-links.yml
+++ b/config/default/system.menu.navigation-user-links.yml
@@ -1,0 +1,13 @@
+uuid: 6c15332f-2e2a-4861-9356-2f63e18fcc3a
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - navigation
+_core:
+  default_config_hash: RP5hKQYc151zqBiiWtGfY-3JN7i35Gtxo1f2hhS09hM
+id: navigation-user-links
+label: 'Navigation user links'
+description: 'User links to be used in Navigation'
+locked: true

--- a/config/default/user.role.civictheme_content_approver.yml
+++ b/config/default/user.role.civictheme_content_approver.yml
@@ -13,10 +13,10 @@ dependencies:
     - filter
     - linkit
     - media
+    - navigation
     - node
     - scheduled_transitions
     - system
-    - toolbar
 _core:
   default_config_hash: z5yWuJJkqJroQmQ21H22z3l-pGKs85Issiy6lqU2-Y8
 id: civictheme_content_approver
@@ -28,7 +28,7 @@ permissions:
   - 'access contextual links'
   - 'access files overview'
   - 'access media overview'
-  - 'access toolbar'
+  - 'access navigation'
   - 'administer linkit profiles'
   - 'administer scheduled transitions'
   - 'generate ai alt tags'

--- a/config/default/user.role.civictheme_content_author.yml
+++ b/config/default/user.role.civictheme_content_author.yml
@@ -24,12 +24,12 @@ dependencies:
     - filter
     - linkit
     - media
+    - navigation
     - node
     - path
     - scheduled_transitions
     - system
     - taxonomy
-    - toolbar
 _core:
   default_config_hash: jKyTaFQv0l2H-eg26nEdCGVYAz9gh29KxOkSF2iBPeQ
 id: civictheme_content_author
@@ -41,7 +41,7 @@ permissions:
   - 'access contextual links'
   - 'access files overview'
   - 'access media overview'
-  - 'access toolbar'
+  - 'access navigation'
   - 'administer linkit profiles'
   - 'administer scheduled transitions'
   - 'administer url aliases'

--- a/config/default/user.role.civictheme_site_administrator.yml
+++ b/config/default/user.role.civictheme_site_administrator.yml
@@ -33,6 +33,7 @@ dependencies:
     - filter
     - linkit
     - media
+    - navigation
     - node
     - paragraphs_library
     - path
@@ -41,7 +42,6 @@ dependencies:
     - scheduled_transitions
     - system
     - taxonomy
-    - toolbar
     - webform
 _core:
   default_config_hash: 3RGvhVh7oqJvosWqYYZ0Fr0Ka_WUl_o2fZkK6xsjhzk
@@ -59,11 +59,11 @@ permissions:
   - 'access environment indicator'
   - 'access files overview'
   - 'access media overview'
+  - 'access navigation'
   - 'access own webform configuration'
   - 'access site in maintenance mode'
   - 'access site reports'
   - 'access taxonomy overview'
-  - 'access toolbar'
   - 'access user profiles'
   - 'access webform help'
   - 'access webform overview'

--- a/tests/behat/features/admin_navigation.feature
+++ b/tests/behat/features/admin_navigation.feature
@@ -1,0 +1,12 @@
+Feature: Administration navigation for site administrator
+
+  As a site administrator
+  I want to navigate the site administration through the core Navigation sidebar
+  So that I have a single administration navigation that does not break contextual links
+
+  @api @javascript
+  Scenario: Site administrator can see the Navigation sidebar and not the classic Toolbar
+    Given I am logged in as a user with the "civictheme_site_administrator" role
+    When I visit "/"
+    Then I should see an "#admin-toolbar" element
+    And I should not see a "#toolbar-administration" element

--- a/tests/behat/features/entity_clone.feature
+++ b/tests/behat/features/entity_clone.feature
@@ -27,9 +27,9 @@ Feature: Entity Clone permissions for Content Author role
     Then I should see the link "Test CivicTheme Clone Page"
 
     When I click "Test CivicTheme Clone Page"
-    Then I should see the link "Clone" in the "primary_tabs" region
+    Then I should see the link "Clone" in the "page_actions" region
 
-    When I click "Clone" in the "primary_tabs" region
+    When I click "Clone" in the "page_actions" region
     Then I should see "Clone Content"
 
     When I press "Clone"

--- a/tests/behat/features/environment_indicator_access.feature
+++ b/tests/behat/features/environment_indicator_access.feature
@@ -5,7 +5,7 @@ Feature: Environment indicator access for site administrator
   So that I know which environment I'm working in
 
   @api @javascript
-  Scenario: Site administrator can see environment indicator toolbar styling
+  Scenario: Site administrator can see environment indicator styling
     Given I am logged in as a user with the "civictheme_site_administrator" role
     When I visit "/"
-    Then the element ".toolbar-menu-administration" with the attribute "style" and the value containing "border-left-color" should exist
+    Then the element "#environment-indicator" with the attribute "style" and the value containing "background-color" should exist

--- a/web/modules/custom/do_base/do_base.install
+++ b/web/modules/custom/do_base/do_base.install
@@ -15,7 +15,7 @@ use Drupal\drupal_helpers\Helper;
 function do_base_update_11001(): string {
   // Update hooks run ahead of config import, so drupal_helpers is not yet
   // enabled from exported configuration on the deployment that first needs it.
-  // This is the one place the core installer is preferred over
+  // This is the one case where the core installer is preferred over
   // Helper::module(), because that API is what is being made available.
   \Drupal::service('module_installer')->install(['drupal_helpers']);
 
@@ -27,4 +27,32 @@ function do_base_update_11001(): string {
   // replacing the shared reporter with an empty one, so the helper's own
   // return value is what reports the outcome.
   return Helper::module()->uninstall('simple_sitemap');
+}
+
+/**
+ * Uninstalls the classic Toolbar stack.
+ */
+function do_base_update_11002(): string {
+  // Update hooks run ahead of config import, so drupal_helpers is not yet
+  // enabled from exported configuration on the deployment that first needs it.
+  // This is the one case where the core installer is preferred over
+  // Helper::module(), because that API is what is being made available.
+  \Drupal::service('module_installer')->install(['drupal_helpers']);
+
+  // The core Navigation module supersedes the classic Toolbar, and core
+  // disables Toolbar's functionality when both are installed. Leaving the two
+  // together also breaks admin contextual links, because the toolbar module
+  // keeps loading contextual.toolbar.js. Removing the stack ahead of config
+  // import - which is what installs Navigation - means the site never runs
+  // both at once. Dependents are removed first so the toolbar uninstall has
+  // nothing left to cascade to. Each uninstall rebuilds the container and
+  // replaces the shared reporter with an empty one, so the helper's own return
+  // values are what report the outcome.
+  $messages = [];
+
+  foreach (['admin_toolbar_tools', 'admin_toolbar', 'gin_toolbar', 'toolbar'] as $module) {
+    $messages[] = Helper::module()->uninstall($module);
+  }
+
+  return implode(' ', $messages);
 }

--- a/web/modules/custom/do_base/do_base.install
+++ b/web/modules/custom/do_base/do_base.install
@@ -47,7 +47,10 @@ function do_base_update_11002(): string {
   // both at once. Dependents are removed first so the toolbar uninstall has
   // nothing left to cascade to. Each uninstall rebuilds the container and
   // replaces the shared reporter with an empty one, so the helper's own return
-  // values are what report the outcome.
+  // values are what report the outcome. An uninstall needs the module's own
+  // code to drop its tables and remove its config, so the drupal/admin_toolbar
+  // and drupal/gin_toolbar packages stay in composer.json until this has run
+  // in every environment.
   $messages = [];
 
   foreach (['admin_toolbar_tools', 'admin_toolbar', 'gin_toolbar', 'toolbar'] as $module) {

--- a/web/sites/default/example.settings.local.php
+++ b/web/sites/default/example.settings.local.php
@@ -112,6 +112,6 @@ $settings['rebuild_access'] = TRUE;
 $settings['skip_permissions_hardening'] = TRUE;
 
 /**
- * Hide admin toolbar. Useful for theming while logged in as admin.
+ * Hide administration navigation. Useful for theming while logged in as admin.
  */
-// $settings['hide_admin_toolbar'] = TRUE;
+// $settings['hide_admin_navigation'] = TRUE;

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -20,6 +20,7 @@ require_once __DIR__ . '/includes/node.inc';
 require_once __DIR__ . '/includes/cards.inc';
 require_once __DIR__ . '/includes/sidebar_navigation.inc';
 require_once __DIR__ . '/includes/content_moderation.inc';
+require_once __DIR__ . '/includes/admin_navigation.inc';
 
 /**
  * Adds a CSS class to a block wrapper.

--- a/web/themes/custom/drevops/includes/admin_navigation.inc
+++ b/web/themes/custom/drevops/includes/admin_navigation.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Administration navigation provided by the core Navigation module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Site\Settings;
+
+/**
+ * Implements template_preprocess_html().
+ */
+function drevops_preprocess_html(array &$variables): void {
+  // Hide the administration navigation. Useful for theming while logged in as
+  // an administrator.
+  if (Settings::get('hide_admin_navigation')) {
+    unset($variables['page_top']['navigation']);
+    unset($variables['page_top']['top_bar']);
+  }
+}


### PR DESCRIPTION
Closes #255

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Replaced the classic Admin Toolbar stack with the core Navigation module: `do_base_update_11002()` in `web/modules/custom/do_base/do_base.install` uninstalls `admin_toolbar_tools`, `admin_toolbar`, `gin_toolbar` and `toolbar` during `drush updatedb`, which runs ahead of config import, so the site never has both admin navigation systems installed at the same time. Core disables Toolbar's functionality when both are present, `gin_toolbar` suppresses the status warning that would surface the conflict, and the leftover `contextual.toolbar.js` from `toolbar` breaks admin contextual links.
2. Added `drupal/navigation_extra_tools` (^1.3.2) to `composer.json` and enabled core `navigation` plus `navigation_extra_tools` in `config/default/core.extension.yml`, alongside the new `navigation.settings` and `navigation.block_layout` config and the `system.menu.content` / `system.menu.navigation-user-links` menus that Navigation depends on. Removed the now-unused `admin_toolbar.settings` and `admin_toolbar_tools.settings`.
3. Retained `drupal/admin_toolbar` and `drupal/gin_toolbar` in `composer.json` on purpose - Drupal needs a module's own code present to run its uninstall path. Follow-up #267 tracks dropping both packages once the uninstall has deployed everywhere.
4. Swapped the `access toolbar` permission and `toolbar` module dependency for `access navigation` / `navigation` on the three CivicTheme roles: `civictheme_content_approver`, `civictheme_content_author`, `civictheme_site_administrator`.
5. Renamed the `hide_admin_toolbar` settings flag to `hide_admin_navigation` in `web/sites/default/example.settings.local.php`, and implemented it in new `web/themes/custom/drevops/includes/admin_navigation.inc` via `drevops_preprocess_html()`, which unsets `page_top.navigation` and `page_top.top_bar` when the flag is set. The old setting was documented but had no code behind it.
6. Updated Behat coverage: `environment_indicator_access.feature` now targets `#environment-indicator` / `background-color` instead of the classic toolbar's `.toolbar-menu-administration`, and new `admin_navigation.feature` asserts `#admin-toolbar` is present and `#toolbar-administration` is absent.
7. Moved the Behat `primary_tabs` region to `page_actions`, pointing at `.top-bar__actions` instead of `#block-drevops-primary-local-tasks`. This follows a behaviour change in core: `NavigationHooks::blockBuildLocalTasksBlockAlter()` sets `#access` to `FALSE` on every `local_tasks_block` for any user holding `access navigation`, and renders those links as Navigation top bar page actions instead, so an editor's View / Edit / Delete / Revisions / Clone links move out of the front-end theme's "Primary tabs" block and into the top bar - `Edit` as a primary button, the rest under "More actions". `block.block.drevops_primary_local_tasks` is left in place because it still renders for an authenticated user without `access navigation`.

## Screenshots

![Admin content page showing the core Navigation sidebar rendered with Gin](https://raw.githubusercontent.com/drevops/website/67e2de194e4d3166971087abc6636f1d332b26e3/feature-255-core-navigation/405fd44c19e73b4654c0eacc2c0de46aeaf26b48.png)

## Before / After

```
BEFORE                                    AFTER
┌─────────────────────────────┐           ┌─────────────────────────────┐
│ Admin navigation stack      │           │ Admin navigation stack      │
│                             │           │                             │
│  toolbar                    │           │  navigation (core)          │
│  admin_toolbar              │  ──────▶  │  navigation_extra_tools     │
│  admin_toolbar_tools        │           │                             │
│  gin_toolbar                │           │  (admin_toolbar/gin_toolbar │
│                             │           │   code kept in              │
│                             │           │   composer.json only, to    │
│                             │           │   run their uninstall path) │
└─────────────────────────────┘           └─────────────────────────────┘

CivicTheme roles
  'access toolbar' + depends on 'toolbar'      ──▶  'access navigation' + depends on 'navigation'

Local tasks for an editor viewing a node on the front-end theme
  #block-drevops-primary-local-tasks           ──▶  .top-bar__actions
  View / Edit / Delete / Revisions / Clone          'Edit' as a primary button,
  rendered as tabs in the 'highlighted' region      the rest under 'More actions'

Deploy order (do_base_update_11002 then config import)
  drush updatedb                             drush cim
  ├─ uninstall admin_toolbar_tools            ├─ installs 'navigation' + 'navigation_extra_tools'
  ├─ uninstall admin_toolbar                  │  (config/default/core.extension.yml)
  ├─ uninstall gin_toolbar          ───────▶  └─ imports navigation.settings,
  └─ uninstall toolbar                           navigation.block_layout, and the two
                                                  Navigation-owned menus
  (both stacks are never installed together)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the classic administration toolbar with a modern administration navigation experience.
  * Added structured navigation menus, shortcuts, user links, and a Help link, with a default navigation layout.
  * Added an option to hide administration navigation for local development.
  * Updated administrative roles to use the new navigation permissions.

* **Bug Fixes**
  * Updated environment indicator UI checks to match the new administration interface.

* **Tests**
  * Added/updated Behat coverage to verify the new navigation is visible and the legacy toolbar is not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
