### PR TITLE
Added generated content for every content type and opened the authoring API to all of them.

### DIFF
--- a/config/default/user.role.do_content_api.yml
+++ b/config/default/user.role.do_content_api.yml
@@ -5,7 +5,11 @@ dependencies:
   config:
     - filter.format.civictheme_rich_text
     - media.type.civictheme_image
+    - node.type.blog
+    - node.type.civictheme_alert
+    - node.type.civictheme_event
     - node.type.civictheme_page
+    - node.type.project
     - workflows.workflow.civictheme_editorial
   module:
     - content_moderation
@@ -25,11 +29,19 @@ is_admin: false
 permissions:
   - 'access content'
   - 'administer redirects'
+  - 'create blog content'
+  - 'create civictheme_alert content'
+  - 'create civictheme_event content'
   - 'create civictheme_image media'
   - 'create civictheme_page content'
   - 'create media'
+  - 'create project content'
   - 'create url aliases'
+  - 'edit own blog content'
+  - 'edit own civictheme_alert content'
+  - 'edit own civictheme_event content'
   - 'edit own civictheme_page content'
+  - 'edit own project content'
   - 'issue subrequests'
   - 'use civictheme_editorial transition create_new_draft'
   - 'use civictheme_editorial transition needs_review'

--- a/docs/content-api.md
+++ b/docs/content-api.md
@@ -6,9 +6,9 @@ This document is the authoring contract: it describes the endpoints, the content
 
 ## Governance model (read this first)
 
-Pages created through the API are **never published automatically**. A human reviews and publishes them.
+Content created through the API is **never published automatically**. A human reviews and publishes it.
 
-- **Pages** (`civictheme_page` nodes) are always created as **draft**. The server forces this: even if a request asks for `published`, the page is coerced to `draft`.
+- **Nodes** of every content type are always created as **draft**. The server forces this: even if a request asks for `published`, the node is coerced to `draft`.
 - **Images** (`civictheme_image` media) are created **published** - they are assets, invisible until referenced by a published page. The server forces this too, so a client never has to set media moderation state.
 
 So the workflow is: the agent creates a draft page with published images, an editor reviews the draft, and when they publish the page it renders immediately because the images are already live.
