### PR TITLE
[#273] Added a Project content type for showcasing delivered work.

### DIFF
--- a/config/default/core.entity_form_display.node.project.default.yml
+++ b/config/default/core.entity_form_display.node.project.default.yml
@@ -1,0 +1,428 @@
+uuid: 1fa2b6f0-ef4f-463c-bf9e-e99aac792605
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.project.field_c_n_banner_background
+    - field.field.node.project.field_c_n_banner_blend_mode
+    - field.field.node.project.field_c_n_banner_components
+    - field.field.node.project.field_c_n_banner_components_bott
+    - field.field.node.project.field_c_n_banner_featured_image
+    - field.field.node.project.field_c_n_banner_hide_breadcrumb
+    - field.field.node.project.field_c_n_banner_theme
+    - field.field.node.project.field_c_n_banner_title
+    - field.field.node.project.field_c_n_banner_type
+    - field.field.node.project.field_c_n_components
+    - field.field.node.project.field_c_n_custom_last_updated
+    - field.field.node.project.field_c_n_hide_sidebar
+    - field.field.node.project.field_c_n_hide_tags
+    - field.field.node.project.field_c_n_show_last_updated
+    - field.field.node.project.field_c_n_show_toc
+    - field.field.node.project.field_c_n_site_section
+    - field.field.node.project.field_c_n_summary
+    - field.field.node.project.field_c_n_thumbnail
+    - field.field.node.project.field_c_n_topics
+    - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_n_metatags
+    - node.type.project
+    - workflows.workflow.civictheme_editorial
+  module:
+    - content_moderation
+    - datetime
+    - field_group
+    - media_library
+    - metatag
+    - paragraphs
+    - path
+third_party_settings:
+  field_group:
+    group_civictheme_tabs:
+      children:
+        - group_civictheme_content
+        - group_civictheme_banner
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: tabs
+      format_settings:
+        classes: ''
+        id: ''
+        direction: horizontal
+    group_civictheme_banner:
+      children:
+        - field_c_n_banner_type
+        - field_c_n_banner_theme
+        - field_c_n_banner_title
+        - field_c_n_banner_hide_breadcrumb
+        - group_banner_background
+        - group_banner_featured_image
+        - field_c_n_banner_components
+        - field_c_n_banner_components_bott
+      label: Banner
+      region: content
+      parent_name: group_civictheme_tabs
+      weight: 14
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_civictheme_content:
+      children:
+        - title
+        - field_c_n_summary
+        - field_c_n_components
+        - group_metadata
+        - group_appearance
+      label: Content
+      region: content
+      parent_name: group_civictheme_tabs
+      weight: 10
+      format_type: tab
+      format_settings:
+        classes: ''
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_last_updated_date:
+      children:
+        - field_c_n_show_last_updated
+        - field_c_n_custom_last_updated
+      label: 'Last updated date'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+        weight: 0
+    group_banner_background:
+      children:
+        - field_c_n_banner_background
+        - field_c_n_banner_blend_mode
+      label: Background
+      region: content
+      parent_name: group_civictheme_banner
+      weight: 21
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: true
+        description: ''
+        required_fields: true
+    group_banner_featured_image:
+      children:
+        - field_c_n_banner_featured_image
+      label: 'Featured image'
+      region: content
+      parent_name: group_civictheme_banner
+      weight: 22
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: true
+        description: ''
+        required_fields: true
+    group_appearance:
+      children:
+        - field_c_n_thumbnail
+        - field_c_n_vertical_spacing
+        - field_c_n_show_toc
+        - field_c_n_hide_sidebar
+        - field_c_n_hide_tags
+      label: Appearance
+      region: content
+      parent_name: group_civictheme_content
+      weight: 15
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_metadata:
+      children:
+        - field_c_n_topics
+      label: Categorisation
+      region: content
+      parent_name: group_civictheme_content
+      weight: 14
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: true
+        description: ''
+        required_fields: true
+id: node.project.default
+targetEntityType: node
+bundle: project
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_n_banner_background:
+    type: media_library_widget
+    weight: 14
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_c_n_banner_blend_mode:
+    type: options_select
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_n_banner_components:
+    type: paragraphs
+    weight: 23
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: all
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_c_n_banner_components_bott:
+    type: paragraphs
+    weight: 25
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: all
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_c_n_banner_featured_image:
+    type: media_library_widget
+    weight: 14
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_c_n_banner_hide_breadcrumb:
+    type: boolean_checkbox
+    weight: 20
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_c_n_banner_theme:
+    type: options_buttons
+    weight: 18
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_n_banner_title:
+    type: string_textfield
+    weight: 19
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_n_banner_type:
+    type: options_buttons
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_n_components:
+    type: paragraphs
+    weight: 13
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: all
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  field_c_n_custom_last_updated:
+    type: datetime_default
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_c_n_hide_sidebar:
+    type: boolean_checkbox
+    weight: 19
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_c_n_hide_tags:
+    type: boolean_checkbox
+    weight: 20
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_c_n_show_last_updated:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_c_n_show_toc:
+    type: boolean_checkbox
+    weight: 18
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_c_n_summary:
+    type: string_textarea
+    weight: 12
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_n_thumbnail:
+    type: media_library_widget
+    weight: 16
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_c_n_topics:
+    type: entity_reference_autocomplete_tags
+    weight: 15
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_c_n_vertical_spacing:
+    type: options_buttons
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_n_metatags:
+    type: metatag_firehose
+    weight: 12
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 9
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 11
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 3
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_c_n_site_section: true

--- a/config/default/core.entity_form_display.node.project.default.yml
+++ b/config/default/core.entity_form_display.node.project.default.yml
@@ -23,6 +23,16 @@ dependencies:
     - field.field.node.project.field_c_n_thumbnail
     - field.field.node.project.field_c_n_topics
     - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_do_n_client
+    - field.field.node.project.field_do_n_delivered_at
+    - field.field.node.project.field_do_n_live_url
+    - field.field.node.project.field_do_n_oss_contributions
+    - field.field.node.project.field_do_n_role
+    - field.field.node.project.field_do_n_sector
+    - field.field.node.project.field_do_n_services
+    - field.field.node.project.field_do_n_status
+    - field.field.node.project.field_do_n_technologies
+    - field.field.node.project.field_do_n_year
     - field.field.node.project.field_n_metatags
     - node.type.project
     - workflows.workflow.civictheme_editorial
@@ -30,6 +40,7 @@ dependencies:
     - content_moderation
     - datetime
     - field_group
+    - link
     - media_library
     - metatag
     - paragraphs
@@ -74,8 +85,9 @@ third_party_settings:
       children:
         - title
         - field_c_n_summary
-        - field_c_n_components
+        - group_project_details
         - group_metadata
+        - field_c_n_components
         - group_appearance
       label: Content
       region: content
@@ -148,7 +160,7 @@ third_party_settings:
       label: Appearance
       region: content
       parent_name: group_civictheme_content
-      weight: 15
+      weight: 16
       format_type: details
       format_settings:
         classes: ''
@@ -160,10 +172,35 @@ third_party_settings:
     group_metadata:
       children:
         - field_c_n_topics
+        - field_do_n_sector
+        - field_do_n_services
+        - field_do_n_technologies
       label: Categorisation
       region: content
       parent_name: group_civictheme_content
       weight: 14
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: true
+        description: ''
+        required_fields: true
+    group_project_details:
+      children:
+        - field_do_n_client
+        - field_do_n_role
+        - field_do_n_delivered_at
+        - field_do_n_year
+        - field_do_n_status
+        - field_do_n_live_url
+        - field_do_n_oss_contributions
+      label: 'Project details'
+      region: content
+      parent_name: group_civictheme_content
+      weight: 13
       format_type: details
       format_settings:
         classes: ''
@@ -271,7 +308,7 @@ content:
     third_party_settings: {  }
   field_c_n_components:
     type: paragraphs
-    weight: 13
+    weight: 15
     region: content
     settings:
       title: Paragraph
@@ -352,6 +389,81 @@ content:
     weight: 17
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_do_n_client:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_do_n_delivered_at:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_do_n_live_url:
+    type: link_default
+    weight: 6
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_do_n_oss_contributions:
+    type: link_default
+    weight: 7
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_do_n_role:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_do_n_sector:
+    type: options_select
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_do_n_services:
+    type: options_buttons
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_do_n_status:
+    type: options_select
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_do_n_technologies:
+    type: entity_reference_autocomplete_tags
+    weight: 18
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_do_n_year:
+    type: number
+    weight: 4
+    region: content
+    settings:
+      placeholder: ''
     third_party_settings: {  }
   field_n_metatags:
     type: metatag_firehose

--- a/config/default/core.entity_view_display.node.project.civictheme_navigation_card.yml
+++ b/config/default/core.entity_view_display.node.project.civictheme_navigation_card.yml
@@ -1,0 +1,83 @@
+uuid: c0b31e35-3538-458f-be11-5882c0790043
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.civictheme_navigation_card
+    - field.field.node.project.field_c_n_banner_background
+    - field.field.node.project.field_c_n_banner_blend_mode
+    - field.field.node.project.field_c_n_banner_components
+    - field.field.node.project.field_c_n_banner_components_bott
+    - field.field.node.project.field_c_n_banner_featured_image
+    - field.field.node.project.field_c_n_banner_hide_breadcrumb
+    - field.field.node.project.field_c_n_banner_theme
+    - field.field.node.project.field_c_n_banner_title
+    - field.field.node.project.field_c_n_banner_type
+    - field.field.node.project.field_c_n_components
+    - field.field.node.project.field_c_n_custom_last_updated
+    - field.field.node.project.field_c_n_hide_sidebar
+    - field.field.node.project.field_c_n_hide_tags
+    - field.field.node.project.field_c_n_show_last_updated
+    - field.field.node.project.field_c_n_show_toc
+    - field.field.node.project.field_c_n_site_section
+    - field.field.node.project.field_c_n_summary
+    - field.field.node.project.field_c_n_thumbnail
+    - field.field.node.project.field_c_n_topics
+    - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_n_metatags
+    - node.type.project
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.project.civictheme_navigation_card
+targetEntityType: node
+bundle: project
+mode: civictheme_navigation_card
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_c_n_summary:
+    type: basic_string
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_c_n_thumbnail:
+    type: entity_reference_label
+    label: visually_hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_c_n_banner_background: true
+  field_c_n_banner_blend_mode: true
+  field_c_n_banner_components: true
+  field_c_n_banner_components_bott: true
+  field_c_n_banner_featured_image: true
+  field_c_n_banner_hide_breadcrumb: true
+  field_c_n_banner_theme: true
+  field_c_n_banner_title: true
+  field_c_n_banner_type: true
+  field_c_n_components: true
+  field_c_n_custom_last_updated: true
+  field_c_n_hide_sidebar: true
+  field_c_n_hide_tags: true
+  field_c_n_show_last_updated: true
+  field_c_n_show_toc: true
+  field_c_n_site_section: true
+  field_c_n_topics: true
+  field_c_n_vertical_spacing: true
+  field_n_metatags: true
+  langcode: true
+  links: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.project.civictheme_navigation_card.yml
+++ b/config/default/core.entity_view_display.node.project.civictheme_navigation_card.yml
@@ -24,6 +24,16 @@ dependencies:
     - field.field.node.project.field_c_n_thumbnail
     - field.field.node.project.field_c_n_topics
     - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_do_n_client
+    - field.field.node.project.field_do_n_delivered_at
+    - field.field.node.project.field_do_n_live_url
+    - field.field.node.project.field_do_n_oss_contributions
+    - field.field.node.project.field_do_n_role
+    - field.field.node.project.field_do_n_sector
+    - field.field.node.project.field_do_n_services
+    - field.field.node.project.field_do_n_status
+    - field.field.node.project.field_do_n_technologies
+    - field.field.node.project.field_do_n_year
     - field.field.node.project.field_n_metatags
     - node.type.project
   module:
@@ -77,6 +87,16 @@ hidden:
   field_c_n_site_section: true
   field_c_n_topics: true
   field_c_n_vertical_spacing: true
+  field_do_n_client: true
+  field_do_n_delivered_at: true
+  field_do_n_live_url: true
+  field_do_n_oss_contributions: true
+  field_do_n_role: true
+  field_do_n_sector: true
+  field_do_n_services: true
+  field_do_n_status: true
+  field_do_n_technologies: true
+  field_do_n_year: true
   field_n_metatags: true
   langcode: true
   links: true

--- a/config/default/core.entity_view_display.node.project.civictheme_promo_card.yml
+++ b/config/default/core.entity_view_display.node.project.civictheme_promo_card.yml
@@ -24,6 +24,16 @@ dependencies:
     - field.field.node.project.field_c_n_thumbnail
     - field.field.node.project.field_c_n_topics
     - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_do_n_client
+    - field.field.node.project.field_do_n_delivered_at
+    - field.field.node.project.field_do_n_live_url
+    - field.field.node.project.field_do_n_oss_contributions
+    - field.field.node.project.field_do_n_role
+    - field.field.node.project.field_do_n_sector
+    - field.field.node.project.field_do_n_services
+    - field.field.node.project.field_do_n_status
+    - field.field.node.project.field_do_n_technologies
+    - field.field.node.project.field_do_n_year
     - field.field.node.project.field_n_metatags
     - node.type.project
   module:
@@ -82,6 +92,16 @@ hidden:
   field_c_n_site_section: true
   field_c_n_topics: true
   field_c_n_vertical_spacing: true
+  field_do_n_client: true
+  field_do_n_delivered_at: true
+  field_do_n_live_url: true
+  field_do_n_oss_contributions: true
+  field_do_n_role: true
+  field_do_n_sector: true
+  field_do_n_services: true
+  field_do_n_status: true
+  field_do_n_technologies: true
+  field_do_n_year: true
   field_n_metatags: true
   langcode: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.project.civictheme_promo_card.yml
+++ b/config/default/core.entity_view_display.node.project.civictheme_promo_card.yml
@@ -1,0 +1,87 @@
+uuid: 505b238b-ecb4-49e7-bd48-aae2b22be54f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.civictheme_promo_card
+    - field.field.node.project.field_c_n_banner_background
+    - field.field.node.project.field_c_n_banner_blend_mode
+    - field.field.node.project.field_c_n_banner_components
+    - field.field.node.project.field_c_n_banner_components_bott
+    - field.field.node.project.field_c_n_banner_featured_image
+    - field.field.node.project.field_c_n_banner_hide_breadcrumb
+    - field.field.node.project.field_c_n_banner_theme
+    - field.field.node.project.field_c_n_banner_title
+    - field.field.node.project.field_c_n_banner_type
+    - field.field.node.project.field_c_n_components
+    - field.field.node.project.field_c_n_custom_last_updated
+    - field.field.node.project.field_c_n_hide_sidebar
+    - field.field.node.project.field_c_n_hide_tags
+    - field.field.node.project.field_c_n_show_last_updated
+    - field.field.node.project.field_c_n_show_toc
+    - field.field.node.project.field_c_n_site_section
+    - field.field.node.project.field_c_n_summary
+    - field.field.node.project.field_c_n_thumbnail
+    - field.field.node.project.field_c_n_topics
+    - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_n_metatags
+    - node.type.project
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.project.civictheme_promo_card
+targetEntityType: node
+bundle: project
+mode: civictheme_promo_card
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_c_n_summary:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_c_n_thumbnail:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  field_c_n_banner_background: true
+  field_c_n_banner_blend_mode: true
+  field_c_n_banner_components: true
+  field_c_n_banner_components_bott: true
+  field_c_n_banner_featured_image: true
+  field_c_n_banner_hide_breadcrumb: true
+  field_c_n_banner_theme: true
+  field_c_n_banner_title: true
+  field_c_n_banner_type: true
+  field_c_n_components: true
+  field_c_n_custom_last_updated: true
+  field_c_n_hide_sidebar: true
+  field_c_n_hide_tags: true
+  field_c_n_show_last_updated: true
+  field_c_n_show_toc: true
+  field_c_n_site_section: true
+  field_c_n_topics: true
+  field_c_n_vertical_spacing: true
+  field_n_metatags: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.project.civictheme_slider_slide.yml
+++ b/config/default/core.entity_view_display.node.project.civictheme_slider_slide.yml
@@ -24,6 +24,16 @@ dependencies:
     - field.field.node.project.field_c_n_thumbnail
     - field.field.node.project.field_c_n_topics
     - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_do_n_client
+    - field.field.node.project.field_do_n_delivered_at
+    - field.field.node.project.field_do_n_live_url
+    - field.field.node.project.field_do_n_oss_contributions
+    - field.field.node.project.field_do_n_role
+    - field.field.node.project.field_do_n_sector
+    - field.field.node.project.field_do_n_services
+    - field.field.node.project.field_do_n_status
+    - field.field.node.project.field_do_n_technologies
+    - field.field.node.project.field_do_n_year
     - field.field.node.project.field_n_metatags
     - node.type.project
   module:
@@ -78,6 +88,16 @@ hidden:
   field_c_n_site_section: true
   field_c_n_topics: true
   field_c_n_vertical_spacing: true
+  field_do_n_client: true
+  field_do_n_delivered_at: true
+  field_do_n_live_url: true
+  field_do_n_oss_contributions: true
+  field_do_n_role: true
+  field_do_n_sector: true
+  field_do_n_services: true
+  field_do_n_status: true
+  field_do_n_technologies: true
+  field_do_n_year: true
   field_n_metatags: true
   langcode: true
   links: true

--- a/config/default/core.entity_view_display.node.project.civictheme_slider_slide.yml
+++ b/config/default/core.entity_view_display.node.project.civictheme_slider_slide.yml
@@ -1,0 +1,84 @@
+uuid: 6106088f-f8ad-48b7-b6bd-5562d0db1dc4
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.civictheme_slider_slide
+    - field.field.node.project.field_c_n_banner_background
+    - field.field.node.project.field_c_n_banner_blend_mode
+    - field.field.node.project.field_c_n_banner_components
+    - field.field.node.project.field_c_n_banner_components_bott
+    - field.field.node.project.field_c_n_banner_featured_image
+    - field.field.node.project.field_c_n_banner_hide_breadcrumb
+    - field.field.node.project.field_c_n_banner_theme
+    - field.field.node.project.field_c_n_banner_title
+    - field.field.node.project.field_c_n_banner_type
+    - field.field.node.project.field_c_n_components
+    - field.field.node.project.field_c_n_custom_last_updated
+    - field.field.node.project.field_c_n_hide_sidebar
+    - field.field.node.project.field_c_n_hide_tags
+    - field.field.node.project.field_c_n_show_last_updated
+    - field.field.node.project.field_c_n_show_toc
+    - field.field.node.project.field_c_n_site_section
+    - field.field.node.project.field_c_n_summary
+    - field.field.node.project.field_c_n_thumbnail
+    - field.field.node.project.field_c_n_topics
+    - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_n_metatags
+    - node.type.project
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.project.civictheme_slider_slide
+targetEntityType: node
+bundle: project
+mode: civictheme_slider_slide
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_c_n_summary:
+    type: basic_string
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_c_n_thumbnail:
+    type: entity_reference_entity_view
+    label: visually_hidden
+    settings:
+      view_mode: default
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  field_c_n_banner_background: true
+  field_c_n_banner_blend_mode: true
+  field_c_n_banner_components: true
+  field_c_n_banner_components_bott: true
+  field_c_n_banner_featured_image: true
+  field_c_n_banner_hide_breadcrumb: true
+  field_c_n_banner_theme: true
+  field_c_n_banner_title: true
+  field_c_n_banner_type: true
+  field_c_n_components: true
+  field_c_n_custom_last_updated: true
+  field_c_n_hide_sidebar: true
+  field_c_n_hide_tags: true
+  field_c_n_show_last_updated: true
+  field_c_n_show_toc: true
+  field_c_n_site_section: true
+  field_c_n_topics: true
+  field_c_n_vertical_spacing: true
+  field_n_metatags: true
+  langcode: true
+  links: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.project.default.yml
+++ b/config/default/core.entity_view_display.node.project.default.yml
@@ -1,0 +1,211 @@
+uuid: a6ebee46-1c2c-4ee2-a036-d8955bc9a1b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.project.field_c_n_banner_background
+    - field.field.node.project.field_c_n_banner_blend_mode
+    - field.field.node.project.field_c_n_banner_components
+    - field.field.node.project.field_c_n_banner_components_bott
+    - field.field.node.project.field_c_n_banner_featured_image
+    - field.field.node.project.field_c_n_banner_hide_breadcrumb
+    - field.field.node.project.field_c_n_banner_theme
+    - field.field.node.project.field_c_n_banner_title
+    - field.field.node.project.field_c_n_banner_type
+    - field.field.node.project.field_c_n_components
+    - field.field.node.project.field_c_n_custom_last_updated
+    - field.field.node.project.field_c_n_hide_sidebar
+    - field.field.node.project.field_c_n_hide_tags
+    - field.field.node.project.field_c_n_show_last_updated
+    - field.field.node.project.field_c_n_show_toc
+    - field.field.node.project.field_c_n_site_section
+    - field.field.node.project.field_c_n_summary
+    - field.field.node.project.field_c_n_thumbnail
+    - field.field.node.project.field_c_n_topics
+    - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_n_metatags
+    - node.type.project
+  module:
+    - datetime
+    - entity_reference_revisions
+    - layout_builder
+    - layout_builder_restrictions
+    - metatag
+    - options
+    - user
+  theme:
+    - civictheme
+third_party_settings:
+  layout_builder:
+    enabled: true
+    allow_custom: false
+    sections:
+      -
+        layout_id: civictheme_three_columns
+        layout_settings:
+          label: 'CivicTheme Three Columns'
+          context_mapping: {  }
+          is_contained: false
+        components:
+          5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0:
+            uuid: 5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0
+            region: main
+            configuration:
+              id: 'extra_field_block:node:project:content_moderation_control'
+              label: 'Moderation control'
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                settings: {  }
+                third_party_settings: {  }
+            weight: 1
+            additional: {  }
+          e1164245-8b1a-4a3f-8b30-30b00be44144:
+            uuid: e1164245-8b1a-4a3f-8b30-30b00be44144
+            region: main
+            configuration:
+              id: 'field_block:node:project:field_c_n_components'
+              label: Components
+              label_display: '0'
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: entity_reference_revisions_entity_view
+                label: hidden
+                settings:
+                  view_mode: default
+                third_party_settings: {  }
+            weight: 2
+            additional: {  }
+          50ce2930-effc-42f3-84b1-b4d3618bcb59:
+            uuid: 50ce2930-effc-42f3-84b1-b4d3618bcb59
+            region: content
+            configuration:
+              id: 'field_block:node:project:field_n_metatags'
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              formatter:
+                type: metatag_empty_formatter
+                label: above
+                settings: {  }
+                third_party_settings: {  }
+            weight: 0
+            additional: {  }
+        third_party_settings: {  }
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      allowed_layouts:
+        - civictheme_three_columns
+      denylisted_blocks: {  }
+      allowlisted_blocks: {  }
+      restricted_categories: {  }
+id: node.project.default
+targetEntityType: node
+bundle: project
+mode: default
+content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_c_n_banner_hide_breadcrumb:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_c_n_banner_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_c_n_components:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_c_n_custom_last_updated:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_c_n_hide_tags:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_c_n_show_last_updated:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_c_n_site_section:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_c_n_vertical_spacing:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_n_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
+    region: content
+hidden:
+  field_c_n_banner_background: true
+  field_c_n_banner_blend_mode: true
+  field_c_n_banner_components: true
+  field_c_n_banner_components_bott: true
+  field_c_n_banner_featured_image: true
+  field_c_n_banner_theme: true
+  field_c_n_banner_type: true
+  field_c_n_hide_sidebar: true
+  field_c_n_show_toc: true
+  field_c_n_summary: true
+  field_c_n_thumbnail: true
+  field_c_n_topics: true
+  langcode: true
+  links: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.project.default.yml
+++ b/config/default/core.entity_view_display.node.project.default.yml
@@ -23,6 +23,16 @@ dependencies:
     - field.field.node.project.field_c_n_thumbnail
     - field.field.node.project.field_c_n_topics
     - field.field.node.project.field_c_n_vertical_spacing
+    - field.field.node.project.field_do_n_client
+    - field.field.node.project.field_do_n_delivered_at
+    - field.field.node.project.field_do_n_live_url
+    - field.field.node.project.field_do_n_oss_contributions
+    - field.field.node.project.field_do_n_role
+    - field.field.node.project.field_do_n_sector
+    - field.field.node.project.field_do_n_services
+    - field.field.node.project.field_do_n_status
+    - field.field.node.project.field_do_n_technologies
+    - field.field.node.project.field_do_n_year
     - field.field.node.project.field_n_metatags
     - node.type.project
   module:
@@ -46,6 +56,7 @@ third_party_settings:
           label: 'CivicTheme Three Columns'
           context_mapping: {  }
           is_contained: false
+          vertical_spacing: auto
         components:
           5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0:
             uuid: 5cf72ad7-c313-4cf3-9d4e-0573bbfa84a0
@@ -206,6 +217,16 @@ hidden:
   field_c_n_summary: true
   field_c_n_thumbnail: true
   field_c_n_topics: true
+  field_do_n_client: true
+  field_do_n_delivered_at: true
+  field_do_n_live_url: true
+  field_do_n_oss_contributions: true
+  field_do_n_role: true
+  field_do_n_sector: true
+  field_do_n_services: true
+  field_do_n_status: true
+  field_do_n_technologies: true
+  field_do_n_year: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/field.field.node.project.field_c_n_banner_background.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_background.yml
@@ -1,0 +1,29 @@
+uuid: 84dd73d8-fadf-47d7-8123-505052e05bca
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_background
+    - media.type.civictheme_image
+    - node.type.project
+id: node.project.field_c_n_banner_background
+field_name: field_c_n_banner_background
+entity_type: node
+bundle: project
+label: 'Banner background'
+description: 'Image displayed as an edge-to-edge banner background.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      civictheme_image: civictheme_image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_c_n_banner_blend_mode.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_blend_mode.yml
@@ -1,0 +1,23 @@
+uuid: c73885bd-b650-4f5d-afe1-689497a967e6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_blend_mode
+    - node.type.project
+  module:
+    - options
+id: node.project.field_c_n_banner_blend_mode
+field_name: field_c_n_banner_blend_mode
+entity_type: node
+bundle: project
+label: 'Banner background blend  mode'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: normal
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.project.field_c_n_banner_components.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_components.yml
@@ -1,0 +1,114 @@
+uuid: c8f583f1-d5f1-422b-beff-b5eb081d095a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_components
+    - node.type.project
+    - paragraphs.paragraphs_type.civictheme_content
+    - paragraphs.paragraphs_type.civictheme_iframe
+    - paragraphs.paragraphs_type.civictheme_manual_list
+    - paragraphs.paragraphs_type.civictheme_map
+    - paragraphs.paragraphs_type.civictheme_slider
+  module:
+    - entity_reference_revisions
+id: node.project.field_c_n_banner_components
+field_name: field_c_n_banner_components
+entity_type: node
+bundle: project
+label: 'Banner components'
+description: 'Components that will appear within the banner content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      civictheme_content: civictheme_content
+      civictheme_manual_list: civictheme_manual_list
+      civictheme_iframe: civictheme_iframe
+      civictheme_map: civictheme_map
+      civictheme_slider: civictheme_slider
+    negate: 0
+    target_bundles_drag_drop:
+      civictheme_accordion:
+        weight: -54
+        enabled: false
+      civictheme_accordion_panel:
+        weight: -53
+        enabled: false
+      civictheme_attachment:
+        weight: -48
+        enabled: false
+      civictheme_automated_list:
+        weight: -39
+        enabled: false
+      civictheme_callout:
+        weight: -47
+        enabled: false
+      civictheme_content:
+        weight: -61
+        enabled: true
+      civictheme_event_card:
+        weight: -46
+        enabled: false
+      civictheme_event_card_ref:
+        weight: -45
+        enabled: false
+      civictheme_iframe:
+        weight: -59
+        enabled: true
+      civictheme_manual_list:
+        weight: -60
+        enabled: true
+      civictheme_map:
+        weight: -58
+        enabled: true
+      civictheme_navigation_card:
+        weight: -52
+        enabled: false
+      civictheme_navigation_card_ref:
+        weight: -44
+        enabled: false
+      civictheme_next_step:
+        weight: -38
+        enabled: false
+      civictheme_promo:
+        weight: -42
+        enabled: false
+      civictheme_promo_card:
+        weight: -51
+        enabled: false
+      civictheme_promo_card_ref:
+        weight: -43
+        enabled: false
+      civictheme_publication_card:
+        weight: -36
+        enabled: false
+      civictheme_service_card:
+        weight: -49
+        enabled: false
+      civictheme_slider:
+        weight: -57
+        enabled: true
+      civictheme_slider_slide:
+        weight: -55
+        enabled: false
+      civictheme_slider_slide_ref:
+        weight: -35
+        enabled: false
+      civictheme_social_icon:
+        weight: -34
+        enabled: false
+      civictheme_subject_card:
+        weight: -41
+        enabled: false
+      civictheme_subject_card_ref:
+        weight: -40
+        enabled: false
+      civictheme_webform:
+        weight: -33
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/default/field.field.node.project.field_c_n_banner_components_bott.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_components_bott.yml
@@ -1,0 +1,129 @@
+uuid: 34a6b114-b44d-4959-ad02-556918215221
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_components_bott
+    - node.type.project
+    - paragraphs.paragraphs_type.civictheme_accordion
+    - paragraphs.paragraphs_type.civictheme_automated_list
+    - paragraphs.paragraphs_type.civictheme_callout
+    - paragraphs.paragraphs_type.civictheme_campaign
+    - paragraphs.paragraphs_type.civictheme_content
+    - paragraphs.paragraphs_type.civictheme_iframe
+    - paragraphs.paragraphs_type.civictheme_manual_list
+    - paragraphs.paragraphs_type.civictheme_map
+    - paragraphs.paragraphs_type.civictheme_promo
+    - paragraphs.paragraphs_type.civictheme_slider
+    - paragraphs.paragraphs_type.civictheme_webform
+  module:
+    - entity_reference_revisions
+id: node.project.field_c_n_banner_components_bott
+field_name: field_c_n_banner_components_bott
+entity_type: node
+bundle: project
+label: 'Banner bottom components'
+description: 'Components that will appear below banner, but above the page content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      civictheme_content: civictheme_content
+      civictheme_accordion: civictheme_accordion
+      civictheme_automated_list: civictheme_automated_list
+      civictheme_callout: civictheme_callout
+      civictheme_campaign: civictheme_campaign
+      civictheme_iframe: civictheme_iframe
+      civictheme_manual_list: civictheme_manual_list
+      civictheme_map: civictheme_map
+      civictheme_promo: civictheme_promo
+      civictheme_slider: civictheme_slider
+      civictheme_webform: civictheme_webform
+    negate: 0
+    target_bundles_drag_drop:
+      civictheme_accordion:
+        weight: -58
+        enabled: true
+      civictheme_accordion_panel:
+        weight: -48
+        enabled: false
+      civictheme_attachment:
+        weight: -47
+        enabled: false
+      civictheme_automated_list:
+        weight: -57
+        enabled: true
+      civictheme_callout:
+        weight: -56
+        enabled: true
+      civictheme_campaign:
+        weight: -55
+        enabled: true
+      civictheme_content:
+        weight: -59
+        enabled: true
+      civictheme_event_card:
+        weight: -46
+        enabled: false
+      civictheme_event_card_ref:
+        weight: -45
+        enabled: false
+      civictheme_iframe:
+        weight: -54
+        enabled: true
+      civictheme_manual_list:
+        weight: -53
+        enabled: true
+      civictheme_map:
+        weight: -52
+        enabled: true
+      civictheme_navigation_card:
+        weight: -44
+        enabled: false
+      civictheme_navigation_card_ref:
+        weight: -43
+        enabled: false
+      civictheme_next_step:
+        weight: -38
+        enabled: false
+      civictheme_promo:
+        weight: -51
+        enabled: true
+      civictheme_promo_card:
+        weight: -42
+        enabled: false
+      civictheme_promo_card_ref:
+        weight: -41
+        enabled: false
+      civictheme_publication_card:
+        weight: -34
+        enabled: false
+      civictheme_service_card:
+        weight: -36
+        enabled: false
+      civictheme_slider:
+        weight: -50
+        enabled: true
+      civictheme_slider_slide:
+        weight: -35
+        enabled: false
+      civictheme_slider_slide_ref:
+        weight: -33
+        enabled: false
+      civictheme_social_icon:
+        weight: -32
+        enabled: false
+      civictheme_subject_card:
+        weight: -40
+        enabled: false
+      civictheme_subject_card_ref:
+        weight: -39
+        enabled: false
+      civictheme_webform:
+        weight: -49
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/default/field.field.node.project.field_c_n_banner_featured_image.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_featured_image.yml
@@ -1,0 +1,29 @@
+uuid: 7a34d54f-95ad-44f6-b5fc-d592b174138e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_featured_image
+    - media.type.civictheme_image
+    - node.type.project
+id: node.project.field_c_n_banner_featured_image
+field_name: field_c_n_banner_featured_image
+entity_type: node
+bundle: project
+label: 'Banner featured image'
+description: 'Image displayed on a side of the banner.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      civictheme_image: civictheme_image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_c_n_banner_hide_breadcrumb.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_hide_breadcrumb.yml
@@ -1,0 +1,23 @@
+uuid: 5eb86e75-e793-4aa3-8aaf-bf2a8308eb90
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_hide_breadcrumb
+    - node.type.project
+id: node.project.field_c_n_banner_hide_breadcrumb
+field_name: field_c_n_banner_hide_breadcrumb
+entity_type: node
+bundle: project
+label: 'Hide breadcrumb'
+description: 'Hide breadcrumb shown in banner.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/field.field.node.project.field_c_n_banner_theme.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_theme.yml
@@ -1,0 +1,23 @@
+uuid: 32db388c-2f47-496b-bdfc-1d9d4dbef5eb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_theme
+    - node.type.project
+  module:
+    - options
+id: node.project.field_c_n_banner_theme
+field_name: field_c_n_banner_theme
+entity_type: node
+bundle: project
+label: 'Banner theme'
+description: 'Use <code>Inherit</code> type to inherit this value from the site-wide banner block.'
+required: true
+translatable: false
+default_value:
+  -
+    value: inherit
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.project.field_c_n_banner_title.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_title.yml
@@ -1,0 +1,19 @@
+uuid: 956622e7-68df-4c62-880e-46583f6c9e06
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_title
+    - node.type.project
+id: node.project.field_c_n_banner_title
+field_name: field_c_n_banner_title
+entity_type: node
+bundle: project
+label: 'Banner title'
+description: 'Override banner title. Leave empty to use page title.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.node.project.field_c_n_banner_type.yml
+++ b/config/default/field.field.node.project.field_c_n_banner_type.yml
@@ -1,0 +1,23 @@
+uuid: 6f3ff3fa-191d-4efb-8ea3-830d636c13a7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_banner_type
+    - node.type.project
+  module:
+    - options
+id: node.project.field_c_n_banner_type
+field_name: field_c_n_banner_type
+entity_type: node
+bundle: project
+label: 'Banner type'
+description: 'Use <code>Inherit</code> type to inherit this value from the site-wide banner block.'
+required: true
+translatable: false
+default_value:
+  -
+    value: inherit
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.project.field_c_n_components.yml
+++ b/config/default/field.field.node.project.field_c_n_components.yml
@@ -1,0 +1,159 @@
+uuid: 2255cf7c-ebcc-4327-be29-33282f2ed5bf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_components
+    - node.type.project
+    - paragraphs.paragraphs_type.civictheme_accordion
+    - paragraphs.paragraphs_type.civictheme_attachment
+    - paragraphs.paragraphs_type.civictheme_automated_list
+    - paragraphs.paragraphs_type.civictheme_callout
+    - paragraphs.paragraphs_type.civictheme_campaign
+    - paragraphs.paragraphs_type.civictheme_content
+    - paragraphs.paragraphs_type.civictheme_iframe
+    - paragraphs.paragraphs_type.civictheme_manual_list
+    - paragraphs.paragraphs_type.civictheme_map
+    - paragraphs.paragraphs_type.civictheme_message
+    - paragraphs.paragraphs_type.civictheme_next_step
+    - paragraphs.paragraphs_type.civictheme_promo
+    - paragraphs.paragraphs_type.civictheme_slider
+    - paragraphs.paragraphs_type.civictheme_webform
+    - paragraphs.paragraphs_type.divider
+    - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.steps
+  module:
+    - entity_reference_revisions
+id: node.project.field_c_n_components
+field_name: field_c_n_components
+entity_type: node
+bundle: project
+label: Components
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      civictheme_content: civictheme_content
+      civictheme_accordion: civictheme_accordion
+      civictheme_attachment: civictheme_attachment
+      civictheme_automated_list: civictheme_automated_list
+      civictheme_callout: civictheme_callout
+      civictheme_campaign: civictheme_campaign
+      civictheme_iframe: civictheme_iframe
+      civictheme_manual_list: civictheme_manual_list
+      civictheme_map: civictheme_map
+      civictheme_next_step: civictheme_next_step
+      civictheme_promo: civictheme_promo
+      civictheme_slider: civictheme_slider
+      civictheme_webform: civictheme_webform
+      divider: divider
+      from_library: from_library
+      civictheme_message: civictheme_message
+      steps: steps
+    negate: 0
+    target_bundles_drag_drop:
+      civictheme_accordion:
+        weight: -58
+        enabled: true
+      civictheme_accordion_panel:
+        weight: -44
+        enabled: false
+      civictheme_attachment:
+        weight: -57
+        enabled: true
+      civictheme_automated_list:
+        weight: -56
+        enabled: true
+      civictheme_callout:
+        weight: -55
+        enabled: true
+      civictheme_campaign:
+        weight: -54
+        enabled: true
+      civictheme_content:
+        weight: -59
+        enabled: true
+      civictheme_event_card:
+        weight: -39
+        enabled: false
+      civictheme_event_card_ref:
+        weight: -38
+        enabled: false
+      civictheme_iframe:
+        weight: -53
+        enabled: true
+      civictheme_manual_list:
+        weight: -52
+        enabled: true
+      civictheme_map:
+        weight: -51
+        enabled: true
+      civictheme_message:
+        weight: -52
+        enabled: true
+      civictheme_navigation_card:
+        weight: -43
+        enabled: false
+      civictheme_navigation_card_ref:
+        weight: -37
+        enabled: false
+      civictheme_next_step:
+        weight: -50
+        enabled: true
+      civictheme_promo:
+        weight: -48
+        enabled: true
+      civictheme_promo_card:
+        weight: -42
+        enabled: false
+      civictheme_promo_card_ref:
+        weight: -40
+        enabled: false
+      civictheme_publication_card:
+        weight: -33
+        enabled: false
+      civictheme_service_card:
+        weight: -41
+        enabled: false
+      civictheme_slider:
+        weight: -47
+        enabled: true
+      civictheme_slider_slide:
+        weight: -45
+        enabled: false
+      civictheme_slider_slide_ref:
+        weight: -32
+        enabled: false
+      civictheme_snippet:
+        weight: 54
+        enabled: false
+      civictheme_snippet_ref:
+        weight: 55
+        enabled: false
+      civictheme_social_icon:
+        weight: -31
+        enabled: false
+      civictheme_subject_card:
+        weight: -36
+        enabled: false
+      civictheme_subject_card_ref:
+        weight: -35
+        enabled: false
+      civictheme_webform:
+        weight: -46
+        enabled: true
+      divider:
+        weight: 60
+        enabled: true
+      from_library:
+        weight: 62
+        enabled: true
+      steps:
+        weight: 61
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/default/field.field.node.project.field_c_n_custom_last_updated.yml
+++ b/config/default/field.field.node.project.field_c_n_custom_last_updated.yml
@@ -1,0 +1,21 @@
+uuid: fc1574b9-b81d-4a38-8b28-0a9822083be4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_custom_last_updated
+    - node.type.project
+  module:
+    - datetime
+id: node.project.field_c_n_custom_last_updated
+field_name: field_c_n_custom_last_updated
+entity_type: node
+bundle: project
+label: 'Custom Last updated date'
+description: "Override <em>Last updated</em> system date with a custom value. Leave empty to use system last updated date.<br/>\r\nApplies only if <em>Show Last updated date</em> is enabled above."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/default/field.field.node.project.field_c_n_hide_sidebar.yml
+++ b/config/default/field.field.node.project.field_c_n_hide_sidebar.yml
@@ -1,0 +1,23 @@
+uuid: 270e8a5b-aaf4-41d2-92df-d91c80070560
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_hide_sidebar
+    - node.type.project
+id: node.project.field_c_n_hide_sidebar
+field_name: field_c_n_hide_sidebar
+entity_type: node
+bundle: project
+label: 'Hide sidebar'
+description: "Hide sidebar making this page's component appear edge-to-edge."
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/field.field.node.project.field_c_n_hide_tags.yml
+++ b/config/default/field.field.node.project.field_c_n_hide_tags.yml
@@ -1,0 +1,23 @@
+uuid: 684623df-a1d5-4897-9531-bf19b007c243
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_hide_tags
+    - node.type.project
+id: node.project.field_c_n_hide_tags
+field_name: field_c_n_hide_tags
+entity_type: node
+bundle: project
+label: 'Hide tags'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/field.field.node.project.field_c_n_show_last_updated.yml
+++ b/config/default/field.field.node.project.field_c_n_show_last_updated.yml
@@ -1,0 +1,23 @@
+uuid: 512a62db-f0b2-4fb3-b046-f1fdf23b9294
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_show_last_updated
+    - node.type.project
+id: node.project.field_c_n_show_last_updated
+field_name: field_c_n_show_last_updated
+entity_type: node
+bundle: project
+label: 'Show Last updated date'
+description: 'Show <em>Last updated</em> date on the page.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/field.field.node.project.field_c_n_show_toc.yml
+++ b/config/default/field.field.node.project.field_c_n_show_toc.yml
@@ -1,0 +1,23 @@
+uuid: 276b00e5-7283-4d30-9823-9247c1493f5b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_show_toc
+    - node.type.project
+id: node.project.field_c_n_show_toc
+field_name: field_c_n_show_toc
+entity_type: node
+bundle: project
+label: 'Show Table of Contents'
+description: 'Scan the content of the page for <code>h2</code> HTML tags and automatically create a Table of Contents.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/field.field.node.project.field_c_n_site_section.yml
+++ b/config/default/field.field.node.project.field_c_n_site_section.yml
@@ -1,0 +1,29 @@
+uuid: 2f0b2b3a-b711-43f1-9ded-1d4ec267c420
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_site_section
+    - node.type.project
+    - taxonomy.vocabulary.civictheme_site_sections
+id: node.project.field_c_n_site_section
+field_name: field_c_n_site_section
+entity_type: node
+bundle: project
+label: 'Site section'
+description: 'Add this content to be a part of pre-defined site section.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      civictheme_site_sections: civictheme_site_sections
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_c_n_summary.yml
+++ b/config/default/field.field.node.project.field_c_n_summary.yml
@@ -1,0 +1,19 @@
+uuid: a45ffd45-6025-440e-8d64-e688f8fee1a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_summary
+    - node.type.project
+id: node.project.field_c_n_summary
+field_name: field_c_n_summary
+entity_type: node
+bundle: project
+label: Summary
+description: 'Short summary of the page contents. Shown in teasers and on cards.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.field.node.project.field_c_n_summary.yml
+++ b/config/default/field.field.node.project.field_c_n_summary.yml
@@ -10,7 +10,7 @@ field_name: field_c_n_summary
 entity_type: node
 bundle: project
 label: Summary
-description: 'Short summary of the page contents. Shown in teasers and on cards.'
+description: 'Short summary of the project. Shown in teasers and on cards.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/default/field.field.node.project.field_c_n_thumbnail.yml
+++ b/config/default/field.field.node.project.field_c_n_thumbnail.yml
@@ -1,0 +1,29 @@
+uuid: 08952470-19bb-4a73-9077-0e7a525a60f0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_thumbnail
+    - media.type.civictheme_image
+    - node.type.project
+id: node.project.field_c_n_thumbnail
+field_name: field_c_n_thumbnail
+entity_type: node
+bundle: project
+label: Thumbnail
+description: 'Image to appear in teasers and on cards.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      civictheme_image: civictheme_image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_c_n_topics.yml
+++ b/config/default/field.field.node.project.field_c_n_topics.yml
@@ -1,0 +1,29 @@
+uuid: 443625a9-f195-422e-9009-21f2c1871ee3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_topics
+    - node.type.project
+    - taxonomy.vocabulary.civictheme_topics
+id: node.project.field_c_n_topics
+field_name: field_c_n_topics
+entity_type: node
+bundle: project
+label: Topics
+description: 'Group content by topics to allow sorting in lists.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      civictheme_topics: civictheme_topics
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_c_n_vertical_spacing.yml
+++ b/config/default/field.field.node.project.field_c_n_vertical_spacing.yml
@@ -1,0 +1,23 @@
+uuid: 7d55a45b-4167-4069-bd26-7ea034fa2816
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_c_n_vertical_spacing
+    - node.type.project
+  module:
+    - options
+id: node.project.field_c_n_vertical_spacing
+field_name: field_c_n_vertical_spacing
+entity_type: node
+bundle: project
+label: 'Vertical spacing'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: both
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.project.field_do_n_client.yml
+++ b/config/default/field.field.node.project.field_do_n_client.yml
@@ -1,0 +1,19 @@
+uuid: e68d9a2b-13bb-4187-9e58-8f44a43aa2f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_client
+    - node.type.project
+id: node.project.field_do_n_client
+field_name: field_do_n_client
+entity_type: node
+bundle: project
+label: Client
+description: 'The organisation the work was delivered for. Leave empty when the client cannot be named.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.node.project.field_do_n_delivered_at.yml
+++ b/config/default/field.field.node.project.field_do_n_delivered_at.yml
@@ -1,0 +1,19 @@
+uuid: f76b170b-0b63-42f1-a6c6-c0d458667b2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_delivered_at
+    - node.type.project
+id: node.project.field_do_n_delivered_at
+field_name: field_do_n_delivered_at
+entity_type: node
+bundle: project
+label: 'Delivered at'
+description: 'The organisation the work was delivered under. Leave empty when it cannot be named.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.node.project.field_do_n_live_url.yml
+++ b/config/default/field.field.node.project.field_do_n_live_url.yml
@@ -1,0 +1,23 @@
+uuid: 19d74955-2161-40c3-8e47-5a2c6b6d1d9a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_live_url
+    - node.type.project
+  module:
+    - link
+id: node.project.field_do_n_live_url
+field_name: field_do_n_live_url
+entity_type: node
+bundle: project
+label: 'Live site URL'
+description: 'The address of the live site. Leave empty when the work is no longer reachable.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/default/field.field.node.project.field_do_n_oss_contributions.yml
+++ b/config/default/field.field.node.project.field_do_n_oss_contributions.yml
@@ -1,0 +1,23 @@
+uuid: 8ceec8df-0b96-435c-ace8-ae4d02253ba2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_oss_contributions
+    - node.type.project
+  module:
+    - link
+id: node.project.field_do_n_oss_contributions
+field_name: field_do_n_oss_contributions
+entity_type: node
+bundle: project
+label: 'Open source contributions'
+description: 'Modules, patches and tools contributed back from this work.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/config/default/field.field.node.project.field_do_n_role.yml
+++ b/config/default/field.field.node.project.field_do_n_role.yml
@@ -1,0 +1,19 @@
+uuid: 102e941f-7e3f-4cfc-852e-f2e24593b688
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_role
+    - node.type.project
+id: node.project.field_do_n_role
+field_name: field_do_n_role
+entity_type: node
+bundle: project
+label: Role
+description: 'The roles held on this project.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/field.field.node.project.field_do_n_sector.yml
+++ b/config/default/field.field.node.project.field_do_n_sector.yml
@@ -1,0 +1,29 @@
+uuid: 3c6ef9b4-06e7-4fba-9254-57861b40962c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_sector
+    - node.type.project
+    - taxonomy.vocabulary.do_sector
+id: node.project.field_do_n_sector
+field_name: field_do_n_sector
+entity_type: node
+bundle: project
+label: Sector
+description: 'The sector the client operates in.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      do_sector: do_sector
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_do_n_services.yml
+++ b/config/default/field.field.node.project.field_do_n_services.yml
@@ -1,0 +1,29 @@
+uuid: feb0353c-b29d-4d44-8c9a-927662d963b9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_services
+    - node.type.project
+    - taxonomy.vocabulary.do_service
+id: node.project.field_do_n_services
+field_name: field_do_n_services
+entity_type: node
+bundle: project
+label: Services
+description: 'The services provided on this project.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      do_service: do_service
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_do_n_status.yml
+++ b/config/default/field.field.node.project.field_do_n_status.yml
@@ -1,0 +1,21 @@
+uuid: c1569122-1e5a-4824-a576-0c1a94e8e604
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_status
+    - node.type.project
+  module:
+    - options
+id: node.project.field_do_n_status
+field_name: field_do_n_status
+entity_type: node
+bundle: project
+label: Status
+description: 'Whether the work is still running, finished, or no longer live.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.project.field_do_n_technologies.yml
+++ b/config/default/field.field.node.project.field_do_n_technologies.yml
@@ -1,0 +1,29 @@
+uuid: c8032685-8f06-43ae-9d6d-031a43342b05
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_technologies
+    - node.type.project
+    - taxonomy.vocabulary.do_technology
+id: node.project.field_do_n_technologies
+field_name: field_do_n_technologies
+entity_type: node
+bundle: project
+label: Technologies
+description: 'The platforms and tools the work was delivered on.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      do_technology: do_technology
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: do_technology
+field_type: entity_reference

--- a/config/default/field.field.node.project.field_do_n_year.yml
+++ b/config/default/field.field.node.project.field_do_n_year.yml
@@ -1,0 +1,23 @@
+uuid: 57765fd6-648e-4521-bcb5-12c1b73384c3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_do_n_year
+    - node.type.project
+id: node.project.field_do_n_year
+field_name: field_do_n_year
+entity_type: node
+bundle: project
+label: Year
+description: 'The year the work was delivered. Used for sorting.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/default/field.field.node.project.field_do_n_year.yml
+++ b/config/default/field.field.node.project.field_do_n_year.yml
@@ -16,8 +16,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
-  max: null
+  min: 1
+  max: 9999
   prefix: ''
   suffix: ''
 field_type: integer

--- a/config/default/field.field.node.project.field_n_metatags.yml
+++ b/config/default/field.field.node.project.field_n_metatags.yml
@@ -1,0 +1,21 @@
+uuid: 21a8c430-1796-4623-b65a-6797c64beb11
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_n_metatags
+    - node.type.project
+  module:
+    - metatag
+id: node.project.field_n_metatags
+field_name: field_n_metatags
+entity_type: node
+bundle: project
+label: Metatags
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/default/field.storage.node.field_do_n_client.yml
+++ b/config/default/field.storage.node.field_do_n_client.yml
@@ -1,0 +1,21 @@
+uuid: f9b56eae-97a6-4755-aaa3-7805f7894ca2
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_do_n_client
+field_name: field_do_n_client
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_delivered_at.yml
+++ b/config/default/field.storage.node.field_do_n_delivered_at.yml
@@ -1,0 +1,21 @@
+uuid: 1e304b51-bba6-4bcd-be79-32bdf977f88a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_do_n_delivered_at
+field_name: field_do_n_delivered_at
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_live_url.yml
+++ b/config/default/field.storage.node.field_do_n_live_url.yml
@@ -1,0 +1,19 @@
+uuid: 1c397b55-c8e6-454f-84b7-9dd1be47c0b1
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_do_n_live_url
+field_name: field_do_n_live_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_oss_contributions.yml
+++ b/config/default/field.storage.node.field_do_n_oss_contributions.yml
@@ -1,0 +1,19 @@
+uuid: 111c8456-d254-4351-8bc6-2c86aa5f3d65
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_do_n_oss_contributions
+field_name: field_do_n_oss_contributions
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_role.yml
+++ b/config/default/field.storage.node.field_do_n_role.yml
@@ -1,0 +1,21 @@
+uuid: 61f37a4f-091c-40f9-a5e3-3acac4f234a4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_do_n_role
+field_name: field_do_n_role
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_sector.yml
+++ b/config/default/field.storage.node.field_do_n_sector.yml
@@ -1,0 +1,20 @@
+uuid: cec28580-ce82-4037-85fe-b0378559d159
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_do_n_sector
+field_name: field_do_n_sector
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_services.yml
+++ b/config/default/field.storage.node.field_do_n_services.yml
@@ -1,0 +1,20 @@
+uuid: 0181abec-980f-48d2-b07a-83379f3f5fd4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_do_n_services
+field_name: field_do_n_services
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_status.yml
+++ b/config/default/field.storage.node.field_do_n_status.yml
@@ -1,0 +1,30 @@
+uuid: 510f2f06-a480-4586-8124-6244a707d36d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_do_n_status
+field_name: field_do_n_status
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: ongoing
+      label: Ongoing
+    -
+      value: completed
+      label: Completed
+    -
+      value: decommissioned
+      label: Decommissioned
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_technologies.yml
+++ b/config/default/field.storage.node.field_do_n_technologies.yml
@@ -1,0 +1,20 @@
+uuid: 69502699-9345-4092-bd2d-a968f96e1e75
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_do_n_technologies
+field_name: field_do_n_technologies
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_do_n_year.yml
+++ b/config/default/field.storage.node.field_do_n_year.yml
@@ -1,0 +1,20 @@
+uuid: be80dd83-158f-46a3-9b76-2c9aef294608
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_do_n_year
+field_name: field_do_n_year
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.paragraph.field_c_p_list_content_type.yml
+++ b/config/default/field.storage.paragraph.field_c_p_list_content_type.yml
@@ -25,6 +25,9 @@ settings:
     -
       value: blog
       label: 'Blog post'
+    -
+      value: project
+      label: Project
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/default/language.content_settings.node.project.yml
+++ b/config/default/language.content_settings.node.project.yml
@@ -1,0 +1,11 @@
+uuid: ef3246e3-6a27-470d-87ee-ff9e84199baf
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.project
+id: node.project
+target_entity_type_id: node
+target_bundle: project
+default_langcode: site_default
+language_alterable: false

--- a/config/default/metatag.metatag_defaults.node__project.yml
+++ b/config/default/metatag.metatag_defaults.node__project.yml
@@ -1,0 +1,8 @@
+uuid: c7d5d8bd-20f9-4d77-a1f7-d69cef5f7dc0
+langcode: en
+status: true
+dependencies: {  }
+id: node__project
+label: 'Content: Project'
+tags:
+  description: '[node:field_c_n_summary:value]'

--- a/config/default/node.type.project.yml
+++ b/config/default/node.type.project.yml
@@ -1,0 +1,28 @@
+uuid: e71243d6-5aef-479f-8134-9be674702e41
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_moderation
+    - menu_ui
+third_party_settings:
+  content_moderation:
+    enabled: true
+    allowed_moderation_states:
+      - draft
+      - needs_review
+      - published
+      - archived
+    default_moderation_state: published
+  menu_ui:
+    available_menus:
+      - civictheme-primary-navigation
+      - civictheme-secondary-navigation
+    parent: 'civictheme-primary-navigation:'
+name: Project
+type: project
+description: 'Use projects to showcase delivered work with structured facts and a flexible narrative.'
+help: null
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/default/pathauto.pattern.project.yml
+++ b/config/default/pathauto.pattern.project.yml
@@ -1,0 +1,23 @@
+uuid: 64e047f7-b167-4a75-8514-6e7bddca7f84
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.project
+  module:
+    - node
+id: project
+label: Project
+type: 'canonical_entities:node'
+pattern: '/projects/[node:title]'
+selection_criteria:
+  4359d4f8-fcd8-4814-8ee7-2cd0ba4da65c:
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: node
+    bundles:
+      project: project
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/default/taxonomy.vocabulary.do_sector.yml
+++ b/config/default/taxonomy.vocabulary.do_sector.yml
@@ -1,0 +1,9 @@
+uuid: 961a7357-f5a6-4828-9da5-17f859cbc9ca
+langcode: en
+status: true
+dependencies: {  }
+name: Sector
+vid: do_sector
+description: 'The sector or industry a project was delivered for.'
+weight: 0
+new_revision: false

--- a/config/default/taxonomy.vocabulary.do_service.yml
+++ b/config/default/taxonomy.vocabulary.do_service.yml
@@ -1,0 +1,9 @@
+uuid: ac449193-2324-40c1-8457-747be798b273
+langcode: en
+status: true
+dependencies: {  }
+name: Service
+vid: do_service
+description: 'The services provided on a project.'
+weight: 0
+new_revision: false

--- a/config/default/taxonomy.vocabulary.do_technology.yml
+++ b/config/default/taxonomy.vocabulary.do_technology.yml
@@ -1,0 +1,9 @@
+uuid: 148ea75f-bb76-40bf-a222-fb0821e720ac
+langcode: en
+status: true
+dependencies: {  }
+name: Technology
+vid: do_technology
+description: 'The platforms and tools a project was delivered on.'
+weight: 0
+new_revision: false

--- a/config/default/user.role.civictheme_content_author.yml
+++ b/config/default/user.role.civictheme_content_author.yml
@@ -14,6 +14,7 @@ dependencies:
     - node.type.civictheme_alert
     - node.type.civictheme_event
     - node.type.civictheme_page
+    - node.type.project
     - taxonomy.vocabulary.civictheme_media_tags
     - workflows.workflow.civictheme_editorial
   module:
@@ -60,6 +61,7 @@ permissions:
   - 'create civictheme_remote_video media'
   - 'create civictheme_video media'
   - 'create media'
+  - 'create project content'
   - 'create terms in civictheme_media_tags'
   - 'create url aliases'
   - 'delete all revisions'
@@ -74,6 +76,7 @@ permissions:
   - 'delete any civictheme_remote_video media'
   - 'delete any civictheme_video media'
   - 'delete any media'
+  - 'delete any project content'
   - 'delete blog revisions'
   - 'delete civictheme_alert revisions'
   - 'delete civictheme_event revisions'
@@ -89,6 +92,8 @@ permissions:
   - 'delete own civictheme_page content'
   - 'delete own civictheme_remote_video media'
   - 'delete own civictheme_video media'
+  - 'delete own project content'
+  - 'delete project revisions'
   - 'delete terms in civictheme_media_tags'
   - 'edit any blog content'
   - 'edit any civictheme_alert content'
@@ -100,6 +105,7 @@ permissions:
   - 'edit any civictheme_page content'
   - 'edit any civictheme_remote_video media'
   - 'edit any civictheme_video media'
+  - 'edit any project content'
   - 'edit own blog content'
   - 'edit own civictheme_alert content'
   - 'edit own civictheme_audio media'
@@ -110,6 +116,7 @@ permissions:
   - 'edit own civictheme_page content'
   - 'edit own civictheme_remote_video media'
   - 'edit own civictheme_video media'
+  - 'edit own project content'
   - 'edit terms in civictheme_media_tags'
   - 'generate ai alt tags'
   - 'revert all revisions'
@@ -117,6 +124,7 @@ permissions:
   - 'revert civictheme_alert revisions'
   - 'revert civictheme_event revisions'
   - 'revert civictheme_page revisions'
+  - 'revert project revisions'
   - 'update any media'
   - 'update media'
   - 'use civictheme_editorial transition create_new_draft'
@@ -134,4 +142,5 @@ permissions:
   - 'view latest version'
   - 'view own unpublished content'
   - 'view own unpublished media'
+  - 'view project revisions'
   - 'view the administration theme'

--- a/config/default/user.role.civictheme_site_administrator.yml
+++ b/config/default/user.role.civictheme_site_administrator.yml
@@ -19,6 +19,7 @@ dependencies:
     - node.type.civictheme_alert
     - node.type.civictheme_event
     - node.type.civictheme_page
+    - node.type.project
     - taxonomy.vocabulary.civictheme_media_tags
     - taxonomy.vocabulary.civictheme_topics
     - workflows.workflow.civictheme_editorial
@@ -107,6 +108,7 @@ permissions:
   - 'create civictheme_video media'
   - 'create media'
   - 'create paragraph library item'
+  - 'create project content'
   - 'create terms in civictheme_media_tags'
   - 'create terms in civictheme_topics'
   - 'create url aliases'
@@ -133,6 +135,7 @@ permissions:
   - 'delete any civictheme_social_links block content revisions'
   - 'delete any civictheme_video media'
   - 'delete any media'
+  - 'delete any project content'
   - 'delete any webform'
   - 'delete any webform submission'
   - 'delete blog revisions'
@@ -150,8 +153,10 @@ permissions:
   - 'delete own civictheme_page content'
   - 'delete own civictheme_remote_video media'
   - 'delete own civictheme_video media'
+  - 'delete own project content'
   - 'delete own webform'
   - 'delete own webform submission'
+  - 'delete project revisions'
   - 'delete terms in civictheme_media_tags'
   - 'delete terms in civictheme_topics'
   - 'edit any blog content'
@@ -169,6 +174,7 @@ permissions:
   - 'edit any civictheme_search block content'
   - 'edit any civictheme_social_links block content'
   - 'edit any civictheme_video media'
+  - 'edit any project content'
   - 'edit any webform'
   - 'edit any webform submission'
   - 'edit own blog content'
@@ -181,6 +187,7 @@ permissions:
   - 'edit own civictheme_page content'
   - 'edit own civictheme_remote_video media'
   - 'edit own civictheme_video media'
+  - 'edit own project content'
   - 'edit own webform'
   - 'edit own webform submission'
   - 'edit paragraph library item'
@@ -204,6 +211,7 @@ permissions:
   - 'revert civictheme_alert revisions'
   - 'revert civictheme_event revisions'
   - 'revert civictheme_page revisions'
+  - 'revert project revisions'
   - 'select account cancellation method'
   - 'update any media'
   - 'update media'
@@ -234,5 +242,6 @@ permissions:
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view own webform submission'
+  - 'view project revisions'
   - 'view the administration theme'
   - 'view user email addresses'

--- a/config/default/workflows.workflow.civictheme_editorial.yml
+++ b/config/default/workflows.workflow.civictheme_editorial.yml
@@ -18,6 +18,7 @@ dependencies:
     - node.type.civictheme_alert
     - node.type.civictheme_event
     - node.type.civictheme_page
+    - node.type.project
   module:
     - content_moderation
 _core:
@@ -118,4 +119,5 @@ type_settings:
       - civictheme_alert
       - civictheme_event
       - civictheme_page
+      - project
   default_moderation_state: published

--- a/config/default/xmlsitemap.settings.node.project.yml
+++ b/config/default/xmlsitemap.settings.node.project.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 0

--- a/docs/content-types.md
+++ b/docs/content-types.md
@@ -10,6 +10,7 @@ This page describes how custom node bundles are added to this site, and the part
 | `civictheme_event` | Event | CivicTheme |
 | `civictheme_alert` | Alert | CivicTheme |
 | `blog` | Blog post | This project |
+| `project` | Project | This project |
 
 `civictheme_page` is the reference implementation. A new content type that is meant to look and behave like a page is built by cloning it, so the two bundles stay interchangeable and no field data can be orphaned if content is ever moved between them.
 
@@ -59,6 +60,14 @@ Verify the result by diffing the two displays with the bundle token normalised. 
 | `core.base_field_override.node.<bundle>.promote` | No | The CivicTheme types each carry one setting `promote` to `0`, but core already defaults the base field to `FALSE`, so omitting it changes nothing. |
 | `captcha.captcha_point.node_<bundle>_form` | No | `captcha.settings` has `enable_globally: 0`, so a form with no point gets no challenge. The Page form's point exists but is disabled, so omitting it matches Page behaviour. |
 
+## Fields the bundle does not share with Page
+
+A bundle that carries its own fields, as `project` does, renders them from its preprocessor into a component rather than through the view display. The view display is Layout Builder-driven and its default section is copied from Page, so a field that is not a block in that section never renders, whatever its formatter says. Building the markup in the preprocessor is also what makes it possible to leave a row out when its field is empty and to link a taxonomy value to its term page, neither of which a formatter does.
+
+Add those fields to the view display's `hidden` list anyway, through the configuration factory rather than the entity API. It changes no output, but it records the intent, so the next person does not place them in the layout expecting the panel to move.
+
+Read entity reference values with `civictheme_get_field_referenced_entities($node, $field_name, $variables)` rather than by hand. It drops terms the reader cannot view and registers each one as a cacheable dependency of the page; without that, renaming a term leaves every node still rendering the old label until it is re-saved.
+
 ## The theme layer
 
 **This is the part configuration parity does not cover, and the easiest thing to miss.**
@@ -81,6 +90,8 @@ That indirection is deliberate: each content type owns its own full-view theming
 A new content type must therefore supply its own `_civictheme_preprocess_node__<bundle>__full()`. Put it in a dedicated include under `web/themes/custom/drevops/includes/` and require it from `drevops.theme`; `blog.inc` is the worked example. The theme file is loaded before any preprocessing runs, so CivicTheme's `function_exists()` check finds it.
 
 Keep each type's implementation self-contained rather than delegating to another type's preprocessor. Delegating couples the two bundles, so one cannot be changed without changing the other, and it silently inherits any upstream change to the borrowed function.
+
+Shared *building blocks* are a different thing and belong in `node.inc`. `_drevops_node_add_table_of_contents()` and `_drevops_node_add_topic_tags()` live there and are called by each bundle that wants them, so the render arrays exist once while each bundle still decides for itself what its pages show. Reach for this only once a second bundle needs the same block; a helper with one caller is just indirection.
 
 Do **not** put this logic in the theme's own `_drevops_preprocess_node__<view_mode>()` hook. That hook is for work that applies across bundles, and taking it over for one content type forces every later cross-bundle change to thread around a bundle-specific branch.
 

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -11,6 +11,7 @@ The sitemap is served at `/sitemap.xml`.
 | Front page | Priority `1.0`, change frequency `daily` |
 | `civictheme_page` nodes | Priority `0.5` (omitted from the output, as `0.5` is the format's assumed default) |
 | `blog` nodes | Priority `0.5` (omitted from the output, as `0.5` is the format's assumed default) |
+| `project` nodes | Priority `0.5` (omitted from the output, as `0.5` is the format's assumed default) |
 | `civictheme_event` nodes | Not listed |
 | `civictheme_alert` nodes | Not listed |
 | Taxonomy terms, menu links, users | Not listed |

--- a/tests/behat/features/project_content_type.feature
+++ b/tests/behat/features/project_content_type.feature
@@ -32,6 +32,9 @@ Feature: Project content type
     And the field "field_do_n_oss_contributions[0][title]" should exist
     And the field "field_do_n_sector" should exist
     And the field "field_do_n_technologies[target_id]" should exist
+    # Services is a checkboxes widget, so it has no single named control to
+    # assert against; its wrapper is the stable handle.
+    And should see a "[data-drupal-selector='edit-field-do-n-services']" element
 
     And the field "field_c_n_banner_title[0][value]" should exist
     And the field "field_c_n_banner_type" should exist

--- a/tests/behat/features/project_content_type.feature
+++ b/tests/behat/features/project_content_type.feature
@@ -1,0 +1,314 @@
+@p1 @drevops @project
+Feature: Project content type
+
+  As a content editor
+  I want to publish delivered work as a Project with structured facts and a flexible narrative
+  So that visitors can judge the depth of the work and browse it by sector, service and technology
+
+  @api
+  Scenario: Project is offered as a content type
+    Given I am logged in as a user with the "Content Author" role
+    When I visit "node/add"
+    Then I should see the text "Project"
+    When I visit "node/add/project"
+    Then I should see the text "Create Project"
+
+  @api
+  Scenario: Project offers the structured fact fields alongside the Page controls
+    Given I am logged in as a user with the "Content Author" role
+    When I visit "node/add/project"
+
+    Then the field "title[0][value]" should exist
+    And the field "field_c_n_summary[0][value]" should exist
+    And the field "field_c_n_topics[target_id]" should exist
+
+    And the field "field_do_n_client[0][value]" should exist
+    And the field "field_do_n_role[0][value]" should exist
+    And the field "field_do_n_delivered_at[0][value]" should exist
+    And the field "field_do_n_year[0][value]" should exist
+    And the field "field_do_n_status" should exist
+    And the field "field_do_n_live_url[0][uri]" should exist
+    And the field "field_do_n_oss_contributions[0][uri]" should exist
+    And the field "field_do_n_oss_contributions[0][title]" should exist
+    And the field "field_do_n_sector" should exist
+    And the field "field_do_n_technologies[target_id]" should exist
+
+    And the field "field_c_n_banner_title[0][value]" should exist
+    And the field "field_c_n_banner_type" should exist
+    And the field "field_c_n_show_toc[value]" should exist
+    And the field "field_c_n_hide_tags[value]" should exist
+    And the field "field_c_n_vertical_spacing" should exist
+
+    And I should see the text "Project details"
+    And I should see the text "Categorisation"
+    And I should see the text "Appearance"
+    And I should see the text "Banner"
+
+  @api
+  Scenario: Project offers the same component set as a Page
+    Given I am logged in as a user with the "Content Author" role
+    When I visit "node/add/project"
+    Then the field "field_c_n_components[0][subform][field_c_p_content][0][value]" should not exist
+    And I should see the button "Add Content"
+    And I should see the button "Add Automated list"
+    And I should see the button "Add Manual list"
+    And I should see the button "Add Steps"
+
+  @api
+  Scenario: Three separate vocabularies exist for sector, service and technology
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit "admin/structure/taxonomy"
+    Then I should see the text "Sector"
+    And I should see the text "Service"
+    And I should see the text "Technology"
+    When I visit "admin/structure/taxonomy/manage/do_sector/overview"
+    Then the response status code should be 200
+    When I visit "admin/structure/taxonomy/manage/do_service/overview"
+    Then the response status code should be 200
+    When I visit "admin/structure/taxonomy/manage/do_technology/overview"
+    Then the response status code should be 200
+
+  @api
+  Scenario: Project follows the editorial workflow and gets a /projects URL
+    Given the following "project" content:
+      | title                  | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Example project | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+    When I visit the "project" content page with the title "[TEST] Example project"
+    Then the path should be "/projects/test-example-project"
+    And I should see the text "[TEST] Example project"
+    When I am logged in as a user with the "Site Administrator" role
+    And I visit the "project" content edit page with the title "[TEST] Example project"
+    Then the option "Draft" should exist within the select element "moderation_state[0][state]"
+    And the option "Published" should exist within the select element "moderation_state[0][state]"
+    And the option "Archived" should exist within the select element "moderation_state[0][state]"
+
+  @api
+  Scenario: A draft project is not visible to an anonymous user
+    Given the following "project" content:
+      | title                 | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Draft project  | draft            | 2025            | ongoing           | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I go to "/projects/test-draft-project"
+    Then the response status code should be 403
+
+  @api
+  Scenario: A published project renders its narrative components
+    Given the following "project" content:
+      | title                    | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Narrative project | published        | 2025            | ongoing           | large                 | inherit                | normal                      | both                       |
+    And the following fields for the paragraph "civictheme_content" exist in the field "field_c_n_components" within the "project" "node" identified by the field "title" and the value "[TEST] Narrative project":
+      | field_c_p_content:value    | [TEST] Component body text. |
+      | field_c_p_content:format   | civictheme_rich_text        |
+      | field_c_p_theme            | light                       |
+      | field_c_p_vertical_spacing | both                        |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Narrative project"
+    Then I should see the text "[TEST] Narrative project"
+    And I should see the text "[TEST] Component body text."
+
+  @api
+  Scenario: Figures are entered as fast fact cards inside a manual list
+    Given the following "project" content:
+      | title                 | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Figure project | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+    And the following fields for the paragraph "civictheme_manual_list" exist in the field "field_c_n_components" within the "project" "node" identified by the field "title" and the value "[TEST] Figure project":
+      | field_c_p_title             | [TEST] Project figures |
+      | field_c_p_list_column_count | 3                      |
+      | field_c_p_list_fill_width   | 0                      |
+    And the following fields for the paragraph "civictheme_fast_fact_card" exist in the field "field_c_p_list_items" within the "civictheme_manual_list" "paragraph" identified by the field "field_c_p_title" and the value "[TEST] Project figures":
+      | field_c_p_title   | 4.2 million              |
+      | field_c_p_summary | [TEST] Visitors per year |
+      | field_c_p_theme   | light                    |
+    And the following fields for the paragraph "civictheme_fast_fact_card" exist in the field "field_c_p_list_items" within the "civictheme_manual_list" "paragraph" identified by the field "field_c_p_title" and the value "[TEST] Project figures":
+      | field_c_p_title   | 60%                        |
+      | field_c_p_summary | [TEST] Faster page loads   |
+      | field_c_p_theme   | light                      |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Figure project"
+    Then I should see 2 ".ct-fast-fact-card" elements
+    And I should see the text "4.2 million"
+    And I should see the text "[TEST] Visitors per year"
+    And I should see the text "60%"
+    And I should see the text "[TEST] Faster page loads"
+
+  @api
+  Scenario: The At a glance panel shows every fact with its label
+    Given the following "do_sector" terms:
+      | name            |
+      | [TEST] Sector 1 |
+    And the following "do_service" terms:
+      | name             |
+      | [TEST] Service 1 |
+      | [TEST] Service 2 |
+    And the following "do_technology" terms:
+      | name                |
+      | [TEST] Technology 1 |
+    And the following "project" content:
+      | title                    | moderation_state | field_do_n_client     | field_do_n_role      | field_do_n_delivered_at | field_do_n_year | field_do_n_status | field_do_n_live_url:uri  | field_do_n_sector | field_do_n_services                | field_do_n_technologies | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Complete project  | published        | [TEST] Example Client | [TEST] Technical lead | [TEST] Example Agency   | 2025            | completed         | https://www.example.com  | [TEST] Sector 1   | [TEST] Service 1, [TEST] Service 2 | [TEST] Technology 1     | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Complete project"
+    Then should see a ".ct-at-a-glance" element
+    And I should see 9 ".ct-at-a-glance__row" elements
+
+    And I should see the text "Client"
+    And I should see the text "[TEST] Example Client"
+    And I should see the text "Role"
+    And I should see the text "[TEST] Technical lead"
+    And I should see the text "Delivered at"
+    And I should see the text "[TEST] Example Agency"
+    And I should see the text "Year"
+    And I should see the text "2025"
+    And I should see the text "Status"
+    And I should see the text "Completed"
+    And I should see the text "Live site"
+    And the response should contain "https://www.example.com"
+
+    # Each taxonomy value links to its term page, so the reader can browse
+    # sideways from any project into everything sharing that term.
+    And I should see 4 ".ct-at-a-glance__value a[href^='/taxonomy/term/']" elements
+    And I should see the text "[TEST] Sector 1"
+    And I should see the text "[TEST] Service 1"
+    And I should see the text "[TEST] Service 2"
+    And I should see the text "[TEST] Technology 1"
+
+  @api
+  Scenario: Work that cannot be attributed omits those rows entirely
+    Given the following "project" content:
+      | title                       | moderation_state | field_do_n_role      | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Unattributed project | published        | [TEST] Developer     | 2019            | ongoing           | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Unattributed project"
+    Then should see a ".ct-at-a-glance" element
+    And I should see 3 ".ct-at-a-glance__row" elements
+    And I should not see the text "Client"
+    And I should not see the text "Delivered at"
+    And I should not see the text "Live site"
+    # No value in the panel links anywhere, so an omitted row cannot leave a
+    # dangling link behind it.
+    And should not see a ".ct-at-a-glance__value a" element
+
+  @api
+  Scenario: Work that is no longer live is honest about it
+    Given the following "project" content:
+      | title                         | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Decommissioned project | published        | 2015            | decommissioned    | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Decommissioned project"
+    Then I should see the text "Status"
+    And I should see the text "Decommissioned"
+    And I should not see the text "Live site"
+
+  @api
+  Scenario: Open source contributions are listed
+    Given the following "project" content:
+      | title                       | moderation_state | field_do_n_oss_contributions:uri                                       | field_do_n_oss_contributions:title | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Contributing project | published        | https://github.com/drevops/vortex, https://github.com/drevops/behat-steps | [TEST] Vortex, [TEST] Behat Steps  | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Contributing project"
+    Then should see a ".ct-link-list" element
+    And I should see the text "Open source contributions"
+    And I should see the text "[TEST] Vortex"
+    And I should see the text "[TEST] Behat Steps"
+    And I should see 2 ".ct-link-list__items a" elements
+
+  @api
+  Scenario: A project with no contributions renders no contributions section
+    Given the following "project" content:
+      | title                          | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Non-contributing project | published       | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Non-contributing project"
+    Then should not see a ".ct-link-list" element
+    And I should not see the text "Open source contributions"
+
+  @api
+  Scenario: A project renders its table of contents and topic tags
+    Given the following "civictheme_topics" terms:
+      | name           |
+      | [TEST] Topic 1 |
+      | [TEST] Topic 2 |
+    And the following "project" content:
+      | title                 | moderation_state | field_c_n_topics               | field_c_n_hide_tags | field_c_n_show_toc | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Tagged project | published        | [TEST] Topic 1, [TEST] Topic 2 | 0                   | 1                  | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Tagged project"
+    Then should see a "[data-table-of-contents-anchor-selector]" element
+    And should see a ".ct-tag-list" element
+    And I should see the text "[TEST] Topic 1"
+    And I should see the text "[TEST] Topic 2"
+
+  @api
+  Scenario: A project with tags hidden and no table of contents renders neither
+    Given the following "civictheme_topics" terms:
+      | name           |
+      | [TEST] Topic 3 |
+    And the following "project" content:
+      | title                   | moderation_state | field_c_n_topics | field_c_n_hide_tags | field_c_n_show_toc | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Untagged project | published        | [TEST] Topic 3   | 1                   | 0                  | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "project" content page with the title "[TEST] Untagged project"
+    Then should not see a "[data-table-of-contents-anchor-selector]" element
+    And should not see a ".ct-tag-list" element
+    And I should not see the text "[TEST] Topic 3"
+
+  @api
+  Scenario: Project is selectable in an automated list
+    Given I am logged in as a user with the "Content Author" role
+    When I visit "node/add/civictheme_page"
+    And I press "Add Automated list"
+    Then I should see the text "Project"
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_list_content_type]'][value='project']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_list_content_type]'][value='all']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_list_content_type]'][value='civictheme_page']" element
+    And should see a "[name='field_c_n_components[0][subform][field_c_p_list_content_type]'][value='blog']" element
+
+  @api
+  Scenario: An automated list set to Project returns only projects
+    Given the following "project" content:
+      | title                   | moderation_state | field_c_n_summary          | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Listed project 1 | published        | [TEST] First project card  | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Listed project 2 | published        | [TEST] Second project card | 2024            | completed         | large                 | inherit                | normal                      | both                       |
+    And the following "civictheme_page" content:
+      | title                  | moderation_state | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Excluded page   | published        | large                 | inherit                | normal                      | both                       |
+      | [TEST] Project listing | published        | large                 | inherit                | normal                      | both                       |
+    And the following fields for the paragraph "civictheme_automated_list" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Project listing":
+      | field_c_p_list_content_type | project                           |
+      | field_c_p_list_type         | civictheme_automated_list__block1 |
+      | field_c_p_list_item_view_as | civictheme_promo_card             |
+      | field_c_p_list_item_theme   | light                             |
+      | field_c_p_list_limit_type   | unlimited                         |
+      | field_c_p_list_limit        | 9                                 |
+      | field_c_p_list_column_count | 3                                 |
+      | field_c_p_theme             | light                             |
+      | field_c_p_vertical_spacing  | bottom                            |
+    And I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] Project listing"
+    Then I should see the text "[TEST] Listed project 1"
+    And I should see the text "[TEST] First project card"
+    And I should see the text "[TEST] Listed project 2"
+    And I should not see the text "[TEST] Excluded page"
+
+  @api
+  Scenario: Existing content types are unaffected by the new bundle
+    Given the following "civictheme_page" content:
+      | title                | moderation_state | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Untouched page | published       | large                 | inherit                | normal                      | both                       |
+    And the following "blog" content:
+      | title                 | moderation_state | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Untouched post | published        | large                 | inherit                | normal                      | both                       |
+    And the following "civictheme_event" content:
+      | title                  | moderation_state | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Untouched event | published        | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] Untouched page"
+    Then I should see the text "[TEST] Untouched page"
+    And should not see a ".ct-at-a-glance" element
+    When I visit the "blog" content page with the title "[TEST] Untouched post"
+    Then the path should be "/blog/test-untouched-post"
+    And I should see the text "[TEST] Untouched post"
+    And should not see a ".ct-at-a-glance" element
+    When I visit the "civictheme_event" content page with the title "[TEST] Untouched event"
+    Then I should see the text "[TEST] Untouched event"
+    And should not see a ".ct-at-a-glance" element

