### PR TITLE
Added bulk moderation actions for publishing content from the content listing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "drupal/lagoon_logs": "^3.0.1",
         "drupal/menu_trail_by_path": "^2.2",
         "drupal/metatag": "^2.2",
+        "drupal/moderated_content_bulk_publish": "^2.0",
         "drupal/navigation_extra_tools": "^1.3.2",
         "drupal/pathauto": "^1.15",
         "drupal/purge": "^3.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca1da9b9d46d323f8e15255ad245e8e2",
+    "content-hash": "a56899a74af53f760ff782b4c24b8d3e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4614,6 +4614,61 @@
                 "source": "https://git.drupalcode.org/project/metatag",
                 "issues": "https://www.drupal.org/project/issues/metatag",
                 "docs": "https://www.drupal.org/docs/8/modules/metatag"
+            }
+        },
+        {
+            "name": "drupal/moderated_content_bulk_publish",
+            "version": "2.0.52",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/moderated_content_bulk_publish.git",
+                "reference": "2.0.52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/moderated_content_bulk_publish-2.0.52.zip",
+                "reference": "2.0.52",
+                "shasum": "16e0a4657ac50fc431cdf6ea98cd2bf61d628bf3"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11",
+                "drupal/pathauto": "*",
+                "drupal/views_bulk_operations": "^4.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.52",
+                    "datestamp": "1776128081",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "See all contributors",
+                    "homepage": "https://www.drupal.org/node/3070758/committers"
+                },
+                {
+                    "name": "joseph.olstad",
+                    "homepage": "https://www.drupal.org/user/1321830"
+                },
+                {
+                    "name": "smulvih2",
+                    "homepage": "https://www.drupal.org/user/795442"
+                }
+            ],
+            "description": "The Moderated Content Bulk Publish module does what it says from the /admin/content view.",
+            "homepage": "https://www.drupal.org/project/moderated_content_bulk_publish",
+            "support": {
+                "source": "git://git.drupal.org/project/moderated_content_bulk_publish.git",
+                "issues": "https://www.drupal.org/project/issues/moderated_content_bulk_publish"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -74,6 +74,7 @@ module:
   metatag_google_cse: 0
   metatag_open_graph: 0
   metatag_twitter_cards: 0
+  moderated_content_bulk_publish: 0
   mysql: 0
   navigation: 0
   navigation_extra_tools: 0

--- a/config/default/moderated_content_bulk_publish.settings.yml
+++ b/config/default/moderated_content_bulk_publish.settings.yml
@@ -1,0 +1,17 @@
+_core:
+  default_config_hash: Zh4iXZzPYu0noNB7nq7VJtc2b2jRQlcsm_iPCVhR328
+langcode: en
+publish:
+  state:
+    published: published
+unpublish:
+  state:
+    archived: archived
+    draft: draft
+archive:
+  state:
+    archived: archived
+enable_dialog_node_edit_form: false
+enable_dialog_admin_content: true
+disable_toolbar_language_switcher: true
+retain_revision_info: false

--- a/config/default/system.action.archive_current.yml
+++ b/config/default/system.action.archive_current.yml
@@ -1,0 +1,13 @@
+uuid: aa009340-3f56-4765-8e24-9bc7f221bc9c
+langcode: en
+status: true
+dependencies:
+  module:
+    - moderated_content_bulk_publish
+_core:
+  default_config_hash: jA-dWW4lwPrb-wRuulMa_ieNqemnCucxQuyYjezpHno
+id: archive_current
+label: 'Archive current revision'
+type: node
+plugin: archive_current_revision_action
+configuration: {  }

--- a/config/default/system.action.media_publish_latest.yml
+++ b/config/default/system.action.media_publish_latest.yml
@@ -1,0 +1,13 @@
+uuid: 5ff99ad3-3e55-4177-9084-073e7bb50686
+langcode: en
+status: true
+dependencies:
+  module:
+    - moderated_content_bulk_publish
+_core:
+  default_config_hash: jSGchmlWDxigBTVsT4jFzKa3g3vQZhdJnWcyZilkVEU
+id: media_publish_latest
+label: 'Publish latest revision'
+type: media
+plugin: publish_latest_revision_action
+configuration: {  }

--- a/config/default/system.action.media_unpublish_current.yml
+++ b/config/default/system.action.media_unpublish_current.yml
@@ -1,0 +1,13 @@
+uuid: 9d1693af-57c0-4d65-a2c6-68e61131a92f
+langcode: en
+status: true
+dependencies:
+  module:
+    - moderated_content_bulk_publish
+_core:
+  default_config_hash: z0qRc93RuNB6l-WmjOxpcOUIqmWMrYZsId_GBkcIt-M
+id: media_unpublish_current
+label: 'Unpublish current revision'
+type: media
+plugin: unpublish_current_revision_action
+configuration: {  }

--- a/config/default/system.action.publish_latest.yml
+++ b/config/default/system.action.publish_latest.yml
@@ -1,0 +1,13 @@
+uuid: 95b81902-f673-42f2-b93c-ab5b1bc0e055
+langcode: en
+status: true
+dependencies:
+  module:
+    - moderated_content_bulk_publish
+_core:
+  default_config_hash: LG5X_3pItrdFCa4jIcrtrGgKrMV643Yi7Yo0ItIsbqQ
+id: publish_latest
+label: 'Publish latest revision'
+type: node
+plugin: publish_latest_revision_action
+configuration: {  }

--- a/config/default/system.action.unpublish_current.yml
+++ b/config/default/system.action.unpublish_current.yml
@@ -1,0 +1,13 @@
+uuid: 87725ca9-993f-43de-8624-fa180499cbd0
+langcode: en
+status: true
+dependencies:
+  module:
+    - moderated_content_bulk_publish
+_core:
+  default_config_hash: Bjm8ksX4nHPLBzOEoxaWth8eXdQJzLGgEjYi8aonEWg
+id: unpublish_current
+label: 'Unpublish current revision'
+type: node
+plugin: unpublish_current_revision_action
+configuration: {  }

--- a/config/default/user.role.civictheme_content_approver.yml
+++ b/config/default/user.role.civictheme_content_approver.yml
@@ -13,6 +13,7 @@ dependencies:
     - filter
     - linkit
     - media
+    - moderated_content_bulk_publish
     - navigation
     - node
     - scheduled_transitions
@@ -32,6 +33,9 @@ permissions:
   - 'administer linkit profiles'
   - 'administer scheduled transitions'
   - 'generate ai alt tags'
+  - 'moderated content bulk archive'
+  - 'moderated content bulk publish'
+  - 'moderated content bulk unpublish'
   - 'use civictheme_editorial transition archive'
   - 'use civictheme_editorial transition create_new_draft'
   - 'use civictheme_editorial transition needs_review'

--- a/config/default/user.role.civictheme_site_administrator.yml
+++ b/config/default/user.role.civictheme_site_administrator.yml
@@ -35,6 +35,7 @@ dependencies:
     - filter
     - linkit
     - media
+    - moderated_content_bulk_publish
     - navigation
     - node
     - paragraphs_library
@@ -199,6 +200,9 @@ permissions:
   - 'edit webform variants'
   - 'generate ai alt tags'
   - 'link to any page'
+  - 'moderated content bulk archive'
+  - 'moderated content bulk publish'
+  - 'moderated content bulk unpublish'
   - 'notify of path changes'
   - 'rebuild node access permissions'
   - 'revert all revisions'

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -5,4 +5,8 @@ For common questions and answers, see
 
 ## Project-specific FAQs
 
-<!-- Add project-specific FAQs below -->
+### Why does the "Publish content" bulk action fail with "No access to execute"?
+
+Every node bundle is under the `civictheme_editorial` content moderation workflow. Core forbids the `Publish content` and `Unpublish content` bulk actions on moderated entities, because publication status is owned by the workflow rather than by the `status` field. The failure is by design and applies to every account, including uid 1.
+
+Use `Publish latest revision`, `Unpublish current revision` or `Archive current revision` instead. These apply a workflow transition and are available to the `civictheme_site_administrator` and `civictheme_content_approver` roles.


### PR DESCRIPTION
Every node bundle on this site runs under the `civictheme_editorial` content moderation workflow. Drupal core forbids the core `Publish content` / `Unpublish content` bulk actions on moderated entities, so selecting nodes on `/admin/content` and applying `Publish content` produced a `No access to execute Publish content on the Content <title>` error per row, for every account including uid 1. This adds `drupal/moderated_content_bulk_publish`, which supplies bulk action plugins that apply a workflow transition instead of writing to the `status` field directly.

The module also ships optional `pin` / `unpin` actions that only toggle `sticky`, duplicating core's `node_make_sticky_action` / `node_make_unsticky_action`, so those were not exported. Provisioning here is `VORTEX_PROVISION_TYPE=database` (database import plus config import, never a fresh profile install), so the module's `config/optional` is never reprocessed and they will not reappear.

## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [ ] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added `drupal/moderated_content_bulk_publish` `^2.0` (resolved to 2.0.52, security-advisory covered, ~11.5k sites) to `composer.json`, regenerated `composer.lock`, and enabled the module in `config/default/core.extension.yml`.
2. Added action config for the new bulk operations: `system.action.publish_latest.yml`, `system.action.unpublish_current.yml` and `system.action.archive_current.yml` for nodes, plus `system.action.media_publish_latest.yml` and `system.action.media_unpublish_current.yml` for media, since media bundles are moderated by the same workflow.
3. Added `config/default/moderated_content_bulk_publish.settings.yml`: disabled the confirmation dialog on the node edit form (`enable_dialog_node_edit_form: false`), since it would otherwise prompt on every routine published-to-published re-save of a live page, kept it enabled on `/admin/content` bulk operations (`enable_dialog_admin_content: true`) as a confirmation guard, disabled the toolbar language switcher (`disable_toolbar_language_switcher: true`, site is single-language), and turned off revision-info retention (`retain_revision_info: false`).
4. Granted `moderated content bulk publish`, `moderated content bulk unpublish` and `moderated content bulk archive` to the `civictheme_site_administrator` and `civictheme_content_approver` roles in their exported config, matching the roles that already hold the corresponding `civictheme_editorial` publish and archive transitions. `civictheme_content_author` was left out, matching its existing transition set; `administrator` already inherits everything via `is_admin: true`.
5. Documented the failure and its replacement actions as a project FAQ in `docs/faqs.md`.

## Screenshots

N/A - composer, configuration and documentation change only, no template, style or display changes.

## Before / After

```
BEFORE: /admin/content -> "Publish content"
┌──────────────────────────────────────────────────────────┐
│ [x] Project "Website Redesign"   (draft)                 │
│ [x] Project "Mobile App"         (draft)                 │
│                                                          │
│ Action: Publish content                                  │
│         -> Apply to selected items                       │
│                                                          │
│ Drupal core blocks it two ways:                          │
│  - actionInfoAlter() swaps in ModerationOptOutPublish,   │
│    whose access() = forbidden                            │
│  - entityFieldAccess() forbids edit on the moderated     │
│    "status" field                                        │
│                                                          │
│ Result:                                                  │
│  x "No access to execute Publish content on the          │
│     Content Website Redesign."                           │
│  x Same error, once per selected row.                    │
│                                                          │
│ Nothing published. Fails for every account, incl. uid 1. │
└──────────────────────────────────────────────────────────┘

AFTER: /admin/content -> "Publish latest revision"
┌───────────────────────────────────────────────────────┐
│ [x] Project "Website Redesign"   (draft)              │
│ [x] Project "Mobile App"         (draft)              │
│                                                       │
│ Action: Publish latest revision                       │
│         -> Apply to selected items                    │
│                                                       │
│ moderated_content_bulk_publish applies a workflow     │
│ transition instead of writing the "status" field:     │
│  - publish_latest_revision_action: draft -> published │
│                                                       │
│ Result:                                               │
│  v New published revision per node (e.g. vid 2573),   │
│    attributed to the acting user, revision log        │
│    "Bulk operation publish revision".                 │
│    Prior draft revision preserved.                    │
│                                                       │
│ Both nodes now published (status = 1).                │
└───────────────────────────────────────────────────────┘
```