@@ -21,7 +21,7 @@ Send the API key in the `api-key` request header on every request:
 api-key: <key>
 ```
 
-The key belongs to a dedicated, least-privilege service account (`do_content_api_service`) that may only create pages, images, and the supported components. Pages it authors are forced to draft by the moderation policy - a human publishes them.
+The key belongs to a dedicated, least-privilege service account (`do_content_api_service`) that may create and edit its own nodes of any content type, plus images and the supported components. It cannot delete anything, and cannot edit content authored by anyone else. Nodes it authors are forced to draft by the moderation policy - a human publishes them.
 
 Retrieve (or regenerate) the key as an administrator at `/user/<uid>/key-auth` for the service account, or have a developer read it from the account. Always send it over HTTPS. On deployed environments the `shield` module may sit in front of the site; the API path must be allow-listed there or the client must also supply the Shield credentials.
 
@@ -53,6 +53,10 @@ A page is a `civictheme_page` node whose `field_c_n_components` is an **ordered 
 | `moderation_state` | attribute | Always ends up `draft` (server-enforced). |
 | `field_c_n_components` | relationship (paragraphs) | Ordered list of component paragraphs. |
 | `field_c_n_summary` | attribute (string) | Optional teaser/summary. |
+
+### Other content types
+
+`blog`, `project`, `civictheme_event` and `civictheme_alert` are creatable at `/jsonapi/node/<bundle>` with the same authentication, draft policy and component model. Each carries its own fields on top of the shared ones above, and a bundle's required fields are enforced by entity validation: a request missing one comes back `422` naming the field, which is the quickest way to discover them. `project`, for example, requires `field_do_n_status` and `field_do_n_year`.
 
 ### Supported components (v1)
 

--- a/web/modules/custom/do_generated_content/do_generated_content.info.yml
+++ b/web/modules/custom/do_generated_content/do_generated_content.info.yml
@@ -4,4 +4,12 @@ description: 'Provides generated content for non-production environments.'
 package: DrevOps
 core_version_requirement: ^10.3 || ^11
 dependencies:
+  - drupal:content_moderation
+  - drupal:field
+  - drupal:media
+  - drupal:node
+  - drupal:taxonomy
   - generated_content:generated_content
+  - paragraphs:paragraphs
+  - paragraphs:paragraphs_library
+  - webform:webform

--- a/web/modules/custom/do_generated_content/src/Generator/CaseMatrix.php
+++ b/web/modules/custom/do_generated_content/src/Generator/CaseMatrix.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+/**
+ * Assigns field values across a generation run.
+ *
+ * Random draws only make full coverage likely: over 20 iterations a 16-value
+ * field misses at least one value more often than not. These helpers walk the
+ * values instead, so every value is produced at least once.
+ */
+final class CaseMatrix {
+
+  /**
+   * Pick the value a run index maps onto.
+   *
+   * @param array $values
+   *   Values to walk. Keys are ignored.
+   * @param int $index
+   *   Zero-based run index.
+   * @param int $offset
+   *   Shifts where the walk starts, so two dimensions of the same length do
+   *   not produce the same value on every index.
+   *
+   * @return mixed
+   *   The value for this index.
+   */
+  public static function cycle(array $values, int $index, int $offset = 0): mixed {
+    if ($values === []) {
+      throw new \InvalidArgumentException('Cannot cycle over an empty list of values.');
+    }
+
+    $values = array_values($values);
+
+    return $values[($index + $offset) % count($values)];
+  }
+
+  /**
+   * Read a single bit of a run index.
+   *
+   * Boolean dimensions take a bit each rather than the index itself: cycling
+   * every boolean on the index locks them in lockstep, so a run would only
+   * ever produce the all-on and all-off combinations.
+   *
+   * @param int $index
+   *   Zero-based run index.
+   * @param int $bit
+   *   Zero-based bit position to read.
+   *
+   * @return bool
+   *   The bit value.
+   */
+  public static function bit(int $index, int $bit): bool {
+    return (bool) (intdiv($index, 2 ** $bit) % 2);
+  }
+
+  /**
+   * Take a subset whose size walks the given sizes.
+   *
+   * @param array $values
+   *   Values to draw from. Keys are ignored.
+   * @param int $index
+   *   Zero-based run index.
+   * @param array $sizes
+   *   Subset sizes to walk, for example [0, 1, 3].
+   * @param int $offset
+   *   Shifts where the size walk starts.
+   *
+   * @return array
+   *   Up to the walked size of values, fewer when fewer are available.
+   */
+  public static function subset(array $values, int $index, array $sizes, int $offset = 0): array {
+    $values = array_values($values);
+    $size = min(self::cycle($sizes, $index, $offset), count($values));
+
+    $subset = [];
+
+    for ($i = 0; $i < $size; $i++) {
+      $subset[] = $values[($index + $i) % count($values)];
+    }
+
+    return $subset;
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/CaseMatrix.php
+++ b/web/modules/custom/do_generated_content/src/Generator/CaseMatrix.php
@@ -33,8 +33,11 @@ final class CaseMatrix {
     }
 
     $values = array_values($values);
+    $count = count($values);
 
-    return $values[($index + $offset) % count($values)];
+    // PHP's modulo keeps the sign of its left operand, so a negative index or
+    // offset would land outside the list.
+    return $values[(($index + $offset) % $count + $count) % $count];
   }
 
   /**

--- a/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
+++ b/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
@@ -25,16 +25,6 @@ final class ComponentGenerator {
   use VocabularyTermsTrait;
 
   /**
-   * Rich text format used by every CivicTheme content field.
-   */
-  private const string TEXT_FORMAT = 'civictheme_rich_text';
-
-  /**
-   * Storage format of a datetime field.
-   */
-  private const string DATETIME_FORMAT = 'Y-m-d\TH:i:s';
-
-  /**
    * Library item reused by every generated 'from_library' component.
    */
   protected ?LibraryItem $libraryItem = NULL;
@@ -234,7 +224,7 @@ final class ComponentGenerator {
   protected function richText(int $paragraphs = 2): array {
     return [
       'value' => $this->generatedContentHelper::staticRichText($paragraphs),
-      'format' => self::TEXT_FORMAT,
+      'format' => Formats::TEXT,
     ];
   }
 
@@ -374,8 +364,8 @@ final class ComponentGenerator {
       'field_c_p_link' => $this->link('View event'),
       'field_c_p_topics' => $this->topics($index),
       'field_c_p_date_range' => [
-        'value' => RelativeDate::format('+7 days', self::DATETIME_FORMAT),
-        'end_value' => RelativeDate::format('+7 days +2 hours', self::DATETIME_FORMAT),
+        'value' => RelativeDate::format('+7 days', Formats::DATETIME),
+        'end_value' => RelativeDate::format('+7 days +2 hours', Formats::DATETIME),
       ],
     ];
 

--- a/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
+++ b/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\do_generated_content\Generator;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\field\FieldConfigInterface;
 use Drupal\generated_content\GeneratedContentRepository;
 use Drupal\generated_content\Helpers\GeneratedContentHelper;
 use Drupal\media\MediaInterface;
@@ -420,13 +421,15 @@ final class ComponentGenerator {
    * Build a manual list, walking every card bundle it accepts.
    */
   protected function manualList(int $index): array {
-    $bundles = $this->allowedTargetBundles('paragraph', 'civictheme_manual_list', 'field_c_p_list_items');
+    // Drop the host bundle: a field configured to accept it would otherwise
+    // recurse into this builder until the stack runs out.
+    $bundles = array_values(array_diff($this->allowedTargetBundles('paragraph', 'civictheme_manual_list', 'field_c_p_list_items'), ['civictheme_manual_list']));
 
     $items = [];
 
     // Walk three consecutive card bundles so a run of lists covers all of
     // them rather than repeating the same card everywhere.
-    for ($i = 0; $i < 3; $i++) {
+    for ($i = 0; $bundles !== [] && $i < 3; $i++) {
       $item = $this->create((string) CaseMatrix::cycle($bundles, $this->manualListCount * 3 + $i), $index + $i);
 
       if ($item instanceof Paragraph) {
@@ -787,9 +790,10 @@ final class ComponentGenerator {
     ]);
     $library_item->save();
 
-    // A library item outlives the node that referenced it, so it has to be
-    // tracked to be removed with the rest of the generated content.
-    $this->repository->addEntities([$library_item]);
+    // A library item outlives the node that referenced it, and deleting it
+    // leaves its paragraph behind, so both are tracked to be removed with the
+    // rest of the generated content.
+    $this->repository->addEntities([$library_item, $paragraph]);
 
     $this->libraryItem = $library_item;
 
@@ -806,14 +810,13 @@ final class ComponentGenerator {
     $id = $entity_type . '.' . $bundle . '.' . $field_name;
     $field = $this->entityTypeManager->getStorage('field_config')->load($id);
 
-    if ($field === NULL) {
+    if (!$field instanceof FieldConfigInterface) {
       throw new \RuntimeException(sprintf('Field %s does not exist.', $id));
     }
 
-    // @phpstan-ignore-next-line
-    $target_bundles = $field->getSetting('handler_settings')['target_bundles'] ?? [];
+    $handler_settings = $field->getSetting('handler_settings') ?? [];
 
-    return array_keys($target_bundles);
+    return array_keys($handler_settings['target_bundles'] ?? []);
   }
 
 }

--- a/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
+++ b/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
@@ -1,0 +1,819 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\generated_content\GeneratedContentRepository;
+use Drupal\generated_content\Helpers\GeneratedContentHelper;
+use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\paragraphs_library\Entity\LibraryItem;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Builds one saved paragraph of any component bundle the site allows.
+ */
+final class ComponentGenerator {
+
+  use FieldAllowedValuesTrait;
+
+  /**
+   * Rich text format used by every CivicTheme content field.
+   */
+  protected const TEXT_FORMAT = 'civictheme_rich_text';
+
+  /**
+   * Storage format of a datetime field.
+   */
+  protected const DATETIME_FORMAT = 'Y-m-d\TH:i:s';
+
+  /**
+   * Library item reused by every generated 'from_library' component.
+   */
+  protected ?LibraryItem $libraryItem = NULL;
+
+  /**
+   * Bundles built so far, keyed by bundle name.
+   *
+   * @var array<string, string>
+   */
+  protected array $createdBundles = [];
+
+  /**
+   * How many manual lists have been built.
+   *
+   * The card walk counts lists rather than reusing the host node's index:
+   * only a few node indexes carry a manual list, so walking on that index
+   * revisits the same handful of card bundles and never reaches the rest.
+   */
+  protected int $manualListCount = 0;
+
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected GeneratedContentHelper $helper,
+    protected GeneratedContentRepository $repository,
+  ) {}
+
+  /**
+   * Bundles this generator can build.
+   *
+   * @return string[]
+   *   Paragraph bundle names.
+   */
+  public static function supportedBundles(): array {
+    return [
+      'civictheme_accordion',
+      'civictheme_accordion_panel',
+      'civictheme_attachment',
+      'civictheme_automated_list',
+      'civictheme_callout',
+      'civictheme_campaign',
+      'civictheme_content',
+      'civictheme_event_card',
+      'civictheme_event_card_ref',
+      'civictheme_fast_fact_card',
+      'civictheme_iframe',
+      'civictheme_manual_list',
+      'civictheme_map',
+      'civictheme_message',
+      'civictheme_navigation_card',
+      'civictheme_navigation_card_ref',
+      'civictheme_next_step',
+      'civictheme_promo',
+      'civictheme_promo_card',
+      'civictheme_promo_card_ref',
+      'civictheme_publication_card',
+      'civictheme_service_card',
+      'civictheme_slider',
+      'civictheme_slider_slide',
+      'civictheme_slider_slide_ref',
+      'civictheme_snippet',
+      'civictheme_snippet_ref',
+      'civictheme_subject_card',
+      'civictheme_subject_card_ref',
+      'civictheme_webform',
+      'divider',
+      'from_library',
+      'steps',
+      'steps_item',
+    ];
+  }
+
+  /**
+   * Build and save one component paragraph.
+   *
+   * @param string $bundle
+   *   Paragraph bundle to build.
+   * @param int $index
+   *   Zero-based run index, used to walk each field's values.
+   * @param int $position
+   *   Zero-based position within its parent, for bundles that are numbered or
+   *   whose first item behaves differently.
+   *
+   * @return \Drupal\paragraphs\Entity\Paragraph|null
+   *   The saved paragraph, or NULL when the bundle needs an entity that does
+   *   not exist yet - a reference card before any node has been generated.
+   */
+  public function create(string $bundle, int $index, int $position = 0): ?Paragraph {
+    $values = match ($bundle) {
+      'civictheme_accordion' => $this->accordion($index),
+      'civictheme_accordion_panel' => $this->accordionPanel($position),
+      'civictheme_attachment' => $this->attachment($index),
+      'civictheme_automated_list' => $this->automatedList($index),
+      'civictheme_callout' => $this->callout($index),
+      'civictheme_campaign' => $this->campaign($index),
+      'civictheme_content' => $this->content($index),
+      'civictheme_event_card' => $this->eventCard($index),
+      'civictheme_event_card_ref' => $this->reference($bundle, $index, 'civictheme_event'),
+      'civictheme_fast_fact_card' => $this->fastFactCard($index),
+      'civictheme_iframe' => $this->iframe($index),
+      'civictheme_manual_list' => $this->manualList($index),
+      'civictheme_map' => $this->map($index),
+      'civictheme_message' => $this->message($index),
+      'civictheme_navigation_card' => $this->navigationCard($index),
+      'civictheme_navigation_card_ref' => $this->reference($bundle, $index, 'civictheme_page'),
+      'civictheme_next_step' => $this->nextStep($index),
+      'civictheme_promo' => $this->promo($index),
+      'civictheme_promo_card' => $this->promoCard($index),
+      'civictheme_promo_card_ref' => $this->reference($bundle, $index, 'civictheme_page'),
+      'civictheme_publication_card' => $this->publicationCard($index),
+      'civictheme_service_card' => $this->serviceCard($index),
+      'civictheme_slider' => $this->slider($index),
+      'civictheme_slider_slide' => $this->sliderSlide($index),
+      'civictheme_slider_slide_ref' => $this->sliderSlideReference($index),
+      'civictheme_snippet' => $this->snippet($index),
+      'civictheme_snippet_ref' => $this->reference($bundle, $index, 'civictheme_page'),
+      'civictheme_subject_card' => $this->subjectCard($index),
+      'civictheme_subject_card_ref' => $this->reference($bundle, $index, 'civictheme_page'),
+      'civictheme_webform' => $this->webform($index),
+      'divider' => $this->divider($index),
+      'from_library' => $this->fromLibrary(),
+      'steps' => $this->steps($index),
+      'steps_item' => $this->stepsItem($position),
+      default => throw new \InvalidArgumentException(sprintf('Unsupported component bundle %s.', $bundle)),
+    };
+
+    if ($values === NULL) {
+      return NULL;
+    }
+
+    $paragraph = Paragraph::create(['type' => $bundle] + $values);
+    $paragraph->save();
+
+    $this->createdBundles[$bundle] = $bundle;
+
+    return $paragraph;
+  }
+
+  /**
+   * Bundles built so far, at every nesting level.
+   *
+   * @return string[]
+   *   Bundle names, sorted.
+   */
+  public function createdBundles(): array {
+    $bundles = $this->createdBundles;
+    ksort($bundles);
+
+    return array_values($bundles);
+  }
+
+  /**
+   * Build several paragraphs of one bundle.
+   *
+   * @return \Drupal\paragraphs\Entity\Paragraph[]
+   *   Saved paragraphs, excluding any the generator had to skip.
+   */
+  protected function createMany(string $bundle, int $index, int $count): array {
+    $paragraphs = [];
+
+    for ($i = 0; $i < $count; $i++) {
+      $paragraph = $this->create($bundle, $index + $i, $i);
+
+      if ($paragraph instanceof Paragraph) {
+        $paragraphs[] = $paragraph;
+      }
+    }
+
+    return $paragraphs;
+  }
+
+  /**
+   * Walk a paragraph field's allowed values.
+   */
+  protected function option(string $bundle, string $field_name, int $index, int $offset = 0): string {
+    return (string) CaseMatrix::cycle($this->allowedValues('paragraph', $bundle, $field_name), $index, $offset);
+  }
+
+  /**
+   * Build the theme and vertical spacing every component shares.
+   *
+   * @return array<string, string>
+   *   Field values.
+   */
+  protected function chrome(string $bundle, int $index): array {
+    return [
+      'field_c_p_theme' => $this->option($bundle, 'field_c_p_theme', $index),
+      'field_c_p_vertical_spacing' => $this->option($bundle, 'field_c_p_vertical_spacing', $index, 1),
+    ];
+  }
+
+  /**
+   * Build a rich text field value.
+   *
+   * @return array<string, string>
+   *   Field value.
+   */
+  protected function richText(int $paragraphs = 2): array {
+    return [
+      'value' => $this->helper::staticRichText($paragraphs),
+      'format' => self::TEXT_FORMAT,
+    ];
+  }
+
+  /**
+   * Build a link field value.
+   *
+   * @return array<string, string>
+   *   Field value.
+   */
+  protected function link(string $title): array {
+    return ['uri' => 'internal:/', 'title' => $title];
+  }
+
+  /**
+   * Get a generated image, when any exist.
+   */
+  protected function image(): ?MediaInterface {
+    $media = $this->helper::randomMediaItem('civictheme_image');
+
+    return $media instanceof MediaInterface ? $media : NULL;
+  }
+
+  /**
+   * Build an accordion with panels.
+   */
+  protected function accordion(int $index): array {
+    return $this->chrome('civictheme_accordion', $index) + [
+      'field_c_p_background' => CaseMatrix::bit($index, 0),
+      'field_c_p_expand' => CaseMatrix::bit($index, 1),
+      'field_c_p_panels' => $this->createMany('civictheme_accordion_panel', $index, 3),
+    ];
+  }
+
+  /**
+   * Build a single accordion panel.
+   */
+  protected function accordionPanel(int $position): array {
+    return [
+      'field_c_p_title' => sprintf('Panel %s - %s', $position + 1, $this->helper::staticSentence(3)),
+      'field_c_p_content' => $this->richText(),
+      // The first panel of a set opens so the component is not rendered fully
+      // collapsed on every page.
+      'field_c_p_expand' => $position === 0,
+    ];
+  }
+
+  /**
+   * Build an attachment listing document media.
+   */
+  protected function attachment(int $index): array {
+    $documents = $this->helper::randomMediaItems('civictheme_document', 2);
+
+    return $this->chrome('civictheme_attachment', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_background' => CaseMatrix::bit($index, 2),
+      'field_c_p_attachments' => array_map(static fn(MediaInterface $media): array => ['target_id' => $media->id()], $documents),
+    ];
+  }
+
+  /**
+   * Build an automated list.
+   */
+  protected function automatedList(int $index): array {
+    return $this->chrome('civictheme_automated_list', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_background' => CaseMatrix::bit($index, 0),
+      'field_c_p_list_content_type' => $this->option('civictheme_automated_list', 'field_c_p_list_content_type', $index),
+      'field_c_p_list_type' => $this->option('civictheme_automated_list', 'field_c_p_list_type', $index),
+      'field_c_p_list_item_view_as' => $this->option('civictheme_automated_list', 'field_c_p_list_item_view_as', $index),
+      'field_c_p_list_item_theme' => $this->option('civictheme_automated_list', 'field_c_p_list_item_theme', $index),
+      'field_c_p_list_limit_type' => $this->option('civictheme_automated_list', 'field_c_p_list_limit_type', $index),
+      'field_c_p_list_filters_exp' => $this->option('civictheme_automated_list', 'field_c_p_list_filters_exp', $index),
+      'field_c_p_list_column_count' => $this->option('civictheme_automated_list', 'field_c_p_list_column_count', $index),
+      'field_c_p_list_fill_width' => CaseMatrix::bit($index, 1),
+      'field_c_p_list_limit' => CaseMatrix::cycle([3, 6, 9], $index),
+      'field_c_p_list_link_above' => $this->link('View all'),
+      'field_c_p_list_link_below' => $this->link('See more'),
+    ];
+  }
+
+  /**
+   * Build a callout.
+   */
+  protected function callout(int $index): array {
+    return $this->chrome('civictheme_callout', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_links' => [$this->link('Get started'), $this->link('Contact us')],
+    ];
+  }
+
+  /**
+   * Build a campaign.
+   */
+  protected function campaign(int $index): array {
+    $image = $this->image();
+
+    $values = $this->chrome('civictheme_campaign', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_date' => RelativeDate::format('-7 days'),
+      'field_c_p_image_position' => $this->option('civictheme_campaign', 'field_c_p_image_position', $index),
+      'field_c_p_links' => [$this->link('Read the campaign')],
+      'field_c_p_topics' => $this->topics($index),
+    ];
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a content component.
+   */
+  protected function content(int $index): array {
+    return $this->chrome('civictheme_content', $index) + [
+      'field_c_p_background' => CaseMatrix::bit($index, 0),
+      'field_c_p_content' => $this->richText(3),
+    ];
+  }
+
+  /**
+   * Build an event card.
+   */
+  protected function eventCard(int $index): array {
+    $image = $this->image();
+
+    $values = [
+      'field_c_p_theme' => $this->option('civictheme_event_card', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_location' => 'Melbourne, Victoria',
+      'field_c_p_link' => $this->link('View event'),
+      'field_c_p_topics' => $this->topics($index),
+      'field_c_p_date_range' => [
+        'value' => RelativeDate::format('+7 days', self::DATETIME_FORMAT),
+        'end_value' => RelativeDate::format('+7 days +2 hours', self::DATETIME_FORMAT),
+      ],
+    ];
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a fast fact card.
+   */
+  protected function fastFactCard(int $index): array {
+    $icon = $this->helper::randomMediaItem('civictheme_icon');
+
+    $values = [
+      'field_c_p_theme' => $this->option('civictheme_fast_fact_card', 'field_c_p_theme', $index),
+      'field_c_p_title' => sprintf('%s%%', ($index + 1) * 5),
+      'field_c_p_summary' => $this->helper::staticSentence(6),
+      'field_c_p_link' => $this->link('Read the detail'),
+    ];
+
+    if ($icon instanceof MediaInterface) {
+      $values['field_c_p_icon'] = ['target_id' => $icon->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build an iframe.
+   */
+  protected function iframe(int $index): array {
+    return $this->chrome('civictheme_iframe', $index) + [
+      'field_c_p_background' => CaseMatrix::bit($index, 1),
+      // Generated content stays self-contained, so the frame points at the
+      // site rather than a third-party embed.
+      'field_c_p_url' => '/',
+      'field_c_p_width' => '100%',
+      'field_c_p_height' => CaseMatrix::cycle(['400px', '600px'], $index),
+    ];
+  }
+
+  /**
+   * Build a manual list, walking every card bundle it accepts.
+   */
+  protected function manualList(int $index): array {
+    $bundles = $this->allowedTargetBundles('paragraph', 'civictheme_manual_list', 'field_c_p_list_items');
+
+    $items = [];
+
+    // Walk three consecutive card bundles so a run of lists covers all of
+    // them rather than repeating the same card everywhere.
+    for ($i = 0; $i < 3; $i++) {
+      $item = $this->create((string) CaseMatrix::cycle($bundles, $this->manualListCount * 3 + $i), $index + $i);
+
+      if ($item instanceof Paragraph) {
+        $items[] = $item;
+      }
+    }
+
+    $this->manualListCount++;
+
+    return $this->chrome('civictheme_manual_list', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_background' => CaseMatrix::bit($index, 2),
+      'field_c_p_list_items' => $items,
+      'field_c_p_list_column_count' => $this->option('civictheme_manual_list', 'field_c_p_list_column_count', $index),
+      'field_c_p_list_fill_width' => CaseMatrix::bit($index, 3),
+      'field_p_list_layout' => $this->option('civictheme_manual_list', 'field_p_list_layout', $index),
+      'field_c_p_list_link_above' => $this->link('View all'),
+      'field_c_p_list_link_below' => $this->link('See more'),
+    ];
+  }
+
+  /**
+   * Build a map.
+   */
+  protected function map(int $index): array {
+    return $this->chrome('civictheme_map', $index) + [
+      'field_c_p_background' => CaseMatrix::bit($index, 0),
+      'field_c_p_address' => '121 Exhibition Street, Melbourne VIC 3000',
+      'field_c_p_embed_url' => $this->link('Map'),
+      'field_c_p_view_link' => $this->link('View larger map'),
+    ];
+  }
+
+  /**
+   * Build a message.
+   */
+  protected function message(int $index): array {
+    return $this->chrome('civictheme_message', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_background' => CaseMatrix::bit($index, 1),
+      'field_c_p_message_type' => $this->option('civictheme_message', 'field_c_p_message_type', $index),
+    ];
+  }
+
+  /**
+   * Build a navigation card.
+   */
+  protected function navigationCard(int $index): array {
+    $image = $this->image();
+
+    $values = [
+      'field_c_p_theme' => $this->option('civictheme_navigation_card', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_link' => $this->link('Go to section'),
+      'field_c_p_show_image_as_icon' => CaseMatrix::bit($index, 0),
+    ];
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a next step.
+   */
+  protected function nextStep(int $index): array {
+    return $this->chrome('civictheme_next_step', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_link' => $this->link('Take the next step'),
+    ];
+  }
+
+  /**
+   * Build a promo.
+   */
+  protected function promo(int $index): array {
+    return $this->chrome('civictheme_promo', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_background' => CaseMatrix::bit($index, 2),
+      'field_c_p_link' => $this->link('Learn more'),
+    ];
+  }
+
+  /**
+   * Build a promo card.
+   */
+  protected function promoCard(int $index): array {
+    $image = $this->image();
+
+    $values = [
+      'field_c_p_theme' => $this->option('civictheme_promo_card', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_subtitle' => $this->helper::staticSentence(3),
+      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_link' => $this->link('Read more'),
+      'field_c_p_topics' => $this->topics($index),
+    ];
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a publication card.
+   */
+  protected function publicationCard(int $index): array {
+    $document = $this->helper::randomMediaItem('civictheme_document');
+    $image = $this->image();
+
+    $values = [
+      'field_c_p_theme' => $this->option('civictheme_publication_card', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(5),
+      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+    ];
+
+    if ($document instanceof MediaInterface) {
+      $values['field_c_p_document'] = ['target_id' => $document->id()];
+    }
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a service card.
+   */
+  protected function serviceCard(int $index): array {
+    return [
+      'field_c_p_theme' => $this->option('civictheme_service_card', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_links' => [$this->link('Apply online'), $this->link('Check eligibility')],
+    ];
+  }
+
+  /**
+   * Build a slider with slides.
+   */
+  protected function slider(int $index): array {
+    $slides = $this->createMany('civictheme_slider_slide', $index, 2);
+    $slide_reference = $this->create('civictheme_slider_slide_ref', $index);
+
+    if ($slide_reference instanceof Paragraph) {
+      $slides[] = $slide_reference;
+    }
+
+    return $this->chrome('civictheme_slider', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_background' => CaseMatrix::bit($index, 3),
+      'field_c_p_slides' => $slides,
+    ];
+  }
+
+  /**
+   * Build a slider slide.
+   */
+  protected function sliderSlide(int $index): array {
+    $image = $this->image();
+
+    $values = [
+      'field_c_p_theme' => $this->option('civictheme_slider_slide', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_date' => RelativeDate::format('-14 days'),
+      'field_c_p_image_position' => $this->option('civictheme_slider_slide', 'field_c_p_image_position', $index),
+      'field_c_p_links' => [$this->link('Find out more')],
+      'field_c_p_topics' => $this->topics($index),
+    ];
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a slide referencing a node.
+   */
+  protected function sliderSlideReference(int $index): ?array {
+    $values = $this->reference('civictheme_slider_slide_ref', $index, 'civictheme_page');
+
+    if ($values === NULL) {
+      return NULL;
+    }
+
+    return $values + [
+      'field_c_p_link_text' => 'Read the page',
+      'field_c_p_image_position' => $this->option('civictheme_slider_slide_ref', 'field_c_p_image_position', $index),
+    ];
+  }
+
+  /**
+   * Build a snippet.
+   */
+  protected function snippet(int $index): array {
+    return [
+      'field_c_p_theme' => $this->option('civictheme_snippet', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_link' => $this->link('Read the snippet'),
+      'field_c_p_topics' => $this->topics($index),
+    ];
+  }
+
+  /**
+   * Build a subject card.
+   */
+  protected function subjectCard(int $index): array {
+    $image = $this->image();
+
+    $values = [
+      'field_c_p_theme' => $this->option('civictheme_subject_card', 'field_c_p_theme', $index),
+      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_link' => $this->link('Browse subject'),
+    ];
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a webform component.
+   */
+  protected function webform(int $index): array {
+    return $this->chrome('civictheme_webform', $index) + [
+      'field_c_p_background' => CaseMatrix::bit($index, 0),
+      'field_c_p_webform' => ['target_id' => CaseMatrix::cycle(['civictheme_enquiry', 'civictheme_feedback'], $index)],
+    ];
+  }
+
+  /**
+   * Build a divider.
+   */
+  protected function divider(int $index): array {
+    $image = $this->image();
+
+    $values = $this->chrome('divider', $index) + [
+      'field_p_alignment' => $this->option('divider', 'field_p_alignment', $index),
+      'field_p_size' => $this->option('divider', 'field_p_size', $index),
+    ];
+
+    if ($image instanceof MediaInterface) {
+      $values['field_c_p_image'] = ['target_id' => $image->id()];
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build a component pointing at a reusable library item.
+   */
+  protected function fromLibrary(): array {
+    return ['field_reusable_paragraph' => ['target_id' => $this->libraryItem()->id()]];
+  }
+
+  /**
+   * Build a steps component with items.
+   */
+  protected function steps(int $index): array {
+    return $this->chrome('steps', $index) + [
+      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_content' => $this->richText(1),
+      'field_c_p_background' => CaseMatrix::bit($index, 1),
+      'field_c_p_list_items' => $this->createMany('steps_item', $index, 3),
+    ];
+  }
+
+  /**
+   * Build a single step.
+   */
+  protected function stepsItem(int $position): array {
+    return [
+      'field_c_p_title' => sprintf('Step %s - %s', $position + 1, $this->helper::staticSentence(3)),
+      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_p_receive' => $this->helper::staticSentence(8),
+    ];
+  }
+
+  /**
+   * Build a paragraph that references a node of the given bundle.
+   *
+   * @return array|null
+   *   Field values, or NULL when no node of that bundle exists yet.
+   */
+  protected function reference(string $bundle, int $index, string $node_bundle): ?array {
+    $node = $this->referencedNode($node_bundle);
+
+    if (!$node instanceof NodeInterface) {
+      return NULL;
+    }
+
+    return [
+      'field_c_p_theme' => $this->option($bundle, 'field_c_p_theme', $index),
+      'field_c_p_reference' => ['target_id' => $node->id()],
+    ];
+  }
+
+  /**
+   * Get a node a reference component can point at.
+   *
+   * Prefers a generated node so a fresh site still produces every reference
+   * component: 'randomRealNode' excludes everything the repository tracks, so
+   * on a site with no pre-existing content of the bundle it finds nothing.
+   */
+  protected function referencedNode(string $node_bundle): ?NodeInterface {
+    $node = $this->helper::randomNode($node_bundle) ?? $this->helper::randomRealNode($node_bundle);
+
+    return $node instanceof NodeInterface ? $node : NULL;
+  }
+
+  /**
+   * Build topic references.
+   *
+   * @return array<int, array<string, int|string|null>>
+   *   Field values.
+   */
+  protected function topics(int $index): array {
+    $terms = $this->helper::randomTerms('civictheme_topics', CaseMatrix::cycle([1, 2], $index));
+
+    return array_map(static fn(TermInterface $term): array => ['target_id' => $term->id()], $terms);
+  }
+
+  /**
+   * Get the shared library item, creating it on first use.
+   */
+  protected function libraryItem(): LibraryItem {
+    if ($this->libraryItem instanceof LibraryItem) {
+      return $this->libraryItem;
+    }
+
+    $paragraph = Paragraph::create([
+      'type' => 'civictheme_content',
+      'field_c_p_theme' => 'light',
+      'field_c_p_vertical_spacing' => 'both',
+      'field_c_p_content' => $this->richText(2),
+    ]);
+    $paragraph->save();
+
+    $library_item = LibraryItem::create([
+      'label' => 'Generated reusable content',
+      'paragraphs' => $paragraph,
+    ]);
+    $library_item->save();
+
+    // A library item outlives the node that referenced it, so it has to be
+    // tracked to be removed with the rest of the generated content.
+    $this->repository->addEntities([$library_item]);
+
+    $this->libraryItem = $library_item;
+
+    return $library_item;
+  }
+
+  /**
+   * Get the bundles an entity reference field accepts.
+   *
+   * @return string[]
+   *   Target bundle names, in the order the field declares them.
+   */
+  public function allowedTargetBundles(string $entity_type, string $bundle, string $field_name): array {
+    $id = $entity_type . '.' . $bundle . '.' . $field_name;
+    $field = $this->entityTypeManager->getStorage('field_config')->load($id);
+
+    if ($field === NULL) {
+      throw new \RuntimeException(sprintf('Field %s does not exist.', $id));
+    }
+
+    // @phpstan-ignore-next-line
+    $target_bundles = $field->getSetting('handler_settings')['target_bundles'] ?? [];
+
+    return array_keys($target_bundles);
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
+++ b/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
@@ -16,6 +16,8 @@ use Drupal\taxonomy\TermInterface;
 
 /**
  * Builds one saved paragraph of any component bundle the site allows.
+ *
+ * @codeCoverageIgnore
  */
 final class ComponentGenerator {
 

--- a/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
+++ b/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
@@ -20,6 +20,7 @@ use Drupal\taxonomy\TermInterface;
 final class ComponentGenerator {
 
   use FieldAllowedValuesTrait;
+  use VocabularyTermsTrait;
 
   /**
    * Rich text format used by every CivicTheme content field.
@@ -763,9 +764,16 @@ final class ComponentGenerator {
    *   Field values.
    */
   protected function topics(int $index): array {
-    $terms = $this->helper::randomTerms('civictheme_topics', CaseMatrix::cycle([1, 2], $index));
+    $terms = $this->vocabularyTerms('civictheme_topics');
 
-    return array_map(static fn(TermInterface $term): array => ['target_id' => $term->id()], $terms);
+    if ($terms === []) {
+      return [];
+    }
+
+    return array_map(
+      static fn(TermInterface $term): array => ['target_id' => $term->id()],
+      CaseMatrix::subset($terms, $index, [1, 2])
+    );
   }
 
   /**

--- a/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
+++ b/web/modules/custom/do_generated_content/src/Generator/ComponentGenerator.php
@@ -25,12 +25,12 @@ final class ComponentGenerator {
   /**
    * Rich text format used by every CivicTheme content field.
    */
-  protected const TEXT_FORMAT = 'civictheme_rich_text';
+  private const string TEXT_FORMAT = 'civictheme_rich_text';
 
   /**
    * Storage format of a datetime field.
    */
-  protected const DATETIME_FORMAT = 'Y-m-d\TH:i:s';
+  private const string DATETIME_FORMAT = 'Y-m-d\TH:i:s';
 
   /**
    * Library item reused by every generated 'from_library' component.
@@ -55,8 +55,8 @@ final class ComponentGenerator {
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
-    protected GeneratedContentHelper $helper,
-    protected GeneratedContentRepository $repository,
+    protected GeneratedContentHelper $generatedContentHelper,
+    protected GeneratedContentRepository $generatedContentRepository,
   ) {}
 
   /**
@@ -231,7 +231,7 @@ final class ComponentGenerator {
    */
   protected function richText(int $paragraphs = 2): array {
     return [
-      'value' => $this->helper::staticRichText($paragraphs),
+      'value' => $this->generatedContentHelper::staticRichText($paragraphs),
       'format' => self::TEXT_FORMAT,
     ];
   }
@@ -250,7 +250,7 @@ final class ComponentGenerator {
    * Get a generated image, when any exist.
    */
   protected function image(): ?MediaInterface {
-    $media = $this->helper::randomMediaItem('civictheme_image');
+    $media = $this->generatedContentHelper::randomMediaItem('civictheme_image');
 
     return $media instanceof MediaInterface ? $media : NULL;
   }
@@ -271,7 +271,7 @@ final class ComponentGenerator {
    */
   protected function accordionPanel(int $position): array {
     return [
-      'field_c_p_title' => sprintf('Panel %s - %s', $position + 1, $this->helper::staticSentence(3)),
+      'field_c_p_title' => sprintf('Panel %s - %s', $position + 1, $this->generatedContentHelper::staticSentence(3)),
       'field_c_p_content' => $this->richText(),
       // The first panel of a set opens so the component is not rendered fully
       // collapsed on every page.
@@ -283,10 +283,10 @@ final class ComponentGenerator {
    * Build an attachment listing document media.
    */
   protected function attachment(int $index): array {
-    $documents = $this->helper::randomMediaItems('civictheme_document', 2);
+    $documents = $this->generatedContentHelper::randomMediaItems('civictheme_document', 2);
 
     return $this->chrome('civictheme_attachment', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(3),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_background' => CaseMatrix::bit($index, 2),
       'field_c_p_attachments' => array_map(static fn(MediaInterface $media): array => ['target_id' => $media->id()], $documents),
@@ -298,7 +298,7 @@ final class ComponentGenerator {
    */
   protected function automatedList(int $index): array {
     return $this->chrome('civictheme_automated_list', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_background' => CaseMatrix::bit($index, 0),
       'field_c_p_list_content_type' => $this->option('civictheme_automated_list', 'field_c_p_list_content_type', $index),
@@ -320,7 +320,7 @@ final class ComponentGenerator {
    */
   protected function callout(int $index): array {
     return $this->chrome('civictheme_callout', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(3),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_links' => [$this->link('Get started'), $this->link('Contact us')],
     ];
@@ -333,7 +333,7 @@ final class ComponentGenerator {
     $image = $this->image();
 
     $values = $this->chrome('civictheme_campaign', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_date' => RelativeDate::format('-7 days'),
       'field_c_p_image_position' => $this->option('civictheme_campaign', 'field_c_p_image_position', $index),
@@ -366,8 +366,8 @@ final class ComponentGenerator {
 
     $values = [
       'field_c_p_theme' => $this->option('civictheme_event_card', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(4),
-      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
+      'field_c_p_summary' => $this->generatedContentHelper::staticPlainParagraph(),
       'field_c_p_location' => 'Melbourne, Victoria',
       'field_c_p_link' => $this->link('View event'),
       'field_c_p_topics' => $this->topics($index),
@@ -388,12 +388,12 @@ final class ComponentGenerator {
    * Build a fast fact card.
    */
   protected function fastFactCard(int $index): array {
-    $icon = $this->helper::randomMediaItem('civictheme_icon');
+    $icon = $this->generatedContentHelper::randomMediaItem('civictheme_icon');
 
     $values = [
       'field_c_p_theme' => $this->option('civictheme_fast_fact_card', 'field_c_p_theme', $index),
       'field_c_p_title' => sprintf('%s%%', ($index + 1) * 5),
-      'field_c_p_summary' => $this->helper::staticSentence(6),
+      'field_c_p_summary' => $this->generatedContentHelper::staticSentence(6),
       'field_c_p_link' => $this->link('Read the detail'),
     ];
 
@@ -441,7 +441,7 @@ final class ComponentGenerator {
     $this->manualListCount++;
 
     return $this->chrome('civictheme_manual_list', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_background' => CaseMatrix::bit($index, 2),
       'field_c_p_list_items' => $items,
@@ -470,7 +470,7 @@ final class ComponentGenerator {
    */
   protected function message(int $index): array {
     return $this->chrome('civictheme_message', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(3),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_background' => CaseMatrix::bit($index, 1),
       'field_c_p_message_type' => $this->option('civictheme_message', 'field_c_p_message_type', $index),
@@ -485,8 +485,8 @@ final class ComponentGenerator {
 
     $values = [
       'field_c_p_theme' => $this->option('civictheme_navigation_card', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(4),
-      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
+      'field_c_p_summary' => $this->generatedContentHelper::staticPlainParagraph(),
       'field_c_p_link' => $this->link('Go to section'),
       'field_c_p_show_image_as_icon' => CaseMatrix::bit($index, 0),
     ];
@@ -503,7 +503,7 @@ final class ComponentGenerator {
    */
   protected function nextStep(int $index): array {
     return $this->chrome('civictheme_next_step', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_link' => $this->link('Take the next step'),
     ];
@@ -514,7 +514,7 @@ final class ComponentGenerator {
    */
   protected function promo(int $index): array {
     return $this->chrome('civictheme_promo', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_background' => CaseMatrix::bit($index, 2),
       'field_c_p_link' => $this->link('Learn more'),
@@ -529,9 +529,9 @@ final class ComponentGenerator {
 
     $values = [
       'field_c_p_theme' => $this->option('civictheme_promo_card', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(4),
-      'field_c_p_subtitle' => $this->helper::staticSentence(3),
-      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
+      'field_c_p_subtitle' => $this->generatedContentHelper::staticSentence(3),
+      'field_c_p_summary' => $this->generatedContentHelper::staticPlainParagraph(),
       'field_c_p_link' => $this->link('Read more'),
       'field_c_p_topics' => $this->topics($index),
     ];
@@ -547,13 +547,13 @@ final class ComponentGenerator {
    * Build a publication card.
    */
   protected function publicationCard(int $index): array {
-    $document = $this->helper::randomMediaItem('civictheme_document');
+    $document = $this->generatedContentHelper::randomMediaItem('civictheme_document');
     $image = $this->image();
 
     $values = [
       'field_c_p_theme' => $this->option('civictheme_publication_card', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(5),
-      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(5),
+      'field_c_p_summary' => $this->generatedContentHelper::staticPlainParagraph(),
     ];
 
     if ($document instanceof MediaInterface) {
@@ -573,7 +573,7 @@ final class ComponentGenerator {
   protected function serviceCard(int $index): array {
     return [
       'field_c_p_theme' => $this->option('civictheme_service_card', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(3),
       'field_c_p_links' => [$this->link('Apply online'), $this->link('Check eligibility')],
     ];
   }
@@ -590,7 +590,7 @@ final class ComponentGenerator {
     }
 
     return $this->chrome('civictheme_slider', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_background' => CaseMatrix::bit($index, 3),
       'field_c_p_slides' => $slides,
     ];
@@ -604,7 +604,7 @@ final class ComponentGenerator {
 
     $values = [
       'field_c_p_theme' => $this->option('civictheme_slider_slide', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_date' => RelativeDate::format('-14 days'),
       'field_c_p_image_position' => $this->option('civictheme_slider_slide', 'field_c_p_image_position', $index),
@@ -641,8 +641,8 @@ final class ComponentGenerator {
   protected function snippet(int $index): array {
     return [
       'field_c_p_theme' => $this->option('civictheme_snippet', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(4),
-      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
+      'field_c_p_summary' => $this->generatedContentHelper::staticPlainParagraph(),
       'field_c_p_link' => $this->link('Read the snippet'),
       'field_c_p_topics' => $this->topics($index),
     ];
@@ -656,7 +656,7 @@ final class ComponentGenerator {
 
     $values = [
       'field_c_p_theme' => $this->option('civictheme_subject_card', 'field_c_p_theme', $index),
-      'field_c_p_title' => $this->helper::staticSentence(3),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(3),
       'field_c_p_link' => $this->link('Browse subject'),
     ];
 
@@ -707,7 +707,7 @@ final class ComponentGenerator {
    */
   protected function steps(int $index): array {
     return $this->chrome('steps', $index) + [
-      'field_c_p_title' => $this->helper::staticSentence(4),
+      'field_c_p_title' => $this->generatedContentHelper::staticSentence(4),
       'field_c_p_content' => $this->richText(1),
       'field_c_p_background' => CaseMatrix::bit($index, 1),
       'field_c_p_list_items' => $this->createMany('steps_item', $index, 3),
@@ -719,9 +719,9 @@ final class ComponentGenerator {
    */
   protected function stepsItem(int $position): array {
     return [
-      'field_c_p_title' => sprintf('Step %s - %s', $position + 1, $this->helper::staticSentence(3)),
-      'field_c_p_summary' => $this->helper::staticPlainParagraph(),
-      'field_p_receive' => $this->helper::staticSentence(8),
+      'field_c_p_title' => sprintf('Step %s - %s', $position + 1, $this->generatedContentHelper::staticSentence(3)),
+      'field_c_p_summary' => $this->generatedContentHelper::staticPlainParagraph(),
+      'field_p_receive' => $this->generatedContentHelper::staticSentence(8),
     ];
   }
 
@@ -752,7 +752,7 @@ final class ComponentGenerator {
    * on a site with no pre-existing content of the bundle it finds nothing.
    */
   protected function referencedNode(string $node_bundle): ?NodeInterface {
-    $node = $this->helper::randomNode($node_bundle) ?? $this->helper::randomRealNode($node_bundle);
+    $node = $this->generatedContentHelper::randomNode($node_bundle) ?? $this->generatedContentHelper::randomRealNode($node_bundle);
 
     return $node instanceof NodeInterface ? $node : NULL;
   }
@@ -801,7 +801,7 @@ final class ComponentGenerator {
     // A library item outlives the node that referenced it, and deleting it
     // leaves its paragraph behind, so both are tracked to be removed with the
     // rest of the generated content.
-    $this->repository->addEntities([$library_item, $paragraph]);
+    $this->generatedContentRepository->addEntities([$library_item, $paragraph]);
 
     $this->libraryItem = $library_item;
 
@@ -824,7 +824,7 @@ final class ComponentGenerator {
 
     $handler_settings = $field->getSetting('handler_settings') ?? [];
 
-    return array_keys($handler_settings['target_bundles'] ?? []);
+    return array_map(strval(...), array_keys($handler_settings['target_bundles'] ?? []));
   }
 
 }

--- a/web/modules/custom/do_generated_content/src/Generator/FieldAllowedValuesTrait.php
+++ b/web/modules/custom/do_generated_content/src/Generator/FieldAllowedValuesTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+use Drupal\field\FieldConfigInterface;
+
+/**
+ * Reads the allowed values of a list field from its storage definition.
+ *
+ * Hardcoding the values would stop covering a field the moment CivicTheme adds
+ * one, and the gap would be invisible because the site still looks populated.
+ */
+trait FieldAllowedValuesTrait {
+
+  /**
+   * Allowed values keyed by field config id.
+   *
+   * @var array<string, string[]>
+   */
+  protected array $allowedValuesCache = [];
+
+  /**
+   * Get the allowed values of a list field.
+   *
+   * @param string $entity_type
+   *   Entity type id.
+   * @param string $bundle
+   *   Bundle name.
+   * @param string $field_name
+   *   Field name.
+   *
+   * @return string[]
+   *   Allowed values, in the order the field declares them.
+   */
+  protected function allowedValues(string $entity_type, string $bundle, string $field_name): array {
+    $id = $entity_type . '.' . $bundle . '.' . $field_name;
+
+    if (isset($this->allowedValuesCache[$id])) {
+      return $this->allowedValuesCache[$id];
+    }
+
+    $field = $this->entityTypeManager->getStorage('field_config')->load($id);
+
+    if (!$field instanceof FieldConfigInterface) {
+      throw new \RuntimeException(sprintf('Field %s does not exist.', $id));
+    }
+
+    $allowed_values = $field->getFieldStorageDefinition()->getSetting('allowed_values');
+
+    $this->allowedValuesCache[$id] = array_keys(is_array($allowed_values) ? $allowed_values : []);
+
+    return $this->allowedValuesCache[$id];
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/FieldAllowedValuesTrait.php
+++ b/web/modules/custom/do_generated_content/src/Generator/FieldAllowedValuesTrait.php
@@ -11,6 +11,8 @@ use Drupal\field\FieldConfigInterface;
  *
  * Hardcoding the values would stop covering a field the moment CivicTheme adds
  * one, and the gap would be invisible because the site still looks populated.
+ *
+ * @codeCoverageIgnore
  */
 trait FieldAllowedValuesTrait {
 

--- a/web/modules/custom/do_generated_content/src/Generator/Formats.php
+++ b/web/modules/custom/do_generated_content/src/Generator/Formats.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+/**
+ * Storage formats shared by the node and component generators.
+ *
+ * @codeCoverageIgnore
+ */
+final class Formats {
+
+  /**
+   * Text format used by every CivicTheme rich text field.
+   */
+  public const string TEXT = 'civictheme_rich_text';
+
+  /**
+   * Storage format of a datetime field.
+   */
+  public const string DATETIME = 'Y-m-d\TH:i:s';
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/MediaGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/MediaGeneratorBase.php
@@ -10,6 +10,8 @@ use Drupal\media\Entity\Media;
 
 /**
  * Base class for media generators backed by a generated file.
+ *
+ * @codeCoverageIgnore
  */
 abstract class MediaGeneratorBase extends GeneratedContentPluginBase {
 

--- a/web/modules/custom/do_generated_content/src/Generator/MediaGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/MediaGeneratorBase.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+use Drupal\file\FileInterface;
+use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
+use Drupal\media\Entity\Media;
+
+/**
+ * Base class for media generators backed by a generated file.
+ */
+abstract class MediaGeneratorBase extends GeneratedContentPluginBase {
+
+  /**
+   * Number of media entities to create.
+   */
+  protected const COUNT = 20;
+
+  /**
+   * Name of the file or image field on the bundle.
+   */
+  protected const FIELD_NAME = '';
+
+  /**
+   * File extensions to draw from, in preference order.
+   */
+  protected const EXTENSIONS = [];
+
+  /**
+   * Human-readable bundle name used in names and log lines.
+   */
+  protected const LABEL = 'media';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function generate(): array {
+    $entities = [];
+
+    for ($index = 0; $index < static::COUNT; $index++) {
+      $file = $this->file();
+
+      if (!$file instanceof FileInterface) {
+        $this->helper::log('Skipped %s %s: no %s file was generated.', static::LABEL, $index + 1, implode('/', static::EXTENSIONS));
+
+        continue;
+      }
+
+      $name = sprintf('Generated %s %s', static::LABEL, $index + 1);
+
+      $media = Media::create(['bundle' => $this->getBundle(), 'name' => $name] + $this->fileValues($file));
+      $media->save();
+
+      $entities[] = $media;
+
+      $this->helper::log('Created %s: %s', static::LABEL, $name);
+    }
+
+    return $entities;
+  }
+
+  /**
+   * Build the file reference values.
+   *
+   * @return array
+   *   Field values.
+   */
+  protected function fileValues(FileInterface $file): array {
+    return [static::FIELD_NAME => ['target_id' => $file->id()]];
+  }
+
+  /**
+   * Get a generated file of one of the bundle's extensions.
+   */
+  protected function file(): ?FileInterface {
+    foreach (static::EXTENSIONS as $extension) {
+      $file = $this->helper::randomFile($extension);
+
+      if ($file instanceof FileInterface) {
+        return $file;
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
@@ -23,7 +23,7 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
   /**
    * Number of nodes each bundle generates.
    */
-  protected const COUNT = 20;
+  public const COUNT = 20;
 
   /**
    * Number of components each page-like node carries.
@@ -102,6 +102,9 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
   /**
    * Build the fields every bundle with a summary and topics shares.
    *
+   * @param int $index
+   *   Zero-based run index.
+   *
    * @return array
    *   Field values.
    */
@@ -144,6 +147,9 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
   /**
    * Build the banner fields CivicTheme attaches to page-like bundles.
    *
+   * @param int $index
+   *   Zero-based run index.
+   *
    * @return array
    *   Field values.
    */
@@ -185,6 +191,9 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
   /**
    * Build the sidebar, tag and component fields of a page-like bundle.
    *
+   * @param int $index
+   *   Zero-based run index.
+   *
    * @return array
    *   Field values.
    */
@@ -198,6 +207,13 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
 
   /**
    * Build components for a node, walking the bundles the field accepts.
+   *
+   * @param int $index
+   *   Zero-based run index.
+   * @param string $field_name
+   *   Name of the component field to fill.
+   * @param int $count
+   *   How many components to build.
    *
    * @return \Drupal\paragraphs\Entity\Paragraph[]
    *   Saved paragraphs.
@@ -225,6 +241,16 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
 
   /**
    * Walk a node field's allowed values.
+   *
+   * @param string $field_name
+   *   Name of the list field to read allowed values from.
+   * @param int $index
+   *   Zero-based run index.
+   * @param int $offset
+   *   Shifts where the walk starts.
+   *
+   * @return string
+   *   The allowed value for this index.
    */
   protected function nodeOption(string $field_name, int $index, int $offset = 0): string {
     return (string) CaseMatrix::cycle($this->allowedValues('node', $this->getBundle(), $field_name), $index, $offset);

--- a/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
@@ -58,7 +58,11 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
     $entities = [];
 
     for ($index = 0; $index < static::COUNT; $index++) {
-      $values = ['type' => $this->getBundle(), 'title' => $this->title($index), 'moderation_state' => $this->moderationState($index)] + $this->bundleValues($index);
+      $values = [
+        'type' => $this->getBundle(),
+        'title' => $this->title($index),
+        'moderation_state' => $this->moderationState($index),
+      ] + $this->bundleValues($index);
 
       $node = Node::create($values);
       $node->save();

--- a/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
+use Drupal\media\MediaInterface;
+use Drupal\node\Entity\Node;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Base class for node generators.
+ *
+ * Holds the field set that CivicTheme attaches to every page-like bundle, so
+ * a bundle generator only states what makes it different.
+ */
+abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
+
+  use FieldAllowedValuesTrait;
+
+  /**
+   * Number of nodes each bundle generates.
+   */
+  protected const COUNT = 20;
+
+  /**
+   * Number of components each page-like node carries.
+   */
+  protected const COMPONENTS_PER_NODE = 3;
+
+  /**
+   * Human-readable bundle name used in titles and log lines.
+   */
+  protected const LABEL = 'node';
+
+  /**
+   * Moderation states a run covers, the first of which most nodes take.
+   */
+  public const MODERATION_STATES = ['published', 'draft', 'needs_review', 'archived'];
+
+  /**
+   * The component generator.
+   */
+  protected ?ComponentGenerator $componentGenerator = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function generate(): array {
+    $entities = [];
+
+    for ($index = 0; $index < static::COUNT; $index++) {
+      $values = ['type' => $this->getBundle(), 'title' => $this->title($index), 'moderation_state' => $this->moderationState($index)] + $this->bundleValues($index);
+
+      $node = Node::create($values);
+      $node->save();
+
+      $entities[] = $node;
+
+      $this->helper::log('Created %s: %s (%s)', static::LABEL, $node->label(), $values['moderation_state']);
+    }
+
+    $this->logCoverage();
+
+    return $entities;
+  }
+
+  /**
+   * Build the field values specific to this bundle.
+   *
+   * @param int $index
+   *   Zero-based run index.
+   *
+   * @return array
+   *   Field values, excluding type, title and moderation state.
+   */
+  abstract protected function bundleValues(int $index): array;
+
+  /**
+   * Build the node title.
+   */
+  protected function title(int $index): string {
+    return sprintf('Generated %s %s - %s', static::LABEL, $index + 1, $this->helper::staticSentence(5));
+  }
+
+  /**
+   * Pick the moderation state for a run index.
+   *
+   * Most nodes are published so an anonymous visitor still sees a populated
+   * site, with one node in each of the remaining states.
+   */
+  protected function moderationState(int $index): string {
+    $states = static::MODERATION_STATES;
+    $default = array_shift($states);
+    $first_non_default = static::COUNT - count($states);
+
+    return $index >= $first_non_default ? $states[$index - $first_non_default] : $default;
+  }
+
+  /**
+   * Build the fields every bundle with a summary and topics shares.
+   *
+   * @return array
+   *   Field values.
+   */
+  protected function commonValues(int $index): array {
+    $values = [
+      'field_c_n_vertical_spacing' => $this->nodeOption('field_c_n_vertical_spacing', $index),
+      'field_c_n_show_toc' => CaseMatrix::bit($index, 0),
+      'field_c_n_show_last_updated' => CaseMatrix::bit($index, 1),
+    ];
+
+    if (CaseMatrix::bit($index, 2)) {
+      $values['field_c_n_summary'] = $this->helper::staticPlainParagraph();
+    }
+
+    if (CaseMatrix::bit($index, 3)) {
+      $values['field_c_n_custom_last_updated'] = RelativeDate::format('-3 days');
+    }
+
+    $thumbnail = $this->helper::randomMediaItem('civictheme_image');
+
+    if (CaseMatrix::bit($index, 4) && $thumbnail instanceof MediaInterface) {
+      $values['field_c_n_thumbnail'] = ['target_id' => $thumbnail->id()];
+    }
+
+    $site_section = $this->helper::randomTerm('civictheme_site_sections');
+
+    if (CaseMatrix::bit($index, 0) && $site_section instanceof TermInterface) {
+      $values['field_c_n_site_section'] = ['target_id' => $site_section->id()];
+    }
+
+    $topics = $this->helper::randomTerms('civictheme_topics', CaseMatrix::cycle([0, 1, 3], $index));
+
+    if ($topics !== []) {
+      $values['field_c_n_topics'] = array_map(static fn(TermInterface $term): array => ['target_id' => $term->id()], $topics);
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build the banner fields CivicTheme attaches to page-like bundles.
+   *
+   * @return array
+   *   Field values.
+   */
+  protected function bannerValues(int $index): array {
+    $values = [
+      'field_c_n_banner_type' => $this->nodeOption('field_c_n_banner_type', $index),
+      'field_c_n_banner_theme' => $this->nodeOption('field_c_n_banner_theme', $index, 1),
+      'field_c_n_banner_blend_mode' => $this->nodeOption('field_c_n_banner_blend_mode', $index),
+      'field_c_n_banner_hide_breadcrumb' => CaseMatrix::bit($index, 2),
+    ];
+
+    if (CaseMatrix::bit($index, 3)) {
+      $values['field_c_n_banner_title'] = $this->helper::staticSentence(4);
+    }
+
+    $background = $this->helper::randomMediaItem('civictheme_image');
+
+    if (CaseMatrix::bit($index, 1) && $background instanceof MediaInterface) {
+      $values['field_c_n_banner_background'] = ['target_id' => $background->id()];
+    }
+
+    $featured = $this->helper::randomMediaItem('civictheme_image');
+
+    if (CaseMatrix::bit($index, 4) && $featured instanceof MediaInterface) {
+      $values['field_c_n_banner_featured_image'] = ['target_id' => $featured->id()];
+    }
+
+    if (CaseMatrix::bit($index, 0)) {
+      $values['field_c_n_banner_components'] = $this->components($index, 'field_c_n_banner_components', 1);
+    }
+
+    if (CaseMatrix::bit($index, 2)) {
+      $values['field_c_n_banner_components_bott'] = $this->components($index + 1, 'field_c_n_banner_components_bott', 1);
+    }
+
+    return $values;
+  }
+
+  /**
+   * Build the sidebar, tag and component fields of a page-like bundle.
+   *
+   * @return array
+   *   Field values.
+   */
+  protected function pageValues(int $index): array {
+    return [
+      'field_c_n_hide_sidebar' => CaseMatrix::bit($index, 3),
+      'field_c_n_hide_tags' => CaseMatrix::bit($index, 4),
+      'field_c_n_components' => $this->components($index, 'field_c_n_components', static::COMPONENTS_PER_NODE),
+    ];
+  }
+
+  /**
+   * Build components for a node, walking the bundles the field accepts.
+   *
+   * @return \Drupal\paragraphs\Entity\Paragraph[]
+   *   Saved paragraphs.
+   */
+  protected function components(int $index, string $field_name, int $count): array {
+    $bundles = $this->generator()->allowedTargetBundles('node', $this->getBundle(), $field_name);
+
+    $components = [];
+
+    for ($i = 0; $i < $count; $i++) {
+      $bundle = (string) CaseMatrix::cycle($bundles, $index * $count + $i);
+      $component = $this->generator()->create($bundle, $index + $i);
+
+      if (!$component instanceof Paragraph) {
+        $this->helper::log('Skipped %s component: no entity to reference yet.', $bundle);
+
+        continue;
+      }
+
+      $components[] = $component;
+    }
+
+    return $components;
+  }
+
+  /**
+   * Walk a node field's allowed values.
+   */
+  protected function nodeOption(string $field_name, int $index, int $offset = 0): string {
+    return (string) CaseMatrix::cycle($this->allowedValues('node', $this->getBundle(), $field_name), $index, $offset);
+  }
+
+  /**
+   * Get the component generator.
+   */
+  protected function generator(): ComponentGenerator {
+    if (!$this->componentGenerator instanceof ComponentGenerator) {
+      $this->componentGenerator = new ComponentGenerator($this->entityTypeManager, $this->helper, $this->repository);
+    }
+
+    return $this->componentGenerator;
+  }
+
+  /**
+   * Report which component bundles the run produced.
+   */
+  protected function logCoverage(): void {
+    $bundles = $this->generator()->createdBundles();
+
+    if ($bundles === []) {
+      return;
+    }
+
+    $this->helper::log('Covered %s component bundles for %s: %s', count($bundles), static::LABEL, implode(', ', $bundles));
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
@@ -19,6 +19,7 @@ use Drupal\taxonomy\TermInterface;
 abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
 
   use FieldAllowedValuesTrait;
+  use VocabularyTermsTrait;
 
   /**
    * Number of nodes each bundle generates.
@@ -44,6 +45,11 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
    * The component generator.
    */
   protected ?ComponentGenerator $componentGenerator = NULL;
+
+  /**
+   * How many topics have been assigned so far.
+   */
+  protected int $topicsAssigned = 0;
 
   /**
    * {@inheritdoc}
@@ -129,13 +135,13 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
       $values['field_c_n_thumbnail'] = ['target_id' => $thumbnail->id()];
     }
 
-    $site_section = $this->helper::randomTerm('civictheme_site_sections');
+    $sections = $this->vocabularyTerms('civictheme_site_sections');
 
-    if (CaseMatrix::bit($index, 0) && $site_section instanceof TermInterface) {
-      $values['field_c_n_site_section'] = ['target_id' => $site_section->id()];
+    if (CaseMatrix::bit($index, 0) && $sections !== []) {
+      $values['field_c_n_site_section'] = ['target_id' => CaseMatrix::cycle($sections, $index)->id()];
     }
 
-    $topics = $this->helper::randomTerms('civictheme_topics', CaseMatrix::cycle([0, 1, 3], $index));
+    $topics = $this->topics(CaseMatrix::cycle([0, 1, 3], $index));
 
     if ($topics !== []) {
       $values['field_c_n_topics'] = array_map(static fn(TermInterface $term): array => ['target_id' => $term->id()], $topics);
@@ -237,6 +243,30 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
     }
 
     return $components;
+  }
+
+  /**
+   * Pick the next topics from the vocabulary.
+   *
+   * Walks a counter rather than the run index so a run keeps the whole
+   * vocabulary in play instead of revisiting its first few terms.
+   *
+   * @param int $count
+   *   How many topics to pick.
+   *
+   * @return \Drupal\taxonomy\TermInterface[]
+   *   The picked terms.
+   */
+  protected function topics(int $count): array {
+    $terms = $this->vocabularyTerms('civictheme_topics');
+
+    $picked = [];
+
+    for ($i = 0; $terms !== [] && $i < $count; $i++) {
+      $picked[] = CaseMatrix::cycle($terms, $this->topicsAssigned++);
+    }
+
+    return $picked;
   }
 
   /**

--- a/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
@@ -15,6 +15,8 @@ use Drupal\taxonomy\TermInterface;
  *
  * Holds the field set that CivicTheme attaches to every page-like bundle, so
  * a bundle generator only states what makes it different.
+ *
+ * @codeCoverageIgnore
  */
 abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
 

--- a/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\do_generated_content\Generator;
 
+use Drupal\Component\Serialization\Json;
 use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
 use Drupal\media\MediaInterface;
 use Drupal\node\Entity\Node;
@@ -210,11 +211,22 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
    *   Field values.
    */
   protected function pageValues(int $index): array {
-    return [
+    $values = [
       'field_c_n_hide_sidebar' => CaseMatrix::bit($index, 3),
       'field_c_n_hide_tags' => CaseMatrix::bit($index, 4),
       'field_c_n_components' => $this->components($index, 'field_c_n_components', static::COMPONENTS_PER_NODE),
     ];
+
+    if (CaseMatrix::bit($index, 1)) {
+      // Metatag strips anything matching the site defaults on save, so the
+      // values have to differ from them to be stored at all.
+      $values['field_n_metatags'] = Json::encode([
+        'title' => sprintf('Generated %s %s meta title', static::LABEL, $index + 1),
+        'description' => $this->helper::staticSentence(12),
+      ]);
+    }
+
+    return $values;
   }
 
   /**

--- a/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/NodeGeneratorBase.php
@@ -245,6 +245,14 @@ abstract class NodeGeneratorBase extends GeneratedContentPluginBase {
   protected function components(int $index, string $field_name, int $count): array {
     $bundles = $this->generator()->allowedTargetBundles('node', $this->getBundle(), $field_name);
 
+    if ($bundles === []) {
+      // A field that restricts no bundle declares no target_bundles at all,
+      // and there is nothing to walk.
+      $this->helper::log('Skipped %s components: the field declares no target bundles.', $field_name);
+
+      return [];
+    }
+
     $components = [];
 
     for ($i = 0; $i < $count; $i++) {

--- a/web/modules/custom/do_generated_content/src/Generator/RelativeDate.php
+++ b/web/modules/custom/do_generated_content/src/Generator/RelativeDate.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+/**
+ * Formats a date offset from the moment of generation.
+ *
+ * Generated dates are relative rather than fixed so past, current and future
+ * content stays past, current and future however long ago the site was built.
+ */
+final class RelativeDate {
+
+  /**
+   * Format a date offset from now, in UTC.
+   *
+   * @param string $modifier
+   *   A relative date string, for example '-3 days'.
+   * @param string $format
+   *   A date format string.
+   *
+   * @return string
+   *   The formatted date.
+   */
+  public static function format(string $modifier, string $format = 'Y-m-d'): string {
+    return (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify($modifier)->format($format);
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/RelativeDate.php
+++ b/web/modules/custom/do_generated_content/src/Generator/RelativeDate.php
@@ -24,7 +24,7 @@ final class RelativeDate {
    *   The formatted date.
    */
   public static function format(string $modifier, string $format = 'Y-m-d'): string {
-    return (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify($modifier)->format($format);
+    return new \DateTimeImmutable('now', new \DateTimeZone('UTC'))->modify($modifier)->format($format);
   }
 
 }

--- a/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
@@ -27,6 +27,16 @@ abstract class TaxonomyTermGeneratorBase extends GeneratedContentPluginBase {
     $entities = [];
 
     foreach (static::NAMES as $name) {
+      if ($this->exists($name)) {
+        // A restored production database already carries most of these names,
+        // and a second term under the same name is indistinguishable to an
+        // editor. The existing term is deliberately left untracked: returning
+        // it here would hand real site taxonomy to the removal routine.
+        $this->helper::log('Reused existing %s term: %s', $this->getBundle(), $name);
+
+        continue;
+      }
+
       $term = Term::create(['vid' => $this->getBundle(), 'name' => $name]);
       $term->save();
 
@@ -36,6 +46,18 @@ abstract class TaxonomyTermGeneratorBase extends GeneratedContentPluginBase {
     }
 
     return $entities;
+  }
+
+  /**
+   * Check whether the vocabulary already holds a term of this name.
+   */
+  protected function exists(string $name): bool {
+    $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties([
+      'vid' => $this->getBundle(),
+      'name' => $name,
+    ]);
+
+    return $terms !== [];
   }
 
 }

--- a/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\do_generated_content\Generator;
 
+use Drupal\taxonomy\TermInterface;
 use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
 use Drupal\taxonomy\Entity\Term;
 
@@ -16,6 +17,8 @@ use Drupal\taxonomy\Entity\Term;
  * @codeCoverageIgnore
  */
 abstract class TaxonomyTermGeneratorBase extends GeneratedContentPluginBase {
+
+  use VocabularyTermsTrait;
 
   /**
    * Term names to create, in order.
@@ -54,12 +57,7 @@ abstract class TaxonomyTermGeneratorBase extends GeneratedContentPluginBase {
    * Check whether the vocabulary already holds a term of this name.
    */
   protected function exists(string $name): bool {
-    $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties([
-      'vid' => $this->getBundle(),
-      'name' => $name,
-    ]);
-
-    return $terms !== [];
+    return array_any($this->vocabularyTerms($this->getBundle()), fn(TermInterface $term): bool => $term->getName() === $name);
   }
 
 }

--- a/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Base class for generators of flat vocabularies.
+ *
+ * Terms are named rather than generated: a project referencing 'Drupal' and
+ * 'Health' reads as real content, where a lorem ipsum term does not.
+ */
+abstract class TaxonomyTermGeneratorBase extends GeneratedContentPluginBase {
+
+  /**
+   * Term names to create, in order.
+   */
+  protected const NAMES = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function generate(): array {
+    $entities = [];
+
+    foreach (static::NAMES as $name) {
+      $term = Term::create(['vid' => $this->getBundle(), 'name' => $name]);
+      $term->save();
+
+      $entities[] = $term;
+
+      $this->helper::log('Created %s term: %s', $this->getBundle(), $name);
+    }
+
+    return $entities;
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
+++ b/web/modules/custom/do_generated_content/src/Generator/TaxonomyTermGeneratorBase.php
@@ -12,6 +12,8 @@ use Drupal\taxonomy\Entity\Term;
  *
  * Terms are named rather than generated: a project referencing 'Drupal' and
  * 'Health' reads as real content, where a lorem ipsum term does not.
+ *
+ * @codeCoverageIgnore
  */
 abstract class TaxonomyTermGeneratorBase extends GeneratedContentPluginBase {
 

--- a/web/modules/custom/do_generated_content/src/Generator/VocabularyTermsTrait.php
+++ b/web/modules/custom/do_generated_content/src/Generator/VocabularyTermsTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Generator;
+
+/**
+ * Reads every term of a vocabulary.
+ *
+ * Generation draws terms from the whole vocabulary rather than from the terms
+ * it created itself. The site's automated lists filter on terms that already
+ * exist, so content tagged only with generated terms appears in none of them,
+ * and on a site provisioned from a production database generation creates no
+ * new terms at all.
+ */
+trait VocabularyTermsTrait {
+
+  /**
+   * Terms of each vocabulary, keyed by vocabulary id.
+   *
+   * @var array<string, \Drupal\taxonomy\TermInterface[]>
+   */
+  protected array $vocabularyTermsCache = [];
+
+  /**
+   * Load every term of a vocabulary.
+   *
+   * @param string $vid
+   *   Vocabulary id.
+   *
+   * @return \Drupal\taxonomy\TermInterface[]
+   *   The terms, in storage order.
+   */
+  protected function vocabularyTerms(string $vid): array {
+    if (!isset($this->vocabularyTermsCache[$vid])) {
+      $this->vocabularyTermsCache[$vid] = array_values($this->entityTypeManager->getStorage('taxonomy_term')->loadByProperties(['vid' => $vid]));
+    }
+
+    return $this->vocabularyTermsCache[$vid];
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Generator/VocabularyTermsTrait.php
+++ b/web/modules/custom/do_generated_content/src/Generator/VocabularyTermsTrait.php
@@ -12,6 +12,8 @@ namespace Drupal\do_generated_content\Generator;
  * exist, so content tagged only with generated terms appears in none of them,
  * and on a site provisioned from a production database generation creates no
  * new terms at all.
+ *
+ * @codeCoverageIgnore
  */
 trait VocabularyTermsTrait {
 

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/FileFile.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/FileFile.php
@@ -24,17 +24,21 @@ use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
 class FileFile extends GeneratedContentPluginBase {
 
   /**
-   * How many files to create of each asset type.
+   * How many files to create of each asset type, and how to generate them.
    *
    * Every media bundle draws its files by extension, so a type missing here
    * leaves that bundle with nothing to reference.
+   *
+   * Only raster images have a random generator; asking for a random SVG, PDF
+   * or DOCX silently yields a text stub under that extension, which no viewer
+   * can open. Those types take the static generator and its real fixtures.
    */
-  protected const COUNTS = [
-    GeneratedContentAssetGenerator::ASSET_TYPE_JPG => 12,
-    GeneratedContentAssetGenerator::ASSET_TYPE_PNG => 12,
-    GeneratedContentAssetGenerator::ASSET_TYPE_SVG => 8,
-    GeneratedContentAssetGenerator::ASSET_TYPE_PDF => 6,
-    GeneratedContentAssetGenerator::ASSET_TYPE_DOCX => 4,
+  protected const ASSETS = [
+    [GeneratedContentAssetGenerator::ASSET_TYPE_JPG, 12, GeneratedContentAssetGenerator::GENERATE_TYPE_RANDOM],
+    [GeneratedContentAssetGenerator::ASSET_TYPE_PNG, 12, GeneratedContentAssetGenerator::GENERATE_TYPE_RANDOM],
+    [GeneratedContentAssetGenerator::ASSET_TYPE_SVG, 8, GeneratedContentAssetGenerator::GENERATE_TYPE_STATIC],
+    [GeneratedContentAssetGenerator::ASSET_TYPE_PDF, 6, GeneratedContentAssetGenerator::GENERATE_TYPE_STATIC],
+    [GeneratedContentAssetGenerator::ASSET_TYPE_DOCX, 4, GeneratedContentAssetGenerator::GENERATE_TYPE_STATIC],
   ];
 
   /**
@@ -52,9 +56,9 @@ class FileFile extends GeneratedContentPluginBase {
   public function generate(): array {
     $entities = [];
 
-    foreach (self::COUNTS as $type => $count) {
+    foreach (self::ASSETS as [$type, $count, $generation_type]) {
       for ($index = 0; $index < $count; $index++) {
-        $file = $this->helper::createFile($type, CaseMatrix::cycle(self::DIMENSIONS, $index));
+        $file = $this->helper::createFile($type, CaseMatrix::cycle(self::DIMENSIONS, $index), $generation_type);
 
         $entities[] = $file;
 

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/FileFile.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/FileFile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\do_generated_content\Plugin\GeneratedContent;
 
+use Drupal\do_generated_content\Generator\CaseMatrix;
 use Drupal\generated_content\Attribute\GeneratedContent;
 use Drupal\generated_content\Helpers\GeneratedContentAssetGenerator;
 use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
@@ -23,28 +24,42 @@ use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
 class FileFile extends GeneratedContentPluginBase {
 
   /**
+   * How many files to create of each asset type.
+   *
+   * Every media bundle draws its files by extension, so a type missing here
+   * leaves that bundle with nothing to reference.
+   */
+  protected const COUNTS = [
+    GeneratedContentAssetGenerator::ASSET_TYPE_JPG => 12,
+    GeneratedContentAssetGenerator::ASSET_TYPE_PNG => 12,
+    GeneratedContentAssetGenerator::ASSET_TYPE_SVG => 8,
+    GeneratedContentAssetGenerator::ASSET_TYPE_PDF => 6,
+    GeneratedContentAssetGenerator::ASSET_TYPE_DOCX => 4,
+  ];
+
+  /**
+   * Image dimensions walked so generated images are not all one shape.
+   */
+  protected const DIMENSIONS = [
+    ['width' => 1200, 'height' => 600],
+    ['width' => 800, 'height' => 400],
+    ['width' => 600, 'height' => 600],
+  ];
+
+  /**
    * {@inheritdoc}
    */
   public function generate(): array {
     $entities = [];
 
-    $types = [
-      GeneratedContentAssetGenerator::ASSET_TYPE_JPG,
-      GeneratedContentAssetGenerator::ASSET_TYPE_PNG,
-    ];
+    foreach (self::COUNTS as $type => $count) {
+      for ($index = 0; $index < $count; $index++) {
+        $file = $this->helper::createFile($type, CaseMatrix::cycle(self::DIMENSIONS, $index));
 
-    for ($i = 0; $i < 20; $i++) {
-      $type = $this->helper::randomArrayItem($types);
-      $width = $this->helper::randomBool() ? 1200 : 800;
-      $height = $this->helper::randomBool() ? 600 : 400;
+        $entities[] = $file;
 
-      $file = $this->helper::createFile($type, [
-        'width' => $width,
-        'height' => $height,
-      ]);
-
-      $entities[] = $file;
-      $this->helper::log('Created file: %s', $file->getFilename());
+        $this->helper::log('Created file: %s', $file->getFilename());
+      }
     }
 
     return $entities;

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/MediaCivicthemeDocument.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/MediaCivicthemeDocument.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Plugin\GeneratedContent;
+
+use Drupal\do_generated_content\Generator\MediaGeneratorBase;
+use Drupal\generated_content\Attribute\GeneratedContent;
+
+/**
+ * Generated document media entities.
+ *
+ * @codeCoverageIgnore
+ */
+#[GeneratedContent(
+  id: 'do_generated_content_media_civictheme_document',
+  entity_type: 'media',
+  bundle: 'civictheme_document',
+  weight: 2,
+  tracking: TRUE,
+)]
+class MediaCivicthemeDocument extends MediaGeneratorBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const COUNT = 8;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const FIELD_NAME = 'field_c_m_document';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const EXTENSIONS = ['pdf', 'docx'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const LABEL = 'document';
+
+}

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/MediaCivicthemeIcon.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/MediaCivicthemeIcon.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Plugin\GeneratedContent;
+
+use Drupal\do_generated_content\Generator\MediaGeneratorBase;
+use Drupal\generated_content\Attribute\GeneratedContent;
+
+/**
+ * Generated icon media entities.
+ *
+ * @codeCoverageIgnore
+ */
+#[GeneratedContent(
+  id: 'do_generated_content_media_civictheme_icon',
+  entity_type: 'media',
+  bundle: 'civictheme_icon',
+  weight: 3,
+  tracking: TRUE,
+)]
+class MediaCivicthemeIcon extends MediaGeneratorBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const COUNT = 8;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const FIELD_NAME = 'field_c_m_icon';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const EXTENSIONS = ['svg'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const LABEL = 'icon';
+
+}

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/MediaCivicthemeImage.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/MediaCivicthemeImage.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\do_generated_content\Plugin\GeneratedContent;
 
+use Drupal\do_generated_content\Generator\MediaGeneratorBase;
 use Drupal\file\FileInterface;
 use Drupal\generated_content\Attribute\GeneratedContent;
-use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
-use Drupal\media\Entity\Media;
 
 /**
  * Generated image media entities.
@@ -21,43 +20,33 @@ use Drupal\media\Entity\Media;
   weight: 1,
   tracking: TRUE,
 )]
-class MediaCivicthemeImage extends GeneratedContentPluginBase {
+class MediaCivicthemeImage extends MediaGeneratorBase {
 
   /**
    * {@inheritdoc}
    */
-  public function generate(): array {
-    $entities = [];
+  protected const FIELD_NAME = 'field_c_m_image';
 
-    for ($i = 0; $i < 10; $i++) {
-      $file = $this->helper::randomFile('jpg');
+  /**
+   * {@inheritdoc}
+   */
+  protected const EXTENSIONS = ['jpg', 'png'];
 
-      if (!$file instanceof FileInterface) {
-        $file = $this->helper::randomFile('png');
-      }
+  /**
+   * {@inheritdoc}
+   */
+  protected const LABEL = 'image';
 
-      if (!$file instanceof FileInterface) {
-        continue;
-      }
-
-      $name = sprintf('Generated image %s', $i + 1);
-
-      $media = Media::create([
-        'bundle' => 'civictheme_image',
-        'name' => $name,
-        'field_c_m_image' => [
-          'target_id' => $file->id(),
-          'alt' => $this->helper::staticSentence(3),
-        ],
-      ]);
-
-      $media->save();
-      $entities[] = $media;
-
-      $this->helper::log('Created media: %s', $name);
-    }
-
-    return $entities;
+  /**
+   * {@inheritdoc}
+   */
+  protected function fileValues(FileInterface $file): array {
+    return [
+      static::FIELD_NAME => [
+        'target_id' => $file->id(),
+        'alt' => $this->helper::staticSentence(3),
+      ],
+    ];
   }
 
 }

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeBlog.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeBlog.php
@@ -8,23 +8,23 @@ use Drupal\do_generated_content\Generator\NodeGeneratorBase;
 use Drupal\generated_content\Attribute\GeneratedContent;
 
 /**
- * Generated page nodes.
+ * Generated blog post nodes.
  *
  * @codeCoverageIgnore
  */
 #[GeneratedContent(
-  id: 'do_generated_content_node_civictheme_page',
+  id: 'do_generated_content_node_blog',
   entity_type: 'node',
-  bundle: 'civictheme_page',
-  weight: 31,
+  bundle: 'blog',
+  weight: 32,
   tracking: TRUE,
 )]
-class NodeCivicthemePage extends NodeGeneratorBase {
+class NodeBlog extends NodeGeneratorBase {
 
   /**
    * {@inheritdoc}
    */
-  protected const LABEL = 'page';
+  protected const LABEL = 'blog post';
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeAlert.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeAlert.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Plugin\GeneratedContent;
+
+use Drupal\do_generated_content\Generator\CaseMatrix;
+use Drupal\do_generated_content\Generator\NodeGeneratorBase;
+use Drupal\do_generated_content\Generator\RelativeDate;
+use Drupal\generated_content\Attribute\GeneratedContent;
+
+/**
+ * Generated alert nodes.
+ *
+ * @codeCoverageIgnore
+ */
+#[GeneratedContent(
+  id: 'do_generated_content_node_civictheme_alert',
+  entity_type: 'node',
+  bundle: 'civictheme_alert',
+  weight: 34,
+  tracking: TRUE,
+)]
+class NodeCivicthemeAlert extends NodeGeneratorBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const LABEL = 'alert';
+
+  /**
+   * Number of alerts left visible on every page.
+   *
+   * An alert with no page restriction renders on the whole site, so all but a
+   * couple are scoped to a path the generated content does not use.
+   */
+  protected const SITE_WIDE_COUNT = 2;
+
+  /**
+   * Offsets producing an expired, a running and an upcoming alert.
+   */
+  protected const SCHEDULES = [
+    ['-30 days', '-15 days'],
+    ['-1 day', '+14 days'],
+    ['+15 days', '+30 days'],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function bundleValues(int $index): array {
+    $schedule = CaseMatrix::cycle(self::SCHEDULES, $index);
+
+    $values = [
+      'field_c_n_alert_type' => $this->nodeOption('field_c_n_alert_type', $index),
+      'field_c_n_body' => [
+        'value' => $this->helper::staticHtmlParagraph(),
+        'format' => 'civictheme_rich_text',
+      ],
+      'field_c_n_date_range' => [
+        'value' => RelativeDate::format($schedule[0], 'Y-m-d\TH:i:s'),
+        'end_value' => RelativeDate::format($schedule[1], 'Y-m-d\TH:i:s'),
+      ],
+    ];
+
+    if ($index >= self::SITE_WIDE_COUNT) {
+      $values['field_c_n_alert_page_visibility'] = "/generated-alert-scope\n/generated-alert-scope/*";
+    }
+
+    return $values;
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeAlert.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeAlert.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\do_generated_content\Plugin\GeneratedContent;
 
 use Drupal\do_generated_content\Generator\CaseMatrix;
+use Drupal\do_generated_content\Generator\Formats;
 use Drupal\do_generated_content\Generator\NodeGeneratorBase;
 use Drupal\do_generated_content\Generator\RelativeDate;
 use Drupal\generated_content\Attribute\GeneratedContent;
@@ -55,11 +56,11 @@ class NodeCivicthemeAlert extends NodeGeneratorBase {
       'field_c_n_alert_type' => $this->nodeOption('field_c_n_alert_type', $index),
       'field_c_n_body' => [
         'value' => $this->helper::staticHtmlParagraph(),
-        'format' => 'civictheme_rich_text',
+        'format' => Formats::TEXT,
       ],
       'field_c_n_date_range' => [
-        'value' => RelativeDate::format($schedule[0], 'Y-m-d\TH:i:s'),
-        'end_value' => RelativeDate::format($schedule[1], 'Y-m-d\TH:i:s'),
+        'value' => RelativeDate::format($schedule[0], Formats::DATETIME),
+        'end_value' => RelativeDate::format($schedule[1], Formats::DATETIME),
       ],
     ];
 

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeEvent.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Plugin\GeneratedContent;
+
+use Drupal\do_generated_content\Generator\CaseMatrix;
+use Drupal\do_generated_content\Generator\NodeGeneratorBase;
+use Drupal\do_generated_content\Generator\RelativeDate;
+use Drupal\generated_content\Attribute\GeneratedContent;
+
+/**
+ * Generated event nodes.
+ *
+ * Runs ahead of the page-like bundles: their reference cards can only point at
+ * an event or a page, so with no events yet those cards go ungenerated.
+ *
+ * @codeCoverageIgnore
+ */
+#[GeneratedContent(
+  id: 'do_generated_content_node_civictheme_event',
+  entity_type: 'node',
+  bundle: 'civictheme_event',
+  weight: 30,
+  tracking: TRUE,
+)]
+class NodeCivicthemeEvent extends NodeGeneratorBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const LABEL = 'event';
+
+  /**
+   * Offsets producing a finished, a running and an upcoming event.
+   */
+  protected const SCHEDULES = [
+    ['-30 days', '-30 days +3 hours'],
+    ['-1 hour', '+3 hours'],
+    ['+30 days', '+30 days +3 hours'],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function bundleValues(int $index): array {
+    $schedule = CaseMatrix::cycle(self::SCHEDULES, $index);
+
+    return $this->commonValues($index) + [
+      'field_c_n_body' => [
+        'value' => $this->helper::staticRichText(3),
+        'format' => 'civictheme_rich_text',
+      ],
+      'field_c_n_date_range' => [
+        'value' => RelativeDate::format($schedule[0], 'Y-m-d\TH:i:s'),
+        'end_value' => RelativeDate::format($schedule[1], 'Y-m-d\TH:i:s'),
+      ],
+      'field_c_n_location' => $this->components($index, 'field_c_n_location', 1),
+      'field_c_n_attachments' => $this->components($index, 'field_c_n_attachments', CaseMatrix::cycle([0, 1, 2], $index)),
+    ];
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeEvent.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeCivicthemeEvent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\do_generated_content\Plugin\GeneratedContent;
 
 use Drupal\do_generated_content\Generator\CaseMatrix;
+use Drupal\do_generated_content\Generator\Formats;
 use Drupal\do_generated_content\Generator\NodeGeneratorBase;
 use Drupal\do_generated_content\Generator\RelativeDate;
 use Drupal\generated_content\Attribute\GeneratedContent;
@@ -49,11 +50,11 @@ class NodeCivicthemeEvent extends NodeGeneratorBase {
     return $this->commonValues($index) + [
       'field_c_n_body' => [
         'value' => $this->helper::staticRichText(3),
-        'format' => 'civictheme_rich_text',
+        'format' => Formats::TEXT,
       ],
       'field_c_n_date_range' => [
-        'value' => RelativeDate::format($schedule[0], 'Y-m-d\TH:i:s'),
-        'end_value' => RelativeDate::format($schedule[1], 'Y-m-d\TH:i:s'),
+        'value' => RelativeDate::format($schedule[0], Formats::DATETIME),
+        'end_value' => RelativeDate::format($schedule[1], Formats::DATETIME),
       ],
       'field_c_n_location' => $this->components($index, 'field_c_n_location', 1),
       'field_c_n_attachments' => $this->components($index, 'field_c_n_attachments', CaseMatrix::cycle([0, 1, 2], $index)),

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeProject.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeProject.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Plugin\GeneratedContent;
+
+use Drupal\do_generated_content\Generator\CaseMatrix;
+use Drupal\do_generated_content\Generator\NodeGeneratorBase;
+use Drupal\do_generated_content\Generator\RelativeDate;
+use Drupal\generated_content\Attribute\GeneratedContent;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Generated project nodes.
+ *
+ * @codeCoverageIgnore
+ */
+#[GeneratedContent(
+  id: 'do_generated_content_node_project',
+  entity_type: 'node',
+  bundle: 'project',
+  weight: 33,
+  tracking: TRUE,
+)]
+class NodeProject extends NodeGeneratorBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const LABEL = 'project';
+
+  /**
+   * Roles a delivery team fills, walked so multi-value rendering is covered.
+   */
+  protected const ROLES = [
+    'Technical lead',
+    'Solution architect',
+    'Drupal developer',
+    'DevOps engineer',
+    'Site reliability engineer',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function bundleValues(int $index): array {
+    return $this->commonValues($index) + $this->bannerValues($index) + $this->pageValues($index) + $this->projectValues($index);
+  }
+
+  /**
+   * Build the fields only a project carries.
+   *
+   * @return array
+   *   Field values.
+   */
+  protected function projectValues(int $index): array {
+    $year = (int) RelativeDate::format('now', 'Y') - ($index % 6);
+
+    $values = [
+      'field_do_n_client' => sprintf('Generated Client %s', $index + 1),
+      'field_do_n_delivered_at' => sprintf('%s %s', CaseMatrix::cycle(['March', 'July', 'November'], $index), $year),
+      'field_do_n_year' => $year,
+      'field_do_n_status' => $this->nodeOption('field_do_n_status', $index),
+      'field_do_n_role' => CaseMatrix::subset(self::ROLES, $index, [1, 2, 3]),
+      'field_do_n_live_url' => ['uri' => 'internal:/', 'title' => 'View the live site'],
+    ];
+
+    $contributions = CaseMatrix::cycle([0, 1, 3], $index);
+
+    for ($i = 0; $i < $contributions; $i++) {
+      $values['field_do_n_oss_contributions'][] = ['uri' => 'internal:/', 'title' => sprintf('Contribution %s', $i + 1)];
+    }
+
+    $sector = $this->helper::randomTerm('do_sector');
+
+    if ($sector instanceof TermInterface) {
+      $values['field_do_n_sector'] = ['target_id' => $sector->id()];
+    }
+
+    $values['field_do_n_services'] = $this->termTargets('do_service', $index, [1, 2, 3]);
+    $values['field_do_n_technologies'] = $this->termTargets('do_technology', $index, [1, 3, 5]);
+
+    return $values;
+  }
+
+  /**
+   * Build entity reference values for a walked number of terms.
+   *
+   * @return array<int, array<string, int|string|null>>
+   *   Field values.
+   */
+  protected function termTargets(string $vocabulary, int $index, array $sizes): array {
+    $terms = $this->helper::randomTerms($vocabulary, CaseMatrix::cycle($sizes, $index));
+
+    return array_map(static fn(TermInterface $term): array => ['target_id' => $term->id()], $terms);
+  }
+
+}

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeProject.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/NodeProject.php
@@ -71,10 +71,10 @@ class NodeProject extends NodeGeneratorBase {
       $values['field_do_n_oss_contributions'][] = ['uri' => 'internal:/', 'title' => sprintf('Contribution %s', $i + 1)];
     }
 
-    $sector = $this->helper::randomTerm('do_sector');
+    $sectors = $this->vocabularyTerms('do_sector');
 
-    if ($sector instanceof TermInterface) {
-      $values['field_do_n_sector'] = ['target_id' => $sector->id()];
+    if ($sectors !== []) {
+      $values['field_do_n_sector'] = ['target_id' => CaseMatrix::cycle($sectors, $index)->id()];
     }
 
     $values['field_do_n_services'] = $this->termTargets('do_service', $index, [1, 2, 3]);
@@ -86,11 +86,18 @@ class NodeProject extends NodeGeneratorBase {
   /**
    * Build entity reference values for a walked number of terms.
    *
+   * @param string $vocabulary
+   *   Vocabulary id to draw terms from.
+   * @param int $index
+   *   Zero-based run index.
+   * @param array $sizes
+   *   Numbers of terms to walk.
+   *
    * @return array<int, array<string, int|string|null>>
    *   Field values.
    */
   protected function termTargets(string $vocabulary, int $index, array $sizes): array {
-    $terms = $this->helper::randomTerms($vocabulary, CaseMatrix::cycle($sizes, $index));
+    $terms = CaseMatrix::subset($this->vocabularyTerms($vocabulary), $index, $sizes);
 
     return array_map(static fn(TermInterface $term): array => ['target_id' => $term->id()], $terms);
   }

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermCivicthemeSiteSections.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermCivicthemeSiteSections.php
@@ -8,33 +8,27 @@ use Drupal\do_generated_content\Generator\TaxonomyTermGeneratorBase;
 use Drupal\generated_content\Attribute\GeneratedContent;
 
 /**
- * Generated topic taxonomy terms.
+ * Generated site section taxonomy terms.
  *
  * @codeCoverageIgnore
  */
 #[GeneratedContent(
-  id: 'do_generated_content_taxonomy_term_civictheme_topics',
+  id: 'do_generated_content_taxonomy_term_civictheme_site_sections',
   entity_type: 'taxonomy_term',
-  bundle: 'civictheme_topics',
-  weight: 11,
+  bundle: 'civictheme_site_sections',
+  weight: 12,
   tracking: TRUE,
 )]
-class TaxonomyTermCivicthemeTopics extends TaxonomyTermGeneratorBase {
+class TaxonomyTermCivicthemeSiteSections extends TaxonomyTermGeneratorBase {
 
   /**
    * {@inheritdoc}
    */
   protected const NAMES = [
-    'Drupal',
-    'DevOps',
-    'CI/CD',
-    'Testing',
-    'Automation',
-    'Open Source',
-    'Web Development',
-    'Performance',
-    'Security',
-    'Accessibility',
+    'About',
+    'Services',
+    'Work',
+    'Insights',
   ];
 
 }

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermDoSector.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermDoSector.php
@@ -8,33 +8,31 @@ use Drupal\do_generated_content\Generator\TaxonomyTermGeneratorBase;
 use Drupal\generated_content\Attribute\GeneratedContent;
 
 /**
- * Generated topic taxonomy terms.
+ * Generated sector taxonomy terms.
  *
  * @codeCoverageIgnore
  */
 #[GeneratedContent(
-  id: 'do_generated_content_taxonomy_term_civictheme_topics',
+  id: 'do_generated_content_taxonomy_term_do_sector',
   entity_type: 'taxonomy_term',
-  bundle: 'civictheme_topics',
-  weight: 11,
+  bundle: 'do_sector',
+  weight: 13,
   tracking: TRUE,
 )]
-class TaxonomyTermCivicthemeTopics extends TaxonomyTermGeneratorBase {
+class TaxonomyTermDoSector extends TaxonomyTermGeneratorBase {
 
   /**
    * {@inheritdoc}
    */
   protected const NAMES = [
-    'Drupal',
-    'DevOps',
-    'CI/CD',
-    'Testing',
-    'Automation',
-    'Open Source',
-    'Web Development',
-    'Performance',
-    'Security',
-    'Accessibility',
+    'Government',
+    'Health',
+    'Education',
+    'Finance',
+    'Not-for-profit',
+    'Utilities',
+    'Transport',
+    'Retail',
   ];
 
 }

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermDoService.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermDoService.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_generated_content\Plugin\GeneratedContent;
+
+use Drupal\do_generated_content\Generator\TaxonomyTermGeneratorBase;
+use Drupal\generated_content\Attribute\GeneratedContent;
+
+/**
+ * Generated service taxonomy terms.
+ *
+ * @codeCoverageIgnore
+ */
+#[GeneratedContent(
+  id: 'do_generated_content_taxonomy_term_do_service',
+  entity_type: 'taxonomy_term',
+  bundle: 'do_service',
+  weight: 14,
+  tracking: TRUE,
+)]
+class TaxonomyTermDoService extends TaxonomyTermGeneratorBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected const NAMES = [
+    'Drupal development',
+    'Site migration',
+    'DevOps automation',
+    'Continuous integration',
+    'Performance optimisation',
+    'Security hardening',
+    'Accessibility audit',
+    'Support and maintenance',
+  ];
+
+}

--- a/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermDoTechnology.php
+++ b/web/modules/custom/do_generated_content/src/Plugin/GeneratedContent/TaxonomyTermDoTechnology.php
@@ -8,33 +8,35 @@ use Drupal\do_generated_content\Generator\TaxonomyTermGeneratorBase;
 use Drupal\generated_content\Attribute\GeneratedContent;
 
 /**
- * Generated topic taxonomy terms.
+ * Generated technology taxonomy terms.
  *
  * @codeCoverageIgnore
  */
 #[GeneratedContent(
-  id: 'do_generated_content_taxonomy_term_civictheme_topics',
+  id: 'do_generated_content_taxonomy_term_do_technology',
   entity_type: 'taxonomy_term',
-  bundle: 'civictheme_topics',
-  weight: 11,
+  bundle: 'do_technology',
+  weight: 15,
   tracking: TRUE,
 )]
-class TaxonomyTermCivicthemeTopics extends TaxonomyTermGeneratorBase {
+class TaxonomyTermDoTechnology extends TaxonomyTermGeneratorBase {
 
   /**
    * {@inheritdoc}
    */
   protected const NAMES = [
     'Drupal',
-    'DevOps',
-    'CI/CD',
-    'Testing',
-    'Automation',
-    'Open Source',
-    'Web Development',
-    'Performance',
-    'Security',
-    'Accessibility',
+    'PHP',
+    'Docker',
+    'Kubernetes',
+    'Terraform',
+    'GitHub Actions',
+    'CircleCI',
+    'Solr',
+    'Redis',
+    'Behat',
+    'PHPUnit',
+    'Lagoon',
   ];
 
 }

--- a/web/modules/custom/do_generated_content/tests/src/Unit/CaseMatrixTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/CaseMatrixTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\do_generated_content\Unit;
 
 use Drupal\Tests\UnitTestCase;
 use Drupal\do_generated_content\Generator\CaseMatrix;
+use Drupal\do_generated_content\Generator\NodeGeneratorBase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -17,8 +18,11 @@ class CaseMatrixTest extends UnitTestCase {
 
   /**
    * Number of entities each node generator creates.
+   *
+   * Taken from the generator itself, so the coverage these tests prove is the
+   * coverage a real run produces.
    */
-  protected const RUN_LENGTH = 20;
+  protected const RUN_LENGTH = NodeGeneratorBase::COUNT;
 
   /**
    * Tests that a run index maps onto the expected value.
@@ -41,6 +45,8 @@ class CaseMatrixTest extends UnitTestCase {
     yield 'single value' => [['only'], 5, 3, 'only'];
     yield 'non-sequential keys are ignored' => [[3 => 'a', 9 => 'b'], 1, 0, 'b'];
     yield 'integer values' => [[10, 20], 1, 0, 20];
+    yield 'negative offset stays in range' => [['a', 'b', 'c'], 0, -1, 'c'];
+    yield 'negative index stays in range' => [['a', 'b', 'c'], -4, 0, 'c'];
   }
 
   /**
@@ -194,9 +200,10 @@ class CaseMatrixTest extends UnitTestCase {
    */
   public static function dataProviderDenseWalk(): \Iterator {
     yield 'manual list cards' => [13, 3, 5];
-    yield 'slider slides' => [2, 3, 1];
-    yield 'stride larger than the list' => [2, 3, 1];
+    yield 'slider slides' => [3, 3, 1];
+    yield 'stride larger than the list' => [2, 5, 1];
     yield 'exactly one pass' => [9, 3, 3];
+    yield 'single slot per iteration' => [4, 1, 4];
   }
 
   /**

--- a/web/modules/custom/do_generated_content/tests/src/Unit/CaseMatrixTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/CaseMatrixTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_generated_content\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\do_generated_content\Generator\CaseMatrix;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the value assignment behind the generated content coverage claim.
+ */
+#[Group('DoGeneratedContent')]
+class CaseMatrixTest extends UnitTestCase {
+
+  /**
+   * Number of entities each node generator creates.
+   */
+  protected const RUN_LENGTH = 20;
+
+  /**
+   * Tests that a run index maps onto the expected value.
+   */
+  #[DataProvider('dataProviderCycle')]
+  public function testCycle(array $values, int $index, int $offset, mixed $expected): void {
+    $this->assertSame($expected, CaseMatrix::cycle($values, $index, $offset));
+  }
+
+  /**
+   * Data provider for testCycle().
+   */
+  public static function dataProviderCycle(): \Iterator {
+    yield 'first value' => [['a', 'b', 'c'], 0, 0, 'a'];
+    yield 'second value' => [['a', 'b', 'c'], 1, 0, 'b'];
+    yield 'wraps around' => [['a', 'b', 'c'], 3, 0, 'a'];
+    yield 'wraps around twice' => [['a', 'b', 'c'], 7, 0, 'b'];
+    yield 'offset shifts the start' => [['a', 'b', 'c'], 0, 1, 'b'];
+    yield 'offset wraps around' => [['a', 'b', 'c'], 2, 1, 'a'];
+    yield 'single value' => [['only'], 5, 3, 'only'];
+    yield 'non-sequential keys are ignored' => [[3 => 'a', 9 => 'b'], 1, 0, 'b'];
+    yield 'integer values' => [[10, 20], 1, 0, 20];
+  }
+
+  /**
+   * Tests that cycling an empty list is rejected rather than silently skipped.
+   */
+  public function testCycleRejectsEmptyValues(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Cannot cycle over an empty list of values.');
+
+    CaseMatrix::cycle([], 0);
+  }
+
+  /**
+   * Tests that a full run produces every value of a dimension.
+   *
+   * This is the guarantee the generators rely on. The largest list field on
+   * the site declares 16 values, so the run length has to cover at least that.
+   */
+  #[DataProvider('dataProviderCycleCoversEveryValue')]
+  public function testCycleCoversEveryValue(int $value_count): void {
+    $values = range(1, $value_count);
+
+    $produced = [];
+
+    for ($index = 0; $index < self::RUN_LENGTH; $index++) {
+      $produced[] = CaseMatrix::cycle($values, $index);
+    }
+
+    $this->assertEmpty(array_diff($values, $produced), sprintf('Every one of %s values is produced across a run.', $value_count));
+  }
+
+  /**
+   * Data provider for testCycleCoversEveryValue().
+   */
+  public static function dataProviderCycleCoversEveryValue(): \Iterator {
+    yield 'boolean-sized' => [2];
+    yield 'moderation states' => [4];
+    yield 'largest list field on the site' => [16];
+    yield 'exactly the run length' => [self::RUN_LENGTH];
+  }
+
+  /**
+   * Tests that each bit position reads the expected value.
+   */
+  #[DataProvider('dataProviderBit')]
+  public function testBit(int $index, int $bit, bool $expected): void {
+    $this->assertSame($expected, CaseMatrix::bit($index, $bit));
+  }
+
+  /**
+   * Data provider for testBit().
+   */
+  public static function dataProviderBit(): \Iterator {
+    yield 'zero has no bits set' => [0, 0, FALSE];
+    yield 'one sets the lowest bit' => [1, 0, TRUE];
+    yield 'one leaves the second bit clear' => [1, 1, FALSE];
+    yield 'two sets the second bit' => [2, 1, TRUE];
+    yield 'two leaves the lowest bit clear' => [2, 0, FALSE];
+    yield 'three sets both low bits' => [3, 1, TRUE];
+    yield 'eight sets the fourth bit' => [8, 3, TRUE];
+    yield 'nineteen sets the lowest bit' => [19, 0, TRUE];
+    yield 'nineteen leaves the third bit clear' => [19, 2, FALSE];
+  }
+
+  /**
+   * Tests that boolean dimensions vary independently rather than in lockstep.
+   */
+  public function testBitProducesDistinctCombinations(): void {
+    $combinations = [];
+
+    for ($index = 0; $index < self::RUN_LENGTH; $index++) {
+      $combinations[] = implode('', array_map(
+        static fn(int $bit): string => CaseMatrix::bit($index, $bit) ? '1' : '0',
+        range(0, 3)
+      ));
+    }
+
+    $this->assertCount(16, array_unique($combinations), 'Four boolean dimensions walk all 16 combinations across a run.');
+  }
+
+  /**
+   * Tests that both states of a single boolean dimension are produced.
+   */
+  #[DataProvider('dataProviderBitCoversBothStates')]
+  public function testBitCoversBothStates(int $bit): void {
+    $produced = [];
+
+    for ($index = 0; $index < self::RUN_LENGTH; $index++) {
+      $produced[] = CaseMatrix::bit($index, $bit);
+    }
+
+    $this->assertContains(TRUE, $produced);
+    $this->assertContains(FALSE, $produced);
+  }
+
+  /**
+   * Data provider for testBitCoversBothStates().
+   */
+  public static function dataProviderBitCoversBothStates(): \Iterator {
+    yield 'bit 0' => [0];
+    yield 'bit 1' => [1];
+    yield 'bit 2' => [2];
+    yield 'bit 3' => [3];
+    yield 'bit 4' => [4];
+  }
+
+  /**
+   * Tests that a subset takes the walked number of values.
+   */
+  #[DataProvider('dataProviderSubset')]
+  public function testSubset(array $values, int $index, array $sizes, array $expected): void {
+    $this->assertSame($expected, CaseMatrix::subset($values, $index, $sizes));
+  }
+
+  /**
+   * Data provider for testSubset().
+   */
+  public static function dataProviderSubset(): \Iterator {
+    yield 'empty subset' => [['a', 'b', 'c'], 0, [0, 2], []];
+    yield 'two values' => [['a', 'b', 'c'], 1, [0, 2], ['b', 'c']];
+    yield 'wraps past the end' => [['a', 'b', 'c'], 2, [3], ['c', 'a', 'b']];
+    yield 'size larger than the list' => [['a', 'b'], 0, [5], ['a', 'b']];
+    yield 'no values to draw from' => [[], 0, [3], []];
+    yield 'non-sequential keys are ignored' => [[7 => 'a', 2 => 'b'], 0, [2], ['a', 'b']];
+  }
+
+  /**
+   * Tests that a walk driven by a dense counter reaches every value.
+   *
+   * Nested components walk on a counter of their own rather than on the host
+   * node's index: only a few node indexes carry a manual list, so a walk on
+   * that index revisits the same few card bundles and never reaches the rest.
+   */
+  #[DataProvider('dataProviderDenseWalk')]
+  public function testDenseWalkCoversEveryValue(int $value_count, int $stride, int $iterations): void {
+    $values = range(1, $value_count);
+
+    $produced = [];
+
+    for ($iteration = 0; $iteration < $iterations; $iteration++) {
+      for ($slot = 0; $slot < $stride; $slot++) {
+        $produced[] = CaseMatrix::cycle($values, $iteration * $stride + $slot);
+      }
+    }
+
+    $this->assertEmpty(array_diff($values, $produced), sprintf('%s iterations of %s slots reach all %s values.', $iterations, $stride, $value_count));
+  }
+
+  /**
+   * Data provider for testDenseWalkCoversEveryValue().
+   */
+  public static function dataProviderDenseWalk(): \Iterator {
+    yield 'manual list cards' => [13, 3, 5];
+    yield 'slider slides' => [2, 3, 1];
+    yield 'stride larger than the list' => [2, 3, 1];
+    yield 'exactly one pass' => [9, 3, 3];
+  }
+
+  /**
+   * Tests that every subset size is produced across a run.
+   */
+  public function testSubsetWalksEverySize(): void {
+    $sizes = [0, 1, 3];
+
+    $produced = [];
+
+    for ($index = 0; $index < self::RUN_LENGTH; $index++) {
+      $produced[] = count(CaseMatrix::subset(['a', 'b', 'c', 'd'], $index, $sizes));
+    }
+
+    $this->assertEmpty(array_diff($sizes, $produced));
+  }
+
+}

--- a/web/modules/custom/do_generated_content/tests/src/Unit/CaseMatrixTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/CaseMatrixTest.php
@@ -180,7 +180,7 @@ class CaseMatrixTest extends UnitTestCase {
    * node's index: only a few node indexes carry a manual list, so a walk on
    * that index revisits the same few card bundles and never reaches the rest.
    */
-  #[DataProvider('dataProviderDenseWalk')]
+  #[DataProvider('dataProviderDenseWalkCoversEveryValue')]
   public function testDenseWalkCoversEveryValue(int $value_count, int $stride, int $iterations): void {
     $values = range(1, $value_count);
 
@@ -198,7 +198,7 @@ class CaseMatrixTest extends UnitTestCase {
   /**
    * Data provider for testDenseWalkCoversEveryValue().
    */
-  public static function dataProviderDenseWalk(): \Iterator {
+  public static function dataProviderDenseWalkCoversEveryValue(): \Iterator {
     yield 'manual list cards' => [13, 3, 5];
     yield 'slider slides' => [3, 3, 1];
     yield 'stride larger than the list' => [2, 5, 1];

--- a/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
@@ -25,7 +25,7 @@ class ComponentCoverageTest extends UnitTestCase {
   /**
    * Tests that every bundle a component field accepts can be generated.
    */
-  #[DataProvider('dataProviderComponentField')]
+  #[DataProvider('dataProviderComponentFieldBundlesAreSupported')]
   public function testComponentFieldBundlesAreSupported(string $config_name): void {
     $target_bundles = array_keys($this->fieldSetting($config_name, 'target_bundles'));
 
@@ -39,7 +39,7 @@ class ComponentCoverageTest extends UnitTestCase {
   /**
    * Data provider for testComponentFieldBundlesAreSupported().
    */
-  public static function dataProviderComponentField(): \Iterator {
+  public static function dataProviderComponentFieldBundlesAreSupported(): \Iterator {
     yield 'page components' => ['field.field.node.civictheme_page.field_c_n_components'];
     yield 'blog components' => ['field.field.node.blog.field_c_n_components'];
     yield 'project components' => ['field.field.node.project.field_c_n_components'];
@@ -92,7 +92,7 @@ class ComponentCoverageTest extends UnitTestCase {
   /**
    * Tests that the generators cover every content type the workflow moderates.
    */
-  public function testEveryModeratedContentTypeHasAGenerator(): void {
+  public function testEveryModeratedContentTypeIsGenerated(): void {
     $workflow = $this->config('workflows.workflow.civictheme_editorial');
 
     $bundles = $workflow['type_settings']['entity_types']['node'] ?? [];
@@ -104,9 +104,10 @@ class ComponentCoverageTest extends UnitTestCase {
     $generated = [];
 
     foreach (glob($plugin_dir . '/Node*.php') ?: [] as $file) {
+      /** @var class-string $class */
       $class = 'Drupal\\do_generated_content\\Plugin\\GeneratedContent\\' . basename($file, '.php');
 
-      foreach ((new \ReflectionClass($class))->getAttributes(GeneratedContent::class) as $attribute) {
+      foreach (new \ReflectionClass($class)->getAttributes(GeneratedContent::class) as $attribute) {
         $generated[] = $attribute->newInstance()->bundle;
       }
     }

--- a/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\do_generated_content\Unit;
 use Drupal\Tests\UnitTestCase;
 use Drupal\do_generated_content\Generator\ComponentGenerator;
 use Drupal\do_generated_content\Generator\NodeGeneratorBase;
+use Drupal\generated_content\Attribute\GeneratedContent;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Yaml\Yaml;
@@ -103,10 +104,10 @@ class ComponentCoverageTest extends UnitTestCase {
     $generated = [];
 
     foreach (glob($plugin_dir . '/Node*.php') ?: [] as $file) {
-      $source = file_get_contents($file);
+      $class = 'Drupal\\do_generated_content\\Plugin\\GeneratedContent\\' . basename($file, '.php');
 
-      if ($source !== FALSE && preg_match("/bundle: '([^']+)'/", $source, $matches) === 1) {
-        $generated[] = $matches[1];
+      foreach ((new \ReflectionClass($class))->getAttributes(GeneratedContent::class) as $attribute) {
+        $generated[] = $attribute->newInstance()->bundle;
       }
     }
 

--- a/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
@@ -38,19 +38,36 @@ class ComponentCoverageTest extends UnitTestCase {
 
   /**
    * Data provider for testComponentFieldBundlesAreSupported().
+   *
+   * Derived from the exported configuration rather than listed by hand, so a
+   * paragraph-reference field added later is covered without editing the test.
+   * Scoped to node and paragraph fields: those are what generation populates,
+   * and a paragraph field on any other entity type is outside its remit.
    */
   public static function dataProviderComponentFieldBundlesAreSupported(): \Iterator {
-    yield 'page components' => ['field.field.node.civictheme_page.field_c_n_components'];
-    yield 'blog components' => ['field.field.node.blog.field_c_n_components'];
-    yield 'project components' => ['field.field.node.project.field_c_n_components'];
-    yield 'page banner components' => ['field.field.node.civictheme_page.field_c_n_banner_components'];
-    yield 'page bottom banner components' => ['field.field.node.civictheme_page.field_c_n_banner_components_bott'];
-    yield 'event location' => ['field.field.node.civictheme_event.field_c_n_location'];
-    yield 'event attachments' => ['field.field.node.civictheme_event.field_c_n_attachments'];
-    yield 'manual list items' => ['field.field.paragraph.civictheme_manual_list.field_c_p_list_items'];
-    yield 'accordion panels' => ['field.field.paragraph.civictheme_accordion.field_c_p_panels'];
-    yield 'slider slides' => ['field.field.paragraph.civictheme_slider.field_c_p_slides'];
-    yield 'steps items' => ['field.field.paragraph.steps.field_c_p_list_items'];
+    $directory = dirname(__DIR__, 7) . '/config/default';
+
+    $paragraph_types = [];
+
+    foreach (glob($directory . '/paragraphs.paragraphs_type.*.yml') ?: [] as $file) {
+      $paragraph_types[] = substr(basename($file, '.yml'), strlen('paragraphs.paragraphs_type.'));
+    }
+
+    foreach (['node', 'paragraph'] as $entity_type) {
+      foreach (glob($directory . '/field.field.' . $entity_type . '.*.yml') ?: [] as $file) {
+        $config = (array) Yaml::parseFile($file);
+
+        $target_bundles = array_keys($config['settings']['handler_settings']['target_bundles'] ?? []);
+
+        if (array_intersect($target_bundles, $paragraph_types) === []) {
+          continue;
+        }
+
+        $name = basename($file, '.yml');
+
+        yield $name => [$name];
+      }
+    }
   }
 
   /**

--- a/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/ComponentCoverageTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_generated_content\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\do_generated_content\Generator\ComponentGenerator;
+use Drupal\do_generated_content\Generator\NodeGeneratorBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests that the generators cover everything the site's configuration allows.
+ *
+ * A component type added to a field, or a state added to the workflow, would
+ * otherwise go ungenerated indefinitely: the site still looks populated, so
+ * nothing reveals the gap.
+ */
+#[Group('DoGeneratedContent')]
+class ComponentCoverageTest extends UnitTestCase {
+
+  /**
+   * Tests that every bundle a component field accepts can be generated.
+   */
+  #[DataProvider('dataProviderComponentField')]
+  public function testComponentFieldBundlesAreSupported(string $config_name): void {
+    $target_bundles = array_keys($this->fieldSetting($config_name, 'target_bundles'));
+
+    $this->assertNotEmpty($target_bundles, sprintf('%s declares target bundles.', $config_name));
+
+    $unsupported = array_diff($target_bundles, ComponentGenerator::supportedBundles());
+
+    $this->assertSame([], array_values($unsupported), sprintf('ComponentGenerator can build every bundle %s accepts.', $config_name));
+  }
+
+  /**
+   * Data provider for testComponentFieldBundlesAreSupported().
+   */
+  public static function dataProviderComponentField(): \Iterator {
+    yield 'page components' => ['field.field.node.civictheme_page.field_c_n_components'];
+    yield 'blog components' => ['field.field.node.blog.field_c_n_components'];
+    yield 'project components' => ['field.field.node.project.field_c_n_components'];
+    yield 'page banner components' => ['field.field.node.civictheme_page.field_c_n_banner_components'];
+    yield 'page bottom banner components' => ['field.field.node.civictheme_page.field_c_n_banner_components_bott'];
+    yield 'event location' => ['field.field.node.civictheme_event.field_c_n_location'];
+    yield 'event attachments' => ['field.field.node.civictheme_event.field_c_n_attachments'];
+    yield 'manual list items' => ['field.field.paragraph.civictheme_manual_list.field_c_p_list_items'];
+    yield 'accordion panels' => ['field.field.paragraph.civictheme_accordion.field_c_p_panels'];
+    yield 'slider slides' => ['field.field.paragraph.civictheme_slider.field_c_p_slides'];
+    yield 'steps items' => ['field.field.paragraph.steps.field_c_p_list_items'];
+  }
+
+  /**
+   * Tests that every supported bundle is a paragraph type the site has.
+   */
+  public function testSupportedBundlesExist(): void {
+    $missing = array_filter(
+      ComponentGenerator::supportedBundles(),
+      fn(string $bundle): bool => !file_exists($this->configPath('paragraphs.paragraphs_type.' . $bundle))
+    );
+
+    $this->assertSame([], array_values($missing), 'Every supported bundle is a paragraph type in the exported configuration.');
+  }
+
+  /**
+   * Tests that the supported bundle list carries no duplicates.
+   */
+  public function testSupportedBundlesAreUnique(): void {
+    $bundles = ComponentGenerator::supportedBundles();
+
+    $this->assertSame($bundles, array_values(array_unique($bundles)));
+  }
+
+  /**
+   * Tests that a run covers every moderation state the workflow declares.
+   */
+  public function testModerationStatesAreCovered(): void {
+    $workflow = $this->config('workflows.workflow.civictheme_editorial');
+
+    $states = array_keys($workflow['type_settings']['states'] ?? []);
+
+    $this->assertNotEmpty($states);
+
+    $uncovered = array_diff($states, NodeGeneratorBase::MODERATION_STATES);
+
+    $this->assertSame([], array_values($uncovered), 'Every workflow state is produced by a generation run.');
+  }
+
+  /**
+   * Tests that the generators cover every content type the workflow moderates.
+   */
+  public function testEveryModeratedContentTypeHasAGenerator(): void {
+    $workflow = $this->config('workflows.workflow.civictheme_editorial');
+
+    $bundles = $workflow['type_settings']['entity_types']['node'] ?? [];
+
+    $this->assertNotEmpty($bundles);
+
+    $plugin_dir = dirname(__DIR__, 3) . '/src/Plugin/GeneratedContent';
+
+    $generated = [];
+
+    foreach (glob($plugin_dir . '/Node*.php') ?: [] as $file) {
+      $source = file_get_contents($file);
+
+      if ($source !== FALSE && preg_match("/bundle: '([^']+)'/", $source, $matches) === 1) {
+        $generated[] = $matches[1];
+      }
+    }
+
+    $this->assertSame([], array_values(array_diff($bundles, $generated)), 'Every moderated content type has a node generator.');
+  }
+
+  /**
+   * Read a handler setting from an exported field configuration.
+   */
+  protected function fieldSetting(string $config_name, string $setting): array {
+    return $this->config($config_name)['settings']['handler_settings'][$setting] ?? [];
+  }
+
+  /**
+   * Parse an exported configuration file.
+   */
+  protected function config(string $config_name): array {
+    $path = $this->configPath($config_name);
+
+    $this->assertFileExists($path);
+
+    return (array) Yaml::parseFile($path);
+  }
+
+  /**
+   * Build the path to an exported configuration file.
+   */
+  protected function configPath(string $config_name): string {
+    return dirname(__DIR__, 7) . '/config/default/' . $config_name . '.yml';
+  }
+
+}

--- a/web/modules/custom/do_generated_content/tests/src/Unit/RelativeDateTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/RelativeDateTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_generated_content\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\do_generated_content\Generator\RelativeDate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the relative date formatting used by generated dates.
+ */
+#[Group('DoGeneratedContent')]
+class RelativeDateTest extends UnitTestCase {
+
+  /**
+   * Tests that an offset lands on the expected day.
+   */
+  #[DataProvider('dataProviderFormat')]
+  public function testFormat(string $modifier): void {
+    $expected = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify($modifier);
+
+    $this->assertSame($expected->format('Y-m-d'), RelativeDate::format($modifier));
+  }
+
+  /**
+   * Data provider for testFormat().
+   */
+  public static function dataProviderFormat(): \Iterator {
+    yield 'now' => ['now'];
+    yield 'past' => ['-30 days'];
+    yield 'recent past' => ['-3 days'];
+    yield 'future' => ['+30 days'];
+  }
+
+  /**
+   * Tests that a datetime format keeps the time component.
+   */
+  public function testFormatWithTime(): void {
+    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', RelativeDate::format('+7 days', 'Y-m-d\TH:i:s'));
+  }
+
+  /**
+   * Tests that ordering is preserved across offsets.
+   */
+  public function testOffsetsAreOrdered(): void {
+    $past = RelativeDate::format('-30 days');
+    $now = RelativeDate::format('now');
+    $future = RelativeDate::format('+30 days');
+
+    $this->assertLessThan($now, $past);
+    $this->assertLessThan($future, $now);
+  }
+
+  /**
+   * Tests that an unusable offset fails loudly.
+   */
+  public function testFormatRejectsInvalidModifier(): void {
+    $this->expectException(\DateMalformedStringException::class);
+
+    RelativeDate::format('not a date');
+  }
+
+}

--- a/web/modules/custom/do_generated_content/tests/src/Unit/RelativeDateTest.php
+++ b/web/modules/custom/do_generated_content/tests/src/Unit/RelativeDateTest.php
@@ -20,7 +20,7 @@ class RelativeDateTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderFormat')]
   public function testFormat(string $modifier): void {
-    $expected = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify($modifier);
+    $expected = new \DateTimeImmutable('now', new \DateTimeZone('UTC'))->modify($modifier);
 
     $this->assertSame($expected->format('Y-m-d'), RelativeDate::format($modifier));
   }


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. **Every content type now generates content, at 20 nodes each.** Only `civictheme_page` had a generator, and it produced 10 nodes. There are now generators for `civictheme_page`, `blog`, `project`, `civictheme_event` and `civictheme_alert`, producing 20 nodes each, plus generators for the `do_sector`, `do_service`, `do_technology` and `civictheme_site_sections` vocabularies and for `civictheme_document` and `civictheme_icon` media. `project` previously had no way to be generated at all, and the three vocabularies it references had no terms.

2. **Field values are walked rather than drawn at random, so coverage is a guarantee instead of a probability.** `CaseMatrix` assigns values by walking each field's list, so every value of every dimension is produced at least once in a run. Random draws only made this likely: over 20 iterations a 16-value field such as `field_c_n_banner_blend_mode` misses at least one value more often than not. Boolean dimensions each take a distinct bit of the run index, so a run walks 16 combinations of the first four rather than flipping them all in lockstep.

3. **Every field on every content type is populated, verified by audit.** A per-field audit across all five bundles reports every configurable field populated at least once, every list field producing all its allowed values, every boolean producing both states, and all 4 moderation states. That audit is what surfaced the gaps in points 6 and 7; it now reports no gaps.

4. **All 34 component paragraph bundles are built, at every nesting level.** Page-like bundles previously built 4 of the 17 bundles their component field accepts. `ComponentGenerator` builds every accepted bundle plus the nested ones - accordion panels, slider slides, steps items, and all 13 manual-list card types. Allowed bundles and allowed values are read from field configuration rather than hardcoded, so a value added upstream is picked up without a code change.

5. **Shared generator bases replace what would have been five near-identical plugins.** `civictheme_page`, `blog` and `project` carry an identical set of 20 `field_c_n_*` fields, so `NodeGeneratorBase` states that field set once and each bundle plugin supplies only what makes it different. `TaxonomyTermGeneratorBase` and `MediaGeneratorBase` do the same for their entity types.

6. **Existing taxonomy terms are reused instead of duplicated, and generated content is tagged with the terms the site actually uses.** Provisioning restores a production database before generating content, and that database already contains terms named Drupal, DevOps, Testing and so on; generation was adding a second term under each of those names, leaving an editor with two indistinguishable Drupal topics. An existing term is now reused and deliberately left untracked, so removing generated content never deletes real site taxonomy. Terms are drawn from the whole vocabulary rather than only the generated ones, which is both what makes generated content appear in the site's automated lists and what keeps taxonomy working at all once terms are reused rather than created. That second part covers `field_c_n_topics`, `field_c_n_site_section` and the three `project` vocabulary fields, all of which would otherwise have been left empty.

7. **Non-raster assets are generated with the static generator.** The random asset generator only has real producers for PNG, JPEG, JPG and TXT; asking it for an SVG, PDF or DOCX silently returned a 16-byte text stub under that extension, which no viewer can open. Those types now use the static generator and its real fixtures, so generated PDFs and DOCX files open and generated SVG icons render.

8. **Ordering and reference lookups were corrected so a fresh site produces every component.** Events generate before the page-like bundles, because reference cards accept only an event or a page. Reference components resolve their target through the generated repository first: `randomRealNode()` excludes everything the repository tracks, so on a site with no pre-existing content of that bundle it finds nothing and the card was silently skipped.

9. **The Content API service role can create and edit every content type.** The role held `create civictheme_page content` and `edit own civictheme_page content` only, so the authoring API could produce pages and nothing else. The same pair is now granted for `blog`, `project`, `civictheme_event` and `civictheme_alert`. `edit own` rather than `edit any`, matching the existing entry: the account still cannot touch content authored by anyone else, and it gains no delete permission. The module's access hooks needed no change - the paragraph allow-list is bundle-scoped to paragraphs, and the moderation policy already forced every moderated node to draft regardless of bundle. Verified against the running service account: creating a `project` and a `blog` over JSON:API both return `201` with `moderation_state: draft`, and `DELETE` still returns `403`.

10. **Tests target the coverage claim, which is the part that can regress silently.** `CaseMatrixTest` proves the walking guarantees. `ComponentCoverageTest` derives its cases from the exported configuration - every node and paragraph field that references paragraph bundles - and fails when a component bundle, a moderation state, or a moderated content type exists that the generators cannot produce. That test caught two real gaps while this branch was being written. Entity-creating code is `@codeCoverageIgnore`, consistent with the module, and was verified in the browser instead. The tests need no database and run in milliseconds.

## Screenshots

A generated page rendering its banner, sidebar, content, accordion and attachment components, with the generated site-wide alert above the header.

![Generated page rendering its components](https://raw.githubusercontent.com/drevops/website/28b6af2ea9668ae92ad8b6d916ee0b9cf30aceb2/feature-generated-content/4ecd9571df406a8a149fdcf2ac3b5ac2d7d087cb.png)

## Before / After

```
BEFORE                                   AFTER