--- a/tests/behat/features/xmlsitemap.feature
+++ b/tests/behat/features/xmlsitemap.feature
@@ -38,3 +38,16 @@ Feature: XML sitemap
     # pathauto pattern placing the post under "/blog".
     And the response should contain "blog/test-sitemap-indexed-post"
     And the response should not contain "sitemap-excluded-post"
+
+  @api @project
+  Scenario: Sitemap lists published projects only
+    Given the following "project" content:
+      | title                           | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Sitemap Indexed Project  | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Sitemap Excluded Project | draft            | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+    And I run drush "xmlsitemap:rebuild" "--yes"
+    And I am an anonymous user
+    When I go to "sitemap.xml"
+    Then the response status code should be 200
+    And the response should contain "projects/test-sitemap-indexed-project"
+    And the response should not contain "sitemap-excluded-project"

--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -437,6 +437,57 @@ function do_base_deploy_repoint_blog_lists(?array &$sandbox = NULL): ?string {
 }
 
 /**
+ * Seeds the Sector, Service and Technology vocabularies.
+ */
+function do_base_deploy_seed_project_vocabularies(): string {
+  $trees = [
+    'do_sector' => [
+      'Federal government',
+      'State government',
+      'Local government',
+      'Higher education',
+      'Health',
+      'Not-for-profit',
+      'Commercial',
+    ],
+    'do_service' => [
+      'Discovery and strategy',
+      'Architecture',
+      'Development',
+      'DevOps and hosting',
+      'Migration',
+      'UX and design',
+      'Accessibility',
+      'Support and maintenance',
+      'Training',
+    ],
+    'do_technology' => [
+      'Drupal',
+      'PHP',
+      'JavaScript',
+      'Docker',
+      'Kubernetes',
+      'AWS',
+      'Lagoon',
+      'Acquia Cloud',
+      'GitHub Actions',
+      'CircleCI',
+      'Terraform',
+      'Behat',
+      'PHPUnit',
+    ],
+  ];
+
+  foreach ($trees as $vocabulary => $tree) {
+    // These are a starting point rather than a closed set, so the default safe
+    // mode is used: terms an author adds later survive the next deployment.
+    Helper::term()->createTree($vocabulary, $tree);
+  }
+
+  return Helper::report();
+}
+
+/**
  * Loads the taxonomy term that defines which articles are blog articles.
  */
 function _do_base_blog_topic_term(): ?TermInterface {

--- a/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.component.yml
+++ b/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.component.yml
@@ -1,0 +1,65 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/11.x/core/modules/sdc/src/metadata.schema.json
+name: At a glance
+status: stable
+description: A panel of labelled facts, each value optionally linked.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: light
+    title:
+      type: string
+      title: Title
+      description: Heading shown above the facts.
+    rows:
+      type: array
+      title: Rows
+      description: Fact rows, each rendered as a label beside its values.
+      items:
+        type: object
+        properties:
+          label:
+            type: string
+            title: Label
+            description: Name of the fact.
+          values:
+            type: array
+            title: Values
+            description: One or more values for this fact.
+            items:
+              type: object
+              properties:
+                text:
+                  type: string
+                  title: Text
+                  description: Value shown to the reader.
+                url:
+                  type: [string, 'null']
+                  title: URL
+                  description: Address the value links to, when it links anywhere.
+                is_external:
+                  type: boolean
+                  title: External
+                  description: Whether the value links off this site.
+    vertical_spacing:
+      type: string
+      title: Vertical spacing
+      description: Controls vertical spacing (top, bottom, or both).
+      enum:
+        - top
+        - bottom
+        - both
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Additional HTML attributes
+      description: Additional HTML attributes to add to the component.
+    modifier_class:
+      type: string
+      title: Additional CSS classes
+      description: Additional CSS classes to add to the component.

--- a/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.scss
+++ b/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.scss
@@ -15,6 +15,10 @@
     border-radius: ct-particle(0.5);
     border-width: ct-particle(0.125);
     border-style: solid;
+
+    // Definition lists inherit no typography, so without this the facts render
+    // in the browser's default serif beside the theme's sans-serif prose.
+    font-family: var(--ct-typography-text-regular-font-name, sans-serif);
   }
 
   #{$root}__row {

