### PR TITLE
Rebuilt the generated theme colour stylesheet when the palette changes.

### DIFF
--- a/web/modules/custom/do_base/do_base.deploy.php
+++ b/web/modules/custom/do_base/do_base.deploy.php
@@ -9,6 +9,7 @@
 
 declare(strict_types=1);
 
+use Drupal\civictheme\CivicthemeColorManager;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Sql\DefaultTableMapping;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
@@ -371,6 +372,23 @@ function do_base_deploy_rebuild_xmlsitemap(): string {
   batch_set(xmlsitemap_rebuild_batch($rebuild_types, TRUE));
 
   Helper::reporter()->updated('Queued the XML sitemap rebuild.');
+
+  return Helper::report();
+}
+
+/**
+ * Rebuilds the generated theme colour stylesheet.
+ */
+function do_base_deploy_refresh_theme_colors(): string {
+  /** @var \Drupal\civictheme\CivicthemeColorManager $color_manager */
+  $color_manager = \Drupal::classResolver(CivicthemeColorManager::class);
+
+  // The stylesheet is written only while it is missing, so colours reaching
+  // the site as configuration are never painted into it. Deleting it leaves
+  // the next request to rebuild it from the values the site actually holds.
+  $color_manager->invalidateCache();
+
+  Helper::reporter()->updated('Purged the generated theme colour stylesheet.');
 
   return Helper::report();
 }

--- a/web/modules/custom/do_base/do_base.services.yml
+++ b/web/modules/custom/do_base/do_base.services.yml
@@ -4,3 +4,8 @@ services:
     arguments: ['@theme.manager']
     tags:
       - { name: twig.extension }
+  do_base.theme_color_subscriber:
+    class: Drupal\do_base\EventSubscriber\ThemeColorSubscriber
+    arguments: ['@class_resolver', '@theme_handler']
+    tags:
+      - { name: event_subscriber }

--- a/web/modules/custom/do_base/src/EventSubscriber/ThemeColorSubscriber.php
+++ b/web/modules/custom/do_base/src/EventSubscriber/ThemeColorSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_base\EventSubscriber;
+
+use Drupal\civictheme\CivicthemeColorManager;
+use Drupal\Core\Config\ConfigCrudEvent;
+use Drupal\Core\Config\ConfigEvents;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\Extension\ThemeHandlerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Keeps the generated colour stylesheet in step with theme settings.
+ */
+final class ThemeColorSubscriber implements EventSubscriberInterface {
+
+  public function __construct(protected ClassResolverInterface $classResolver, protected ThemeHandlerInterface $themeHandler) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [ConfigEvents::SAVE => 'onSave'];
+  }
+
+  /**
+   * Purges the stylesheet when the theme's colours change.
+   */
+  public function onSave(ConfigCrudEvent $event): void {
+    if ($event->getConfig()->getName() !== $this->themeHandler->getDefault() . '.settings') {
+      return;
+    }
+
+    if (!$event->isChanged('colors')) {
+      return;
+    }
+
+    // Colours are compiled into a stylesheet that is only ever written while
+    // it is missing. A save that is not followed by a purge leaves the old
+    // palette on disk, and the site keeps serving colours nothing declares.
+    $color_manager = $this->classResolver->getInstanceFromDefinition(CivicthemeColorManager::class);
+
+    if (!$color_manager instanceof CivicthemeColorManager) {
+      return;
+    }
+
+    $color_manager->invalidateCache();
+  }
+
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Root-caused a dev-only all-dark rendering issue on https://dev.drevops.com to a stale generated stylesheet, not to error-page styling: `CivicthemeStylesheetGenerator::generate()` writes `web/sites/default/files/css-variables.drevops.css` only while the file is absent, so once dev's copy held the dark redesign's `light` palette (`--ct-color-light-background: #152235` instead of `#f2f5f8`), a later config import restored the correct configuration but never rewrote the stale file, leaving pages that emit correct `ct-page ct-theme-light` markup painted dark.
2. Added `do_base_deploy_refresh_theme_colors()` to `web/modules/custom/do_base/do_base.deploy.php`, a one-shot deploy hook that calls `CivicthemeColorManager::invalidateCache()` to purge the stale stylesheet on every environment it runs against, so the next request rebuilds it from the configuration the site actually holds.
3. Added `web/modules/custom/do_base/src/EventSubscriber/ThemeColorSubscriber.php`, registered as `do_base.theme_color_subscriber` in `web/modules/custom/do_base/do_base.services.yml`; it listens for `ConfigEvents::SAVE` and purges the stylesheet whenever the default theme's `.settings` config changes its `colors` key, closing the recurrence path the one-shot deploy hook cannot cover: a later config import changing the palette without ever regenerating the file.

Verified by copying dev's stylesheet over the local one, which reproduced the failure exactly (`ct-theme-light` computing to `rgb(43, 57, 77)`, white cards rendering navy). Running the deploy hook rebuilt the file to `#f2f5f8` and restored `rgb(253, 254, 254)`. Saving a palette change and then running `drush cim` both purged the file automatically, confirming the subscriber covers the config-import path. All 44 sitemap pages re-scanned clean.

## Screenshots

N/A

## Before / After

```
BEFORE: a config change never reaches the stylesheet

  ┌──────────────────────────────────────────────────┐
  │ Config import / save changes theme colours       │
  └────────────────────────┬─────────────────────────┘
                           ▼
  ┌──────────────────────────────────────────────────┐
  │ generate() finds css-variables.drevops.css       │
  │ already on disk -> returns early, untouched      │
  └────────────────────────┬─────────────────────────┘
                           ▼
  ┌──────────────────────────────────────────────────┐
  │ Stale file keeps serving the old palette:        │
  │ --ct-color-light-background: #152235             │
  └────────────────────────┬─────────────────────────┘
                           ▼
  ┌──────────────────────────────────────────────────┐
  │ ct-page ct-theme-light renders dark:             │
  │ computed background rgb(43, 57, 77)              │
  └──────────────────────────────────────────────────┘


AFTER: a config change purges and rebuilds the stylesheet

  ┌──────────────────────────────────────────────────┐
  │ Config import / save changes theme colours       │
  └────────────────────────┬─────────────────────────┘
                           ▼
  ┌──────────────────────────────────────────────────┐
  │ ThemeColorSubscriber (on save) or the deploy     │
  │ hook (on deploy) purges the stylesheet           │
  └────────────────────────┬─────────────────────────┘
                           ▼
  ┌──────────────────────────────────────────────────┐
  │ Next request rebuilds the file from the          │
  │ configuration the site actually holds            │
  └────────────────────────┬─────────────────────────┘
                           ▼
  ┌──────────────────────────────────────────────────┐
  │ ct-page ct-theme-light renders light, matching   │
  │ its markup: background rgb(253, 254, 254)        │
  └──────────────────────────────────────────────────┘
```