generated content                        generated content
├── file            20 (jpg, png)        ├── file            42 (jpg, png, svg, pdf, docx)
├── media                                ├── media
│   └── image       10                   │   ├── image       20
│                                        │   ├── document     8
│                                        │   └── icon         8
├── taxonomy                             ├── taxonomy
│   └── topics      10 (duplicated)      │   ├── topics      reused, never duplicated
│                                        │   ├── site sections
│                                        │   ├── sector / service / technology
└── node                                 └── node
    └── page        10                       ├── event       20
                                             ├── page        20
                                             ├── blog        20
                                             ├── project     20
                                             └── alert       20

                                         100 nodes, 4 moderation states each


COVERAGE PER PAGE-LIKE NODE

BEFORE  components ....  4 of 17 bundles      AFTER  components ....  34 of 34 bundles
        blend mode ....  1 of 16 values              blend mode ....  16 of 16 values
        banner type ...  2 of 4 values               banner type ...  4 of 4 values
        moderation ....  1 of 4 states               moderation ....  4 of 4 states
        empty fields ..  metatags, and on            empty fields ..  none
                         project sector,
                         services, technologies

        assignment ....  random draw                 assignment ....  walked, guaranteed
        guarantee .....  none, only likely           guarantee .....  asserted by tests
```