--- a/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.scss
+++ b/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.scss
@@ -1,0 +1,63 @@
+//
+// At a glance component.
+//
+
+.ct-at-a-glance {
+  $root: &;
+
+  #{$root}__title {
+    margin: 0 0 ct-spacing(3);
+  }
+
+  #{$root}__rows {
+    margin: 0;
+    padding: ct-spacing(3);
+    border-radius: ct-particle(0.5);
+    border-width: ct-particle(0.125);
+    border-style: solid;
+  }
+
+  #{$root}__row {
+    display: flex;
+    flex-direction: column;
+    gap: ct-spacing(0.5);
+    padding: ct-spacing(1.5) 0;
+
+    &:first-child {
+      padding-top: 0;
+    }
+
+    &:last-child {
+      padding-bottom: 0;
+    }
+
+    @include ct-breakpoint(m) {
+      flex-direction: row;
+      gap: ct-spacing(2);
+    }
+  }
+
+  #{$root}__label {
+    font-weight: 700;
+    margin: 0;
+
+    @include ct-breakpoint(m) {
+      flex: 0 0 ct-particle(20);
+    }
+  }
+
+  #{$root}__value {
+    margin: 0;
+  }
+
+  @include ct-component-theme($root) using($root, $theme) {
+    #{$root}__rows {
+      background-color: if($theme == 'light', $ct-at-a-glance-light-background-color, $ct-at-a-glance-dark-background-color);
+      border-color: if($theme == 'light', $ct-at-a-glance-light-border-color, $ct-at-a-glance-dark-border-color);
+    }
+
+    #{$root}__label {
+      color: if($theme == 'light', $ct-at-a-glance-light-label-color, $ct-at-a-glance-dark-label-color);
+    }
+  }
+}

