### PR TITLE
[#277] Styled the built-in error pages in the site design.

### DIFF
--- a/tests/behat/features/error_pages.feature
+++ b/tests/behat/features/error_pages.feature
@@ -38,6 +38,7 @@ Feature: Built-in error pages
     And I should see a ".ct-page.ct-theme-dark" element
     And I should see "The requested page could not be found." in the ".ct-layout__main .ct-basic-content.ct-theme-dark" element
     And I should see "Return to homepage" in the ".ct-layout__main .ct-button--primary" element
+    And I should not see a ".ct-layout__sidebar_top_left" element
 
   @api
   Scenario: Pages that are not error pages keep the light page background

--- a/tests/behat/features/error_pages.feature
+++ b/tests/behat/features/error_pages.feature
@@ -45,7 +45,10 @@ Feature: Built-in error pages
     Then the response status code should be 404
     And I should see a ".ct-page.ct-theme-light" element
     And I should see "The requested page could not be found." in the ".ct-layout__main .ct-basic-content.ct-theme-dark.ct-basic-content--with-background" element
+    And I should see a ".ct-layout__inner.container-fluid" element
+    And I should not see a ".ct-layout__inner.container" element
     And I should see "Return to homepage" in the ".ct-layout__main .ct-button--primary" element
+    And the element ".ct-layout__main .ct-button--primary" with the attribute "href" and the value "/" should exist
     And I should not see a ".ct-layout__sidebar_top_left" element
 
   # The error page treatment hides the sidebars and releases the layout from

--- a/tests/behat/features/error_pages.feature
+++ b/tests/behat/features/error_pages.feature
@@ -1,0 +1,48 @@
+@p1 @drevops @errorpages
+Feature: Built-in error pages
+
+  As a site visitor
+  I want an error page to look like the rest of the site and offer me a way out
+  So that I can tell I am still on DrevOps and carry on browsing
+
+  # Drupal answers these routes with a bare sentence and no wrapper of its own,
+  # which lands on the light page background in the browser's default font. The
+  # theme dresses that sentence in the site's dark palette and content styles.
+
+  @api
+  Scenario: Access denied renders in the site design
+    Given I am an anonymous user
+    When I visit "/admin"
+    Then the response status code should be 403
+    And I should see a ".ct-page.ct-theme-dark" element
+    And I should see "You are not authorized to access this page." in the ".ct-layout__main .ct-basic-content.ct-theme-dark" element
+
+  @api
+  Scenario: Access denied offers a way back to the site
+    Given I am an anonymous user
+    When I visit "/admin"
+    Then I should see "Return to homepage" in the ".ct-layout__main .ct-button--primary" element
+    And the element ".ct-layout__main .ct-button--primary" with the attribute "href" and the value "/" should exist
+
+  @api
+  Scenario: Access denied does not offer a menu of pages the visitor cannot reach
+    Given I am an anonymous user
+    When I visit "/admin"
+    Then I should not see a ".ct-layout__sidebar_top_left" element
+
+  @api
+  Scenario: Page not found renders in the site design
+    Given I am an anonymous user
+    When I visit "/test-page-that-does-not-exist"
+    Then the response status code should be 404
+    And I should see a ".ct-page.ct-theme-dark" element
+    And I should see "The requested page could not be found." in the ".ct-layout__main .ct-basic-content.ct-theme-dark" element
+    And I should see "Return to homepage" in the ".ct-layout__main .ct-button--primary" element
+
+  @api
+  Scenario: Pages that are not error pages keep the light page background
+    Given I am an anonymous user
+    When I go to the homepage
+    Then the response status code should be 200
+    And I should see a ".ct-page.ct-theme-light" element
+    And I should not see a ".ct-page.ct-theme-dark" element

--- a/tests/behat/features/error_pages.feature
+++ b/tests/behat/features/error_pages.feature
@@ -7,15 +7,23 @@ Feature: Built-in error pages
 
   # Drupal answers these routes with a bare sentence and no wrapper of its own,
   # which lands on the light page background in the browser's default font. The
-  # theme dresses that sentence in the site's dark palette and content styles.
+  # theme wraps that sentence in a dark, full-width content band, the same way
+  # every other band on the site is painted over the light page.
 
   @api
   Scenario: Access denied renders in the site design
     Given I am an anonymous user
     When I visit "/admin"
     Then the response status code should be 403
-    And I should see a ".ct-page.ct-theme-dark" element
-    And I should see "You are not authorized to access this page." in the ".ct-layout__main .ct-basic-content.ct-theme-dark" element
+    And I should see a ".ct-page.ct-theme-light" element
+    And I should see "You are not authorized to access this page." in the ".ct-layout__main .ct-basic-content.ct-theme-dark.ct-basic-content--with-background" element
+
+  @api
+  Scenario: The Access denied message band spans the full width of the page
+    Given I am an anonymous user
+    When I visit "/admin"
+    Then I should see a ".ct-layout__inner.container-fluid" element
+    And I should not see a ".ct-layout__inner.container" element
 
   @api
   Scenario: Access denied offers a way back to the site
@@ -35,15 +43,19 @@ Feature: Built-in error pages
     Given I am an anonymous user
     When I visit "/test-page-that-does-not-exist"
     Then the response status code should be 404
-    And I should see a ".ct-page.ct-theme-dark" element
-    And I should see "The requested page could not be found." in the ".ct-layout__main .ct-basic-content.ct-theme-dark" element
+    And I should see a ".ct-page.ct-theme-light" element
+    And I should see "The requested page could not be found." in the ".ct-layout__main .ct-basic-content.ct-theme-dark.ct-basic-content--with-background" element
     And I should see "Return to homepage" in the ".ct-layout__main .ct-button--primary" element
     And I should not see a ".ct-layout__sidebar_top_left" element
 
+  # The error page treatment hides the sidebars and releases the layout from
+  # its container. Both are page-level changes, so a page that is not an error
+  # page is the place to catch them leaking.
   @api
-  Scenario: Pages that are not error pages keep the light page background
+  Scenario: Pages that are not error pages keep their sidebar and contained layout
     Given I am an anonymous user
-    When I go to the homepage
+    When I go to "/about-us"
     Then the response status code should be 200
-    And I should see a ".ct-page.ct-theme-light" element
-    And I should not see a ".ct-page.ct-theme-dark" element
+    And I should see a ".ct-layout__sidebar_top_left" element
+    And I should see a ".ct-layout__inner.container" element
+    And I should not see a ".ct-layout__main .ct-basic-content--with-background" element

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -23,6 +23,7 @@ require_once __DIR__ . '/includes/cards.inc';
 require_once __DIR__ . '/includes/sidebar_navigation.inc';
 require_once __DIR__ . '/includes/content_moderation.inc';
 require_once __DIR__ . '/includes/admin_navigation.inc';
+require_once __DIR__ . '/includes/error_page.inc';
 
 /**
  * Adds a CSS class to a block wrapper.
@@ -70,6 +71,7 @@ function drevops_preprocess_civictheme_tag_list(array &$variables): void {
  */
 function drevops_preprocess_block(array &$variables): void {
   _drevops_preprocess_block__system_main_block($variables);
+  _drevops_preprocess_block__system_main_block__error($variables);
   _drevops_preprocess_block__civictheme_banner($variables);
   _drevops_preprocess_block__civictheme_banner__breadcrumb($variables);
   _drevops_preprocess_block__content_moderation_control($variables);
@@ -80,6 +82,7 @@ function drevops_preprocess_block(array &$variables): void {
  */
 function drevops_preprocess_page(array &$variables): void {
   _drevops_preprocess_page($variables);
+  _drevops_preprocess_page__error($variables);
 }
 
 /**

--- a/web/themes/custom/drevops/includes/error_page.inc
+++ b/web/themes/custom/drevops/includes/error_page.inc
@@ -35,15 +35,15 @@ function _drevops_preprocess_page__error(array &$variables): void {
     return;
   }
 
-  // Every band of this site is dark, and the light page background is only
-  // ever hidden by the components painted over it. An error page carries no
-  // such component, so it has to ask for the dark background itself.
-  $variables['theme'] = 'dark';
-
   // A reader who cannot reach the page they asked for is not served by a menu
   // of the pages they can.
   $variables['hide_sidebar_left'] = TRUE;
   $variables['hide_sidebar_right'] = TRUE;
+
+  // Releasing the region from the layout's container lets the message band
+  // carry its own, so its background reaches the edge of the viewport the way
+  // the bands above and below it do.
+  $variables['content_contained'] = FALSE;
 }
 
 /**
@@ -65,9 +65,7 @@ function _drevops_preprocess_block__system_main_block__error(array &$variables):
     '#component' => 'civictheme:basic-content',
     '#props' => [
       'theme' => 'dark',
-      // The layout region is already inside a container, so containing the
-      // message again would indent it past the rest of the page.
-      'is_contained' => FALSE,
+      'with_background' => TRUE,
       'vertical_spacing' => 'both',
     ],
     '#slots' => [

--- a/web/themes/custom/drevops/includes/error_page.inc
+++ b/web/themes/custom/drevops/includes/error_page.inc
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @file
+ * Built-in error page functions.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Url;
+
+/**
+ * Whether the current route serves Drupal's built-in 4xx page.
+ *
+ * Pointing "system.site" at a path for 403 or 404 routes the response through
+ * that path instead, so a site that provides its own error page never reaches
+ * these routes and keeps the theming of the page it points at.
+ */
+function _drevops_is_error_page(): bool {
+  $routes = [
+    'system.401',
+    'system.403',
+    'system.404',
+    'system.4xx',
+  ];
+
+  return in_array(\Drupal::routeMatch()->getRouteName(), $routes, TRUE);
+}
+
+/**
+ * Pre-process the page of a built-in error page.
+ */
+function _drevops_preprocess_page__error(array &$variables): void {
+  if (!_drevops_is_error_page()) {
+    return;
+  }
+
+  // Every band of this site is dark, and the light page background is only
+  // ever hidden by the components painted over it. An error page carries no
+  // such component, so it has to ask for the dark background itself.
+  $variables['theme'] = 'dark';
+
+  // A reader who cannot reach the page they asked for is not served by a menu
+  // of the pages they can.
+  $variables['hide_sidebar_left'] = TRUE;
+  $variables['hide_sidebar_right'] = TRUE;
+}
+
+/**
+ * Pre-process the main block of a built-in error page.
+ */
+function _drevops_preprocess_block__system_main_block__error(array &$variables): void {
+  if (($variables['elements']['#base_plugin_id'] ?? NULL) !== 'system_main_block') {
+    return;
+  }
+
+  if (!_drevops_is_error_page()) {
+    return;
+  }
+
+  $content = $variables['content'];
+
+  $variables['content'] = [
+    '#type' => 'component',
+    '#component' => 'civictheme:basic-content',
+    '#props' => [
+      'theme' => 'dark',
+      // The layout region is already inside a container, so containing the
+      // message again would indent it past the rest of the page.
+      'is_contained' => FALSE,
+      'vertical_spacing' => 'both',
+    ],
+    '#slots' => [
+      'content' => [
+        'message' => [
+          // Every one of the routes above answers with a single sentence, and
+          // the paragraph both marks it up as one and spaces it off the action
+          // below through the content styles.
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          'content' => $content,
+        ],
+        'action' => [
+          '#type' => 'component',
+          '#component' => 'civictheme:button',
+          '#props' => [
+            'theme' => 'dark',
+            'kind' => 'link',
+            'type' => 'primary',
+            'text' => (string) t('Return to homepage'),
+            'url' => Url::fromRoute('<front>')->toString(),
+          ],
+        ],
+      ],
+    ],
+  ];
+}


### PR DESCRIPTION
Closes #277

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

Drupal's built-in 4xx pages (`system.401`, `system.403`, `system.404`, `system.4xx`) rendered a bare sentence with no wrapper of their own: the message landed on the light `ct-page` background in the browser's default serif font (CivicTheme's `ct-text-regular` class never reaches the markup, because `_civictheme_preprocess_block__drupal()` snapshots `attributes` into `drupal_attributes` before `_civictheme_preprocess_block__system_main_block()` adds the class), and the primary-navigation sidebar rendered beside it. The fix covers all four routes rather than just 403, because they share the same controller and the same broken markup - scoping the check to 403 alone would mean deliberately excluding an identically broken page.

The page root stays `ct-theme-light`, exactly as on every other page of the site. The darkness comes from the content band painted over it, which is how the rest of the site composes: the banner above and the call-to-action band below are dark components on the same light page.

1. Added `web/themes/custom/drevops/includes/error_page.inc`. `_drevops_is_error_page()` gates the fix on the `system.401`, `system.403`, `system.404`, and `system.4xx` route names, so a site that points `system.site` at its own error path never reaches this code and keeps that path's own theming. `_drevops_preprocess_page__error()` hides both sidebars and releases the content region from the layout's container so the band can span the viewport. `_drevops_preprocess_block__system_main_block__error()` wraps the bare message in the `civictheme:basic-content` SDC (theme dark, with background, vertical spacing both) and appends a `civictheme:button` linking back to the front page.
2. Updated `web/themes/custom/drevops/drevops.theme` to require the new include and call the two preprocess functions from the existing `drevops_preprocess_page()` and `drevops_preprocess_block()` hooks.
3. Added `tests/behat/features/error_pages.feature`. The 403 and 404 scenarios assert the status code, the light page root, the message landing inside the dark full-width band, that the layout is released from its container, the "Return to homepage" button and its `href`, and the absent sidebar. A final scenario loads `/about-us` and asserts it keeps its sidebar and its contained layout and grows no message band - the two page-level levers this change pulls are exactly what could leak onto a normal page, so that is where they are caught.

Verified locally: the six Behat scenarios pass (`ahoy test-bdd -- --tags=@errorpages`), `ahoy lint` is clean, and `ahoy test-unit` passes. All four routes were checked in a browser at desktop and mobile widths, signed in and out. The message measures 10:1 contrast against the band and the button 6.4:1, both past WCAG AA. The homepage, `/blog`, `/about-us` and `/user/login` still render their own content with their own layout.

## Screenshots

![Access denied rendered as a full-width dark band on the light page](https://raw.githubusercontent.com/drevops/website/0de4a1fae2abb1accfb38e5d3aa30c85e318f88d/feature-277-style-403-page/fb42a775e325fe9b3e37e3cf99694ca87dbd1a27.png)

## Before / After

```
BEFORE                                        AFTER
┌──────────┬─────────────────────────┐        ┌────────────────────────────────────┐
│          │ ct-layout__inner        │        │ ct-layout__inner .container-fluid  │
│ Sidebar  │ .container              │        │ ┌────────────────────────────────┐ │
│ (primary │                         │        │ │ ct-basic-content               │ │
│  nav     │  You are not authorized │  ==>   │ │  .ct-theme-dark                │ │
│  menu)   │  to access this page.   │        │ │  --with-background             │ │
│          │  (default serif font)   │        │ │                                │ │
│          │                         │        │ │  You are not authorized to     │ │
│          │                         │        │ │  access this page.             │ │
│          │                         │        │ │  [ Return to homepage ]        │ │
│          │                         │        │ └────────────────────────────────┘ │
└──────────┴─────────────────────────┘        └────────────────────────────────────┘
        ct-page .ct-theme-light                       ct-page .ct-theme-light

The raw message string renders inside the      The page root is untouched. The message
layout's container with the sidebar beside     band paints its own dark background edge
it, in the browser's default font, with no     to edge - the same way the banner above
way back to the site.                          and the CTA band below already do.
```
