### PR TITLE
[#271] Lowered sticky header below Drupal administration z-index band.

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -151,4 +151,53 @@ class FeatureContext extends DrupalContext {
     }
   }
 
+  /**
+   * Assert that an element paints on top of another element.
+   *
+   * Compares the computed z-index of two elements that both establish a
+   * root-level stacking context. A descendant cannot escape its ancestor's
+   * stacking context, so this also settles the order of any popup opened
+   * inside either element.
+   *
+   * @code
+   * Then the element ".top-bar" should stack above the element ".ct-header"
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should stack above the element :other_selector')]
+  public function elementAssertStacksAbove(string $selector, string $other_selector): void {
+    $above = $this->elementZIndex($selector);
+    $below = $this->elementZIndex($other_selector);
+
+    if ($above <= $below) {
+      throw new \RuntimeException(sprintf('Expected element "%s" to stack above element "%s", but their z-index values are %d and %d.', $selector, $other_selector, $above, $below));
+    }
+  }
+
+  /**
+   * Get the computed z-index of an element.
+   *
+   * @param string $selector
+   *   The CSS selector.
+   *
+   * @return int
+   *   The computed z-index.
+   */
+  protected function elementZIndex(string $selector): int {
+    $script = <<<JS
+      return window.getComputedStyle({{ELEMENT}}).zIndex;
+JS;
+    $z_index = (string) $this->elementExecuteJs($selector, $script);
+
+    // An element without a stacking order of its own cannot be compared, and
+    // silently treating it as zero would assert something that was never
+    // styled.
+    if (!is_numeric($z_index)) {
+      throw new \RuntimeException(sprintf('Expected element "%s" to have a numeric z-index, but it is "%s".', $selector, $z_index));
+    }
+
+    return (int) $z_index;
+  }
+
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -35,6 +35,7 @@ use DrevOps\BehatSteps\KeyboardTrait;
 use DrevOps\BehatSteps\LinkTrait;
 use DrevOps\BehatSteps\PathTrait;
 use DrevOps\BehatSteps\ResponseTrait;
+use DrevOps\BehatSteps\ResponsiveTrait;
 use DrevOps\BehatSteps\WaitTrait;
 use Behat\Step\Given;
 use Behat\Step\Then;