--- a/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.stories.js
+++ b/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.stories.js
@@ -17,7 +17,7 @@ const meta = {
     },
     vertical_spacing: {
       control: { type: 'radio' },
-      options: ['none', 'top', 'bottom', 'both'],
+      options: ['top', 'bottom', 'both'],
     },
     modifier_class: {
       control: { type: 'text' },

--- a/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.stories.js
+++ b/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.stories.js
@@ -1,0 +1,67 @@
+// phpcs:ignoreFile
+import Component from './at-a-glance.twig';
+
+const meta = {
+  title: 'Molecules/At a glance',
+  component: Component,
+  argTypes: {
+    theme: {
+      control: { type: 'radio' },
+      options: ['light', 'dark'],
+    },
+    title: {
+      control: { type: 'text' },
+    },
+    rows: {
+      control: { type: 'object' },
+    },
+    vertical_spacing: {
+      control: { type: 'radio' },
+      options: ['none', 'top', 'bottom', 'both'],
+    },
+    modifier_class: {
+      control: { type: 'text' },
+    },
+    attributes: {
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const AtAGlance = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    theme: 'light',
+    title: 'At a glance',
+    rows: [
+      { label: 'Client', values: [{ text: 'Department of Example' }] },
+      { label: 'Role', values: [{ text: 'Technical lead' }, { text: 'Architect' }] },
+      { label: 'Year', values: [{ text: '2025' }] },
+      { label: 'Status', values: [{ text: 'Completed' }] },
+      { label: 'Live site', values: [{ text: 'www.example.com', url: 'https://www.example.com', is_external: true }] },
+      { label: 'Sector', values: [{ text: 'Federal government', url: '/taxonomy/term/1' }] },
+      { label: 'Technologies', values: [{ text: 'Drupal', url: '/taxonomy/term/2' }, { text: 'Docker', url: '/taxonomy/term/3' }] },
+    ],
+    vertical_spacing: 'both',
+    modifier_class: '',
+    attributes: '',
+  },
+};
+
+export const WithMissingFacts = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    ...AtAGlance.args,
+    rows: [
+      { label: 'Role', values: [{ text: 'Technical lead' }] },
+      { label: 'Year', values: [{ text: '2019' }] },
+      { label: 'Status', values: [{ text: 'Decommissioned' }] },
+    ],
+  },
+};

--- a/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.twig
+++ b/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.twig
@@ -18,16 +18,16 @@
  */
 #}
 
-{% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
+{% set vertical_spacing_class = vertical_spacing is defined and vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s %s'|format(theme_class, vertical_spacing_class, modifier_class|default('')) %}
 
-{% if rows is not empty %}
+{% if rows is defined and rows is not empty %}
   <div class="ct-at-a-glance {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     <div class="container">
       <div class="row">
         <div class="col-xxs-12">
-          {% if title %}
+          {% if title is defined and title %}
             {{ include('civictheme:heading', {
               content: title,
               level: 2,
@@ -44,7 +44,7 @@
                   {% set values = [] %}
                   {% for value in row.values %}
                     {% set rendered %}
-                      {% if value.url %}
+                      {% if value.url is defined and value.url %}
                         {{ include('civictheme:link', {
                           text: value.text,
                           url: value.url,

--- a/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.twig
+++ b/web/themes/custom/drevops/components/02-molecules/at-a-glance/at-a-glance.twig
@@ -1,0 +1,74 @@
+{#
+/**
+ * @file
+ * At a glance component.
+ *
+ * Variables:
+ * - theme: [string] Theme: light, dark.
+ * - title: [string] Heading shown above the facts.
+ * - rows: [array] Fact rows:
+ *   - label: [string] Name of the fact.
+ *   - values: [array] Values for this fact:
+ *     - text: [string] Value shown to the reader.
+ *     - url: [string] Address the value links to, when it links anywhere.
+ *     - is_external: [boolean] Whether the value links off this site.
+ * - vertical_spacing: [string] With top, bottom or both vertical spaces.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ */
+#}
+
+{% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set modifier_class = '%s %s %s'|format(theme_class, vertical_spacing_class, modifier_class|default('')) %}
+
+{% if rows is not empty %}
+  <div class="ct-at-a-glance {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="container">
+      <div class="row">
+        <div class="col-xxs-12">
+          {% if title %}
+            {{ include('civictheme:heading', {
+              content: title,
+              level: 2,
+              theme: theme,
+              modifier_class: 'ct-at-a-glance__title',
+            }, with_context: false) }}
+          {% endif %}
+
+          <dl class="ct-at-a-glance__rows">
+            {% for row in rows %}
+              <div class="ct-at-a-glance__row">
+                <dt class="ct-at-a-glance__label">{{ row.label }}</dt>
+                <dd class="ct-at-a-glance__value">
+                  {% set values = [] %}
+                  {% for value in row.values %}
+                    {% set rendered %}
+                      {% if value.url %}
+                        {{ include('civictheme:link', {
+                          text: value.text,
+                          url: value.url,
+                          theme: theme,
+                          is_external: value.is_external|default(false),
+                        }, with_context: false) }}
+                      {% else %}
+                        {{ value.text }}
+                      {% endif %}
+                    {% endset %}
+                    {% set values = values|merge([rendered]) %}
+                  {% endfor %}
+
+                  {{ include('civictheme:item-list', {
+                    direction: 'horizontal',
+                    items: values,
+                    modifier_class: 'ct-at-a-glance__values',
+                  }, with_context: false) }}
+                </dd>
+              </div>
+            {% endfor %}
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/components/02-molecules/link-list/link-list.component.yml
+++ b/web/themes/custom/drevops/components/02-molecules/link-list/link-list.component.yml
@@ -1,0 +1,54 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/11.x/core/modules/sdc/src/metadata.schema.json
+name: Link list
+status: stable
+description: A titled list of links.
+props:
+  type: object
+  properties:
+    theme:
+      type: string
+      title: Theme
+      description: Theme variation (light or dark).
+      enum:
+        - light
+        - dark
+      default: light
+    title:
+      type: string
+      title: Title
+      description: Heading shown above the list.
+    links:
+      type: array
+      title: Links
+      description: Links rendered in order.
+      items:
+        type: object
+        properties:
+          text:
+            type: string
+            title: Text
+            description: Link text.
+          url:
+            type: string
+            title: URL
+            description: Link address.
+          is_external:
+            type: boolean
+            title: External
+            description: Whether the link points off this site.
+    vertical_spacing:
+      type: string
+      title: Vertical spacing
+      description: Controls vertical spacing (top, bottom, or both).
+      enum:
+        - top
+        - bottom
+        - both
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Additional HTML attributes
+      description: Additional HTML attributes to add to the component.
+    modifier_class:
+      type: string
+      title: Additional CSS classes
+      description: Additional CSS classes to add to the component.

--- a/web/themes/custom/drevops/components/02-molecules/link-list/link-list.scss
+++ b/web/themes/custom/drevops/components/02-molecules/link-list/link-list.scss
@@ -1,0 +1,15 @@
+//
+// Link list component.
+//
+
+.ct-link-list {
+  $root: &;
+
+  #{$root}__title {
+    margin: 0 0 ct-spacing(2);
+  }
+
+  #{$root}__items {
+    margin: 0;
+  }
+}

--- a/web/themes/custom/drevops/components/02-molecules/link-list/link-list.stories.js
+++ b/web/themes/custom/drevops/components/02-molecules/link-list/link-list.stories.js
@@ -17,7 +17,7 @@ const meta = {
     },
     vertical_spacing: {
       control: { type: 'radio' },
-      options: ['none', 'top', 'bottom', 'both'],
+      options: ['top', 'bottom', 'both'],
     },
     modifier_class: {
       control: { type: 'text' },

--- a/web/themes/custom/drevops/components/02-molecules/link-list/link-list.stories.js
+++ b/web/themes/custom/drevops/components/02-molecules/link-list/link-list.stories.js
@@ -1,0 +1,49 @@
+// phpcs:ignoreFile
+import Component from './link-list.twig';
+
+const meta = {
+  title: 'Molecules/Link list',
+  component: Component,
+  argTypes: {
+    theme: {
+      control: { type: 'radio' },
+      options: ['light', 'dark'],
+    },
+    title: {
+      control: { type: 'text' },
+    },
+    links: {
+      control: { type: 'object' },
+    },
+    vertical_spacing: {
+      control: { type: 'radio' },
+      options: ['none', 'top', 'bottom', 'both'],
+    },
+    modifier_class: {
+      control: { type: 'text' },
+    },
+    attributes: {
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+export const LinkList = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    theme: 'light',
+    title: 'Open source contributions',
+    links: [
+      { text: 'Vortex', url: 'https://github.com/drevops/vortex', is_external: true },
+      { text: 'Behat Steps', url: 'https://github.com/drevops/behat-steps', is_external: true },
+      { text: 'Issue 1234567: Fix the thing', url: 'https://www.drupal.org/project/drupal/issues/1234567', is_external: true },
+    ],
+    vertical_spacing: 'both',
+    modifier_class: '',
+    attributes: '',
+  },
+};

--- a/web/themes/custom/drevops/components/02-molecules/link-list/link-list.twig
+++ b/web/themes/custom/drevops/components/02-molecules/link-list/link-list.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Link list component.
+ *
+ * Variables:
+ * - theme: [string] Theme: light, dark.
+ * - title: [string] Heading shown above the list.
+ * - links: [array] Links:
+ *   - text: [string] Link text.
+ *   - url: [string] Link address.
+ *   - is_external: [boolean] Whether the link points off this site.
+ * - vertical_spacing: [string] With top, bottom or both vertical spaces.
+ * - attributes: [Drupal\Core\Template\Attribute] Additional attributes.
+ * - modifier_class: [string] Additional classes.
+ */
+#}
+
+{% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
+{% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
+{% set modifier_class = '%s %s %s'|format(theme_class, vertical_spacing_class, modifier_class|default('')) %}
+
+{% if links is not empty %}
+  <div class="ct-link-list {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
+    <div class="container">
+      <div class="row">
+        <div class="col-xxs-12">
+          {% if title %}
+            {{ include('civictheme:heading', {
+              content: title,
+              level: 2,
+              theme: theme,
+              modifier_class: 'ct-link-list__title',
+            }, with_context: false) }}
+          {% endif %}
+
+          {% set items = [] %}
+          {% for link in links %}
+            {% set item %}
+              {{ include('civictheme:link', {
+                text: link.text,
+                url: link.url,
+                theme: theme,
+                is_external: link.is_external|default(false),
+              }, with_context: false) }}
+            {% endset %}
+            {% set items = items|merge([item]) %}
+          {% endfor %}
+
+          {{ include('civictheme:item-list', {
+            direction: 'vertical',
+            items: items,
+            modifier_class: 'ct-link-list__items',
+          }, with_context: false) }}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/web/themes/custom/drevops/components/02-molecules/link-list/link-list.twig
+++ b/web/themes/custom/drevops/components/02-molecules/link-list/link-list.twig
@@ -16,16 +16,16 @@
  */
 #}
 
-{% set vertical_spacing_class = vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
+{% set vertical_spacing_class = vertical_spacing is defined and vertical_spacing in ['top', 'bottom', 'both'] ? 'ct-vertical-spacing-inset--%s'|format(vertical_spacing) : '' %}
 {% set theme_class = 'ct-theme-%s'|format(theme|default('light')) %}
 {% set modifier_class = '%s %s %s'|format(theme_class, vertical_spacing_class, modifier_class|default('')) %}
 
-{% if links is not empty %}
+{% if links is defined and links is not empty %}
   <div class="ct-link-list {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
     <div class="container">
       <div class="row">
         <div class="col-xxs-12">
-          {% if title %}
+          {% if title is defined and title %}
             {{ include('civictheme:heading', {
               content: title,
               level: 2,

--- a/web/themes/custom/drevops/components/variables.components.scss
+++ b/web/themes/custom/drevops/components/variables.components.scss
@@ -140,3 +140,13 @@ $ct-steps-light-receive-background-color: ct-color-light('background') !default;
 $ct-steps-dark-receive-background-color: ct-color-dark('background-light') !default;
 $ct-steps-light-receive-border-color: ct-color-light('highlight') !default;
 $ct-steps-dark-receive-border-color: ct-color-dark('highlight') !default;
+
+//
+// At a glance.
+//
+$ct-at-a-glance-light-background-color: ct-color-light('background-light') !default;
+$ct-at-a-glance-dark-background-color: ct-color-dark('background-light') !default;
+$ct-at-a-glance-light-border-color: rgba(ct-color-light('highlight'), 0.35) !default;
+$ct-at-a-glance-dark-border-color: rgba(ct-color-dark('highlight'), 0.35) !default;
+$ct-at-a-glance-light-label-color: ct-color-light('heading') !default;
+$ct-at-a-glance-dark-label-color: ct-color-dark('heading') !default;

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -18,6 +18,7 @@ require_once __DIR__ . '/includes/steps.inc';
 require_once __DIR__ . '/includes/page.inc';
 require_once __DIR__ . '/includes/node.inc';
 require_once __DIR__ . '/includes/blog.inc';
+require_once __DIR__ . '/includes/project.inc';
 require_once __DIR__ . '/includes/cards.inc';
 require_once __DIR__ . '/includes/sidebar_navigation.inc';
 require_once __DIR__ . '/includes/content_moderation.inc';

--- a/web/themes/custom/drevops/includes/blog.inc
+++ b/web/themes/custom/drevops/includes/blog.inc
@@ -27,29 +27,6 @@ function _civictheme_preprocess_node__blog__full(array &$variables): void {
   // in place would repeat it on revision pages.
   unset($variables['label']);
 
-  if (civictheme_get_field_value($node, 'field_c_n_show_toc')) {
-    array_unshift($variables['content'], [
-      '#theme' => 'civictheme_table_of_contents',
-      '#position' => 'prepend',
-      '#anchor_selector' => 'h2',
-      '#title' => t('On this page'),
-      '#scope_selector' => '.ct-layout__main',
-    ]);
-  }
-
-  if (civictheme_get_field_value($node, 'field_c_n_hide_tags')) {
-    return;
-  }
-
-  $topics = civictheme_get_referenced_entity_labels($node, 'field_c_n_topics', $variables);
-
-  if (empty($topics)) {
-    return;
-  }
-
-  $variables['content'][] = [
-    '#theme' => 'civictheme_tag_list',
-    '#tags' => array_map(static fn($label): array => ['content' => (string) $label], $topics),
-    '#vertical_spacing' => 'both',
-  ];
+  _drevops_node_add_table_of_contents($node, $variables);
+  _drevops_node_add_topic_tags($node, $variables);
 }

--- a/web/themes/custom/drevops/includes/node.inc
+++ b/web/themes/custom/drevops/includes/node.inc
@@ -7,6 +7,46 @@
 
 declare(strict_types=1);
 
+use Drupal\node\NodeInterface;
+
+/**
+ * Prepends the table of contents to a node's full-view content.
+ */
+function _drevops_node_add_table_of_contents(NodeInterface $node, array &$variables): void {
+  if (!civictheme_get_field_value($node, 'field_c_n_show_toc')) {
+    return;
+  }
+
+  array_unshift($variables['content'], [
+    '#theme' => 'civictheme_table_of_contents',
+    '#position' => 'prepend',
+    '#anchor_selector' => 'h2',
+    '#title' => t('On this page'),
+    '#scope_selector' => '.ct-layout__main',
+  ]);
+}
+
+/**
+ * Appends the topic tag list to a node's full-view content.
+ */
+function _drevops_node_add_topic_tags(NodeInterface $node, array &$variables): void {
+  if (civictheme_get_field_value($node, 'field_c_n_hide_tags')) {
+    return;
+  }
+
+  $topics = civictheme_get_referenced_entity_labels($node, 'field_c_n_topics', $variables);
+
+  if (empty($topics)) {
+    return;
+  }
+
+  $variables['content'][] = [
+    '#theme' => 'civictheme_tag_list',
+    '#tags' => array_map(static fn($label): array => ['content' => (string) $label], $topics),
+    '#vertical_spacing' => 'both',
+  ];
+}
+
 /**
  * Implements template_preprocess_node().
  */

--- a/web/themes/custom/drevops/includes/node.inc
+++ b/web/themes/custom/drevops/includes/node.inc
@@ -23,6 +23,9 @@ function _drevops_node_add_table_of_contents(NodeInterface $node, array &$variab
     '#anchor_selector' => 'h2',
     '#title' => t('On this page'),
     '#scope_selector' => '.ct-layout__main',
+    // The renderer orders children by weight, so position in the array alone
+    // does not survive alongside the display's own weighted fields.
+    '#weight' => -100,
   ]);
 }
 
@@ -44,6 +47,7 @@ function _drevops_node_add_topic_tags(NodeInterface $node, array &$variables): v
     '#theme' => 'civictheme_tag_list',
     '#tags' => array_map(static fn($label): array => ['content' => (string) $label], $topics),
     '#vertical_spacing' => 'both',
+    '#weight' => 100,
   ];
 }
 

--- a/web/themes/custom/drevops/includes/project.inc
+++ b/web/themes/custom/drevops/includes/project.inc
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * @file
+ * Project node functions.
+ */
+
+declare(strict_types=1);
+
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Pre-process Project nodes.
+ *
+ * CivicTheme resolves full-view node preprocessing by bundle name, calling
+ * `_civictheme_preprocess_node__<bundle>__full()` when such a function exists,
+ * so each content type owns its own full-view theming.
+ */
+function _civictheme_preprocess_node__project__full(array &$variables): void {
+  $node = $variables['node'] ?? NULL;
+
+  if (!$node instanceof NodeInterface) {
+    return;
+  }
+
+  // The page title is rendered by the page template, so leaving the node label
+  // in place would repeat it on revision pages.
+  unset($variables['label']);
+
+  // Each of these places itself relative to the narrative components, so the
+  // call order is the reverse of the order the sections appear in.
+  _drevops_project_add_contributions($node, $variables);
+  _drevops_node_add_topic_tags($node, $variables);
+  _drevops_project_add_at_a_glance($node, $variables);
+  _drevops_node_add_table_of_contents($node, $variables);
+}
+
+/**
+ * Prepends the "At a glance" panel to a project's content.
+ */
+function _drevops_project_add_at_a_glance(NodeInterface $node, array &$variables): void {
+  $rows = _drevops_project_at_a_glance_rows($node, $variables);
+
+  if ($rows === []) {
+    return;
+  }
+
+  array_unshift($variables['content'], [
+    '#type' => 'component',
+    '#component' => 'drevops:at-a-glance',
+    '#props' => [
+      'title' => (string) t('At a glance'),
+      'rows' => $rows,
+      'vertical_spacing' => 'both',
+    ],
+  ]);
+}
+
+/**
+ * Appends the open source contributions list to a project's content.
+ */
+function _drevops_project_add_contributions(NodeInterface $node, array &$variables): void {
+  $links = _drevops_project_link_values($node, 'field_do_n_oss_contributions');
+
+  if ($links === []) {
+    return;
+  }
+
+  $variables['content'][] = [
+    '#type' => 'component',
+    '#component' => 'drevops:link-list',
+    '#props' => [
+      'title' => (string) t('Open source contributions'),
+      'links' => $links,
+      'vertical_spacing' => 'both',
+    ],
+  ];
+}
+
+/**
+ * Builds the label and value rows of the "At a glance" panel.
+ *
+ * A row whose field holds no value is left out entirely, so a project that
+ * cannot name its client or its live site renders no empty label.
+ */
+function _drevops_project_at_a_glance_rows(NodeInterface $node, array &$variables): array {
+  $fields = [
+    'field_do_n_client' => ['label' => t('Client'), 'resolver' => 'scalar'],
+    'field_do_n_role' => ['label' => t('Role'), 'resolver' => 'scalar'],
+    'field_do_n_delivered_at' => ['label' => t('Delivered at'), 'resolver' => 'scalar'],
+    'field_do_n_year' => ['label' => t('Year'), 'resolver' => 'scalar'],
+    'field_do_n_status' => ['label' => t('Status'), 'resolver' => 'list'],
+    'field_do_n_live_url' => ['label' => t('Live site'), 'resolver' => 'link'],
+    'field_do_n_sector' => ['label' => t('Sector'), 'resolver' => 'terms'],
+    'field_do_n_services' => ['label' => t('Services'), 'resolver' => 'terms'],
+    'field_do_n_technologies' => ['label' => t('Technologies'), 'resolver' => 'terms'],
+  ];
+
+  $rows = [];
+
+  foreach ($fields as $field_name => $info) {
+    if (!$node->hasField($field_name)) {
+      continue;
+    }
+
+    $values = match ($info['resolver']) {
+      'scalar' => _drevops_project_scalar_values($node, $field_name),
+      'list' => _drevops_project_list_values($node, $field_name),
+      'link' => _drevops_project_link_values($node, $field_name),
+      'terms' => _drevops_project_term_values($node, $field_name, $variables),
+    };
+
+    if ($values === []) {
+      continue;
+    }
+
+    $rows[] = ['label' => (string) $info['label'], 'values' => $values];
+  }
+
+  return $rows;
+}
+
+/**
+ * Resolves the plain text values held by a field.
+ */
+function _drevops_project_scalar_values(NodeInterface $node, string $field_name): array {
+  $values = [];
+
+  foreach ($node->get($field_name) as $item) {
+    $text = trim((string) $item->value);
+
+    if ($text === '') {
+      continue;
+    }
+
+    $values[] = ['text' => $text];
+  }
+
+  return $values;
+}
+
+/**
+ * Resolves the human-readable labels behind a list field's stored keys.
+ */
+function _drevops_project_list_values(NodeInterface $node, string $field_name): array {
+  $field = $node->get($field_name);
+  $allowed = options_allowed_values($field->getFieldDefinition()->getFieldStorageDefinition(), $node);
+  $values = [];
+
+  foreach ($field as $item) {
+    $key = (string) $item->value;
+
+    if ($key === '') {
+      continue;
+    }
+
+    $values[] = ['text' => (string) ($allowed[$key] ?? $key)];
+  }
+
+  return $values;
+}
+
+/**
+ * Resolves the links held by a link field.
+ */
+function _drevops_project_link_values(NodeInterface $node, string $field_name): array {
+  $values = [];
+
+  foreach ($node->get($field_name) as $item) {
+    if (trim((string) $item->uri) === '') {
+      continue;
+    }
+
+    $url = $item->getUrl();
+    $address = $url->toString();
+    $text = trim((string) $item->title);
+
+    $values[] = [
+      'text' => $text !== '' ? $text : $address,
+      'url' => $address,
+      'is_external' => $url->isExternal(),
+    ];
+  }
+
+  return $values;
+}
+
+/**
+ * Resolves the terms referenced by a field as links to their term pages.
+ */
+function _drevops_project_term_values(NodeInterface $node, string $field_name, array &$variables): array {
+  $values = [];
+
+  // The CivicTheme helper drops terms the reader cannot view and records each
+  // one as a cacheable dependency, so a renamed term cannot serve a stale
+  // label from the node's render cache.
+  foreach (civictheme_get_field_referenced_entities($node, $field_name, $variables) as $term) {
+    if (!$term instanceof TermInterface) {
+      continue;
+    }
+
+    $values[] = [
+      'text' => (string) $term->label(),
+      'url' => $term->toUrl()->toString(),
+    ];
+  }
+
+  return $values;
+}

--- a/web/themes/custom/drevops/includes/project.inc
+++ b/web/themes/custom/drevops/includes/project.inc
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 
@@ -127,8 +128,10 @@ function _drevops_project_at_a_glance_rows(NodeInterface $node, array &$variable
 function _drevops_project_scalar_values(NodeInterface $node, string $field_name): array {
   $values = [];
 
-  foreach ($node->get($field_name) as $item) {
-    $text = trim((string) $item->value);
+  // Reading the raw values keeps one resolver serving both the string fields
+  // and the integer year, which share no field-item type.
+  foreach ($node->get($field_name)->getValue() as $item) {
+    $text = trim((string) ($item['value'] ?? ''));
 
     if ($text === '') {
       continue;
@@ -148,8 +151,8 @@ function _drevops_project_list_values(NodeInterface $node, string $field_name): 
   $allowed = options_allowed_values($field->getFieldDefinition()->getFieldStorageDefinition(), $node);
   $values = [];
 
-  foreach ($field as $item) {
-    $key = (string) $item->value;
+  foreach ($field->getValue() as $item) {
+    $key = (string) ($item['value'] ?? '');
 
     if ($key === '') {
       continue;
@@ -167,14 +170,16 @@ function _drevops_project_list_values(NodeInterface $node, string $field_name): 
 function _drevops_project_link_values(NodeInterface $node, string $field_name): array {
   $values = [];
 
-  foreach ($node->get($field_name) as $item) {
-    if (trim((string) $item->uri) === '') {
+  foreach ($node->get($field_name)->getValue() as $item) {
+    $uri = trim((string) ($item['uri'] ?? ''));
+
+    if ($uri === '') {
       continue;
     }
 
-    $url = $item->getUrl();
+    $url = Url::fromUri($uri);
     $address = $url->toString();
-    $text = trim((string) $item->title);
+    $text = trim((string) ($item['title'] ?? ''));
 
     $values[] = [
       'text' => $text !== '' ? $text : $address,

--- a/web/themes/custom/drevops/includes/project.inc
+++ b/web/themes/custom/drevops/includes/project.inc
@@ -29,8 +29,8 @@ function _civictheme_preprocess_node__project__full(array &$variables): void {
   // in place would repeat it on revision pages.
   unset($variables['label']);
 
-  // Each of these places itself relative to the narrative components, so the
-  // call order is the reverse of the order the sections appear in.
+  // Each of these carries its own render weight, so the call order here does
+  // not decide where the section ends up on the page.
   _drevops_project_add_contributions($node, $variables);
   _drevops_node_add_topic_tags($node, $variables);
   _drevops_project_add_at_a_glance($node, $variables);
@@ -55,6 +55,7 @@ function _drevops_project_add_at_a_glance(NodeInterface $node, array &$variables
       'rows' => $rows,
       'vertical_spacing' => 'both',
     ],
+    '#weight' => -90,
   ]);
 }
 
@@ -76,6 +77,7 @@ function _drevops_project_add_contributions(NodeInterface $node, array &$variabl
       'links' => $links,
       'vertical_spacing' => 'both',
     ],
+    '#weight' => 90,
   ];
 }
 


### PR DESCRIPTION
Closes #273

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added a `project` content type cloned from the `civictheme_page` bundle, so the two stay interchangeable and no field data can be orphaned if content is ever moved between them.
2. Added three taxonomy vocabularies, `do_sector`, `do_service` and `do_technology`, seeded with a starting term tree by a deploy hook that calls `Helper::term()->createTree()` in its default safe mode, so authored terms survive later deployments.
3. Added ten bundle-specific fields prefixed `field_do_n_`: `client`, `role`, `delivered_at`, `year`, `status`, `live_url`, `oss_contributions`, `sector`, `services` and `technologies`. `year` and `status` are required, since sorting and honest presentation both depend on them; `year` is bounded to `1`-`9999` so an impossible value cannot be saved and rendered publicly.
4. Added two Single Directory Components in the `drevops` theme: `at-a-glance`, a labelled facts panel with optional linked values, and `link-list`, a titled list of links.
5. Added `includes/project.inc` with the full-view preprocessor for the `project` bundle, which builds the "At a glance" panel and the open source contributions list, omitting any row or section whose field is empty and linking taxonomy values to their term pages. Its resolvers read field values through `getValue()` rather than typed field-item properties, since `_drevops_project_scalar_values()` serves both string fields and the integer year field, which share no common field-item type.
6. Extracted the shared table of contents and topic tag render-array builders out of `blog.inc` into `node.inc` as `_drevops_node_add_table_of_contents()` and `_drevops_node_add_topic_tags()`, so both the `blog` and `project` bundles call the same implementation instead of each carrying its own copy.
7. Gave every injected section an explicit `#weight` (table of contents `-100`, At a glance `-90`, contributions `90`, topic tags `100`), so the order of the page is declared in the code rather than resting on the renderer's insertion-order tiebreak.
8. Resolved taxonomy values through `civictheme_get_field_referenced_entities()`, which drops terms the reader cannot view and registers each one as a cacheable dependency, so renaming a term cannot leave a stale label in the node's render cache.
9. Added supporting configuration: a pathauto pattern publishing projects at `/projects/[node:title]`, editorial workflow and permissions for the new bundle, xmlsitemap and metatag defaults, language settings, and `project` appended to the automated list's content type options so a Project listing can be built the same way as a Blog listing.
10. Added Behat coverage in `tests/behat/features/project_content_type.feature` (19 scenarios) plus a sitemap scenario confirming published projects are indexed and drafts are not. The scenarios assert theme-layer output rather than configuration alone, including both states of the table of contents and tag toggles, and the empty-field case where a project that cannot name its client renders no empty label and no dangling link.
11. Updated `docs/content-types.md` and `docs/sitemap.md` to document the new bundle, including a note on how fields that are not shared with Page get rendered from the preprocessor rather than the view display.

## Screenshots

![Project page with the At a glance panel](https://raw.githubusercontent.com/drevops/website/9c1ac617d4e06acc4b8f662b6665d5737b91f328/feature-273-project-content-type/f3fe82d7ebf041b93f2d58f20e95d9d477dabf5e.png)

## Before / After

```
BEFORE                              AFTER
+----------------------------+      +----------------------------+
| Page / Blog                |      | Page / Blog / Project      |
|                            |      |                            |
| No structured way to       |      | +------------------------+ |
| showcase delivered work.   |      | | At a glance            | |
|                            |      | | Client   ...           | |
|                            |      | | Role     ...           | |
|                            |      | | Status   ...           | |
|                            |      | | Sector   ... (linked)  | |
|                            |      | +------------------------+ |
|                            |      | | Narrative components   | |
|                            |      | +------------------------+ |
|                            |      | | Open source            | |
|                            |      | | contributions          | |
|                            |      | +------------------------+ |
+----------------------------+      +----------------------------+

Empty fields omit their row entirely, so unattributable work
still renders cleanly:

+----------------------------+
| At a glance                |
| Role     Developer         |
| Year     2019              |
| Status   Decommissioned    |
+----------------------------+
  (no Client, no Delivered at, no Live site row, no link)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Project content type with structured project details, banner options, components, metadata, taxonomy, moderation, and revision support.
  * Added project presentation modes, canonical project URLs, sitemap inclusion, and seeded Sector, Service, and Technology classifications.
  * Added “At a glance” and link-list components, including responsive styling and Storybook examples.
  * Project pages now display key facts, contributions, topic tags, and table of contents.
* **Documentation**
  * Documented Project content and sitemap behavior.
* **Tests**
  * Added coverage for project creation, rendering, access, workflows, URLs, and sitemap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