@@ -70,6 +71,7 @@ class FeatureContext extends DrupalContext {
   use ParagraphsTrait;
   use PathTrait;
   use ResponseTrait;
+  use ResponsiveTrait;
   use SearchApiTrait;
   use TaxonomyTrait;
   use TestmodeTrait;

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -169,8 +169,8 @@ class FeatureContext extends DrupalContext {
    */
   #[Then('the element :selector should stack above the element :other_selector')]
   public function elementAssertStacksAbove(string $selector, string $other_selector): void {
-    $above = $this->elementZIndex($selector);
-    $below = $this->elementZIndex($other_selector);
+    $above = $this->elementZindex($selector);
+    $below = $this->elementZindex($other_selector);
 
     if ($above <= $below) {
       throw new \RuntimeException(sprintf('Expected element "%s" to stack above element "%s", but their z-index values are %d and %d.', $selector, $other_selector, $above, $below));
@@ -186,7 +186,7 @@ class FeatureContext extends DrupalContext {
    * @return int
    *   The computed z-index.
    */
-  protected function elementZIndex(string $selector): int {
+  protected function elementZindex(string $selector): int {
     $script = <<<JS
       return window.getComputedStyle({{ELEMENT}}).zIndex;
 JS;

--- a/tests/behat/features/admin_navigation.feature
+++ b/tests/behat/features/admin_navigation.feature
@@ -16,3 +16,12 @@ Feature: Administration navigation for site administrator
     Given I am logged in as a user with the "civictheme_site_administrator" role
     When I visit "/"
     Then the element ".top-bar" should stack above the element ".ct-header--sticky"
+
+  @api @javascript
+  Scenario: Site administrator sees the open mobile navigation above the administration top bar
+    Given I am logged in as a user with the "civictheme_site_administrator" role
+    When I visit "/"
+    And I set the viewport to 390 by 844
+    And I trigger the JS event "click" on the element ".ct-mobile-navigation-trigger"
+    And I wait for 1 second
+    Then the element ".ct-header--sticky" should stack above the element ".top-bar"

--- a/tests/behat/features/admin_navigation.feature
+++ b/tests/behat/features/admin_navigation.feature
@@ -10,3 +10,9 @@ Feature: Administration navigation for site administrator
     When I visit "/"
     Then I should see an "#admin-toolbar" element
     And I should not see a "#toolbar-administration" element
+
+  @api @javascript
+  Scenario: Site administrator sees the administration top bar above the sticky site header
+    Given I am logged in as a user with the "civictheme_site_administrator" role
+    When I visit "/"
+    Then the element ".top-bar" should stack above the element ".ct-header--sticky"

--- a/web/themes/custom/drevops/components/03-organisms/header/header.scss
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.scss
@@ -12,6 +12,14 @@
     position: fixed;
     width: 100%;
     z-index: $ct-header-sticky-zindex;
+
+    // The mobile navigation flyout sits inside the header, so the header's
+    // stacking context caps how high the flyout panel can rise. Lift the
+    // header to the flyout tier while the flyout is open, so the panel keeps
+    // covering everything else the way a full-screen overlay should.
+    &:has([data-flyout-expanded]) {
+      z-index: $ct-flyout-zindex;
+    }
   }
 
   &__top {

--- a/web/themes/custom/drevops/components/variables.components.scss
+++ b/web/themes/custom/drevops/components/variables.components.scss
@@ -119,7 +119,11 @@ $ct-divider-dark-border-color: transparent;
 // Header.
 //
 
-$ct-header-sticky-zindex: 500;
+// Drupal reserves z-index 490 and above for administration chrome: the
+// navigation top bar, contextual links, the toolbar and off-canvas dialogs.
+// Keeping the sticky header below that band lets those layers, and the popups
+// they open, paint over the header instead of being covered by it.
+$ct-header-sticky-zindex: 400;
 
 //
 // Steps.


### PR DESCRIPTION
Closes #271

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#271` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Lowered `$ct-header-sticky-zindex` from `500` to `400` in `web/themes/custom/drevops/components/variables.components.scss`, moving the sticky site header below the entire z-index band Drupal reserves for administration chrome (navigation top bar `490` through tooltip `801`), so admin overlays and the popups they open are never trapped underneath it.
2. Added a `&:has([data-flyout-expanded])` rule to `.ct-header--sticky` in `web/themes/custom/drevops/components/03-organisms/header/header.scss` that lifts the header to `$ct-flyout-zindex` while the mobile navigation flyout is open, because the flyout panel is a descendant of the header and is capped by the header's own stacking context.
3. Added a generic Behat step `Then the element :selector should stack above the element :other_selector` and a protected `elementZindex()` helper to `tests/behat/bootstrap/FeatureContext.php`, comparing computed z-index via the existing `elementExecuteJs` helper and rejecting a non-numeric value instead of silently treating it as zero. Wired in `ResponsiveTrait` for viewport resizing.
4. Added two `@api @javascript` scenarios to `tests/behat/features/admin_navigation.feature`: the administration top bar stacks above the sticky header, and, with the mobile navigation open at 390x844, the header stacks above the top bar.

## Screenshots

![Administration "More actions" dropdown fully visible above the sticky header, all items legible](https://raw.githubusercontent.com/drevops/website/481526430cc84abebf6fa59976cdfac2b1203445/feature-271-header-covers-nav/dce45a2a2a9586f658b6df0d0d3f0b30083fd522.png)

## Before / After

```
BEFORE - sticky header sits inside Drupal's admin z-index band
┌──────────────────────────────────────────────────────────────────
│  801  tooltip
│  701  footer
│  601  popover
│  501  contextual links / off-canvas dialog
│  500  .ct-header--sticky                     <- header (the bug)
│  500  navigation overlay / contextual link trigger
│  499  admin toolbar control bar
│  490  .top-bar (admin top bar) -> "More actions" menu, trapped
└──────────────────────────────────────────────────────────────────

AFTER - sticky header dropped below the whole admin band
┌──────────────────────────────────────────────────────────────────
│  801  tooltip
│  701  footer
│  601  popover
│  501  contextual links / off-canvas dialog
│  500  navigation overlay / contextual link trigger
│  499  admin toolbar control bar
│  490  .top-bar (admin top bar) -> "More actions" menu, visible
│  400  .ct-header--sticky                     <- header (fixed)
└──────────────────────────────────────────────────────────────────
  1000  .ct-header--sticky while [data-flyout-expanded] (mobile nav open)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive header layering to ensure administration controls and sticky navigation appear in the correct order.
  * Updated mobile navigation behavior so expanded flyouts display above overlapping content.
  * Prevented the sticky header from obscuring administration interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->