### PR TITLE
Added preview links for sharing unpublished content.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ The `docs/` directory contains **what** applies to this project:
 - `docs/deployment.md` - Hosting provider and deployment rules
 - `docs/releasing.md` - Version scheme and release process
 - `docs/sitemap.md` - XML sitemap module, coverage and generation
+- `docs/preview-links.md` - sharing unpublished content by link
 - `docs/faqs.md` - Project-specific FAQs
 
 **Always check these files first** to understand project-specific decisions.

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/moderated_content_bulk_publish": "^2.0",
         "drupal/navigation_extra_tools": "^1.3.2",
         "drupal/pathauto": "^1.15",
+        "drupal/preview_link": "^2.2.1",
         "drupal/purge": "^3.7",
         "drupal/purge_control": "^2.1",
         "drupal/recaptcha_v3": "^2.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "572debe49aeb0ec27544ffda1c9ff193",
+    "content-hash": "7a6d90396c70152e71e7d425ce2f9a56",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4802,6 +4802,80 @@
                 "source": "https://cgit.drupalcode.org/pathauto",
                 "issues": "https://www.drupal.org/project/issues/pathauto",
                 "documentation": "https://www.drupal.org/docs/8/modules/pathauto"
+            }
+        },
+        {
+            "name": "drupal/preview_link",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/preview_link.git",
+                "reference": "2.2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/preview_link-2.2.1.zip",
+                "reference": "2.2.1",
+                "shasum": "a54a66a0fbca9dc4d8eba80174ce0a041c48dda8"
+            },
+            "require": {
+                "drupal/core": "^10.2 || ^11",
+                "drupal/dynamic_entity_reference": "^3 || ^4",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "drupal/entity_reference_revisions": "*",
+                "drupal/paragraphs": "^1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.2.1",
+                    "datestamp": "1776652947",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "acbramley",
+                    "homepage": "https://www.drupal.org/user/1036766"
+                },
+                {
+                    "name": "benjy",
+                    "homepage": "https://www.drupal.org/user/1852732"
+                },
+                {
+                    "name": "dpi",
+                    "homepage": "https://www.drupal.org/user/81431"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                },
+                {
+                    "name": "mstrelan",
+                    "homepage": "https://www.drupal.org/user/314289"
+                },
+                {
+                    "name": "sam152",
+                    "homepage": "https://www.drupal.org/user/1485048"
+                }
+            ],
+            "description": "Allows anyone to preview unpublished content with a unique link.",
+            "homepage": "https://www.drupal.org/project/preview_link",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/preview_link",
+                "issues": "https://www.drupal.org/project/issues/preview_link"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -84,6 +84,7 @@ module:
   paragraphs_library: 0
   path: 0
   path_alias: 0
+  preview_link: 0
   purge: 0
   purge_drush: 0
   purge_processor_cron: 0

--- a/config/default/entity_clone.cloneable_entities.yml
+++ b/config/default/entity_clone.cloneable_entities.yml
@@ -64,3 +64,4 @@ cloneable_entities:
   - ai_prompt_type
   - ai_prompt
   - xmlsitemap
+  - preview_link

--- a/config/default/preview_link.settings.yml
+++ b/config/default/preview_link.settings.yml
@@ -4,4 +4,4 @@ display_message: subsequent
 enabled_entity_types:
   node: {  }
 multiple_entities: true
-expiry_seconds: 604800
+expiry_seconds: 1209600

--- a/config/default/preview_link.settings.yml
+++ b/config/default/preview_link.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: zsRG48Wp1H1fGnUoDCdsnWJMnrrwtZPwGLvGYuvKCNU
+display_message: subsequent
+enabled_entity_types:
+  node: {  }
+multiple_entities: true
+expiry_seconds: 604800

--- a/config/default/user.role.civictheme_content_approver.yml
+++ b/config/default/user.role.civictheme_content_approver.yml
@@ -16,6 +16,7 @@ dependencies:
     - moderated_content_bulk_publish
     - navigation
     - node
+    - preview_link
     - scheduled_transitions
     - system
 _core:
@@ -33,6 +34,7 @@ permissions:
   - 'administer linkit profiles'
   - 'administer scheduled transitions'
   - 'generate ai alt tags'
+  - 'generate preview links'
   - 'moderated content bulk archive'
   - 'moderated content bulk publish'
   - 'moderated content bulk unpublish'

--- a/config/default/user.role.civictheme_content_author.yml
+++ b/config/default/user.role.civictheme_content_author.yml
@@ -29,6 +29,7 @@ dependencies:
     - navigation
     - node
     - path
+    - preview_link
     - scheduled_transitions
     - system
     - taxonomy
@@ -119,6 +120,7 @@ permissions:
   - 'edit own project content'
   - 'edit terms in civictheme_media_tags'
   - 'generate ai alt tags'
+  - 'generate preview links'
   - 'revert all revisions'
   - 'revert blog revisions'
   - 'revert civictheme_alert revisions'

--- a/config/default/user.role.civictheme_site_administrator.yml
+++ b/config/default/user.role.civictheme_site_administrator.yml
@@ -41,6 +41,7 @@ dependencies:
     - paragraphs_library
     - path
     - pathauto
+    - preview_link
     - redirect
     - scheduled_transitions
     - system
@@ -81,6 +82,7 @@ permissions:
   - 'administer menu'
   - 'administer nodes'
   - 'administer paragraphs library'
+  - 'administer preview link settings'
   - 'administer redirects'
   - 'administer scheduled transitions'
   - 'administer taxonomy'
@@ -199,6 +201,7 @@ permissions:
   - 'edit webform twig'
   - 'edit webform variants'
   - 'generate ai alt tags'
+  - 'generate preview links'
   - 'link to any page'
   - 'moderated content bulk archive'
   - 'moderated content bulk publish'

--- a/docs/preview-links.md
+++ b/docs/preview-links.md
@@ -29,10 +29,10 @@ Opening the link binds its token to the visitor's session, so from that point th
 
 ## Keeping previews contained
 
-`_do_base_protect_preview_link_page()` acts on any route flagged `_preview_link_route` and does two things the module does not:
+Both act on any route flagged `_preview_link_route`, and both cover gaps the module leaves open:
 
-- Emits `noindex, nofollow`, because a preview URL is meant to be pasted into mail and chat clients that follow links.
-- Triggers the page cache kill switch. Rendering the page issues a session cookie and the response would otherwise be `max-age=900, public`, letting a shared cache serve the content after the link expired or was regenerated.
+- `_do_base_attach_preview_link_robots()` emits `noindex, nofollow`, because a preview URL is meant to be pasted into mail and chat clients that follow links.
+- `PreviewLinkCacheSubscriber` sends `Cache-Control: no-store` and trips the page cache kill switch. Left alone the response is `max-age=900, public`, and merely starting a session would only downgrade it to `private` - enough to bar shared caches, but the recipient's own browser could still surface the content from history once the link had expired or been regenerated.
 
 ## Expiry
 

--- a/docs/preview-links.md
+++ b/docs/preview-links.md
@@ -1,0 +1,44 @@
+# Preview links
+
+Editors share unpublished content with people who have no account on the site using [`drupal/preview_link`](https://www.drupal.org/project/preview_link). Generating a link produces a tokenised URL that anyone can open, so a reviewer needs neither an account nor a permission.
+
+## Why this module
+
+The editorial workflow keeps `draft` and `needs_review` off the default revision, so a page that is already live can carry a pending draft that no canonical URL will ever render. `preview_link` grants access to the **latest** revision, which covers both a page that has never been published and a draft sitting behind a published one.
+
+The obvious alternative, [`drupal/access_unpublished`](https://www.drupal.org/project/access_unpublished), only unlocks entities whose default revision is unpublished. It cannot reveal a pending draft, which is half the cases here.
+
+## How editors use it
+
+1. Open the content item and choose the **Preview Link** tab (`/node/<nid>/generate-preview-link`).
+2. Copy the generated URL and send it on.
+3. **Save and regenerate preview link** mints a new token and immediately kills the old URL. **Reset lifetime** restarts the clock without changing the URL.
+
+Opening the link binds its token to the visitor's session, so from that point they can also follow ordinary links into the content.
+
+## What is configured
+
+| Setting | Value | Why |
+|---|---|---|
+| `enabled_entity_types` | `node`, no bundle list | An empty bundle list means every content type, so a type added later gets preview links without a config change. |
+| `expiry_seconds` | `604800` (7 days) | Long enough for a review round, short enough to bound how long unpublished content stays reachable. |
+| `multiple_entities` | `true` | A page is assembled from paragraphs and media, which have to travel with the node for the preview to render like the published page will. |
+| `display_message` | `subsequent` | Tells the editor a link already exists rather than silently reusing it. |
+
+`generate preview links` is granted to Content Author, Content Approver and Site Administrator. `administer preview link settings` is granted to Site Administrator only. Recipients need no permission at all - the token is the entire credential, which is why neither permission belongs on the anonymous or authenticated role.
+
+## Keeping previews contained
+
+`_do_base_protect_preview_link_page()` acts on any route flagged `_preview_link_route` and does two things the module does not:
+
+- Emits `noindex, nofollow`, because a preview URL is meant to be pasted into mail and chat clients that follow links.
+- Triggers the page cache kill switch. Rendering the page issues a session cookie and the response would otherwise be `max-age=900, public`, letting a shared cache serve the content after the link expired or was regenerated.
+
+## Expiry
+
+Expired links are deleted on cron. Expiry is enforced on access, so a link stops working the moment it lapses rather than when cron next runs.
+
+## Related
+
+- [Development agreements](development.md) - function visibility conventions the hook follows
+- [Testing](testing.md) - PHPUnit and Behat conventions

--- a/docs/preview-links.md
+++ b/docs/preview-links.md
@@ -14,7 +14,7 @@ The obvious alternative, [`drupal/access_unpublished`](https://www.drupal.org/pr
 2. Copy the generated URL and send it on.
 3. **Save and regenerate preview link** mints a new token and immediately kills the old URL. **Reset lifetime** restarts the clock without changing the URL.
 
-Opening the link binds its token to the visitor's session, so from that point they can also follow ordinary links into the content.
+Opening the link binds its token to the visitor's session, so from that point they can follow ordinary links into the content: a URL they could not otherwise see redirects them to its preview, carrying a notice that explains why and offers to drop the token.
 
 ## What is configured
 
@@ -23,7 +23,7 @@ Opening the link binds its token to the visitor's session, so from that point th
 | `enabled_entity_types` | `node`, no bundle list | An empty bundle list means every content type, so a type added later gets preview links without a config change. |
 | `expiry_seconds` | `604800` (7 days) | Long enough for a review round, short enough to bound how long unpublished content stays reachable. |
 | `multiple_entities` | `true` | A page is assembled from paragraphs and media, which have to travel with the node for the preview to render like the published page will. |
-| `display_message` | `subsequent` | Tells the editor a link already exists rather than silently reusing it. |
+| `display_message` | `subsequent` | Shows the recipient why they can see the page, and offers to drop the token, but only when they arrive by being redirected from a normal URL. Landing on the preview link itself says nothing, which keeps the first thing they see the content rather than a notice. |
 
 `generate preview links` is granted to Content Author, Content Approver and Site Administrator. `administer preview link settings` is granted to Site Administrator only. Recipients need no permission at all - the token is the entire credential, which is why neither permission belongs on the anonymous or authenticated role.
 

--- a/docs/preview-links.md
+++ b/docs/preview-links.md
@@ -21,7 +21,7 @@ Opening the link binds its token to the visitor's session, so from that point th
 | Setting | Value | Why |
 |---|---|---|
 | `enabled_entity_types` | `node`, no bundle list | An empty bundle list means every content type, so a type added later gets preview links without a config change. |
-| `expiry_seconds` | `604800` (7 days) | Long enough for a review round, short enough to bound how long unpublished content stays reachable. |
+| `expiry_seconds` | `1209600` (14 days) | Covers a review that spans a couple of weeks, including a reviewer who is away for one of them, while still bounding how long unpublished content stays reachable. |
 | `multiple_entities` | `true` | A page is assembled from paragraphs and media, which have to travel with the node for the preview to render like the published page will. |
 | `display_message` | `subsequent` | Shows the recipient why they can see the page, and offers to drop the token, but only when they arrive by being redirected from a normal URL. Landing on the preview link itself says nothing, which keeps the first thing they see the content rather than a notice. |
 

--- a/tests/behat/features/preview_link.feature
+++ b/tests/behat/features/preview_link.feature
@@ -17,10 +17,14 @@ Feature: Preview links for unpublished content
     And I click "Preview Link"
     Then the response status code should be 200
     And I should see "Preview link"
-    And I should see the button "Save and regenerate preview link"
+
+    When I press "Save and regenerate preview link"
+    Then the response status code should be 200
+    And I should see "Expiry:"
+    And the response should contain "/preview-link/node/"
 
   @api
-  Scenario: Site Administrator generates a preview link for a draft page
+  Scenario: Site Administrator can reach the preview link form for a draft page
     Given I am logged in as a user with the "Site Administrator" role
     When I visit the "civictheme_page" content page with the title "[TEST] Preview Draft Page"
     And I click "Preview Link"

--- a/tests/behat/features/preview_link.feature
+++ b/tests/behat/features/preview_link.feature
@@ -1,0 +1,40 @@
+@p1 @preview_link
+Feature: Preview links for unpublished content
+
+  As a content editor
+  I want to send someone a link to content that is not published yet
+  So that they can review it without needing an account on the site
+
+  Background:
+    Given the following "civictheme_page" content:
+      | title                     | moderation_state | field_c_n_summary        |
+      | [TEST] Preview Draft Page | draft            | [TEST] Draft page summary |
+
+  @api
+  Scenario: Content Author generates a preview link for a draft page
+    Given I am logged in as a user with the "Content Author" role
+    When I visit the "civictheme_page" content page with the title "[TEST] Preview Draft Page"
+    And I click "Preview Link"
+    Then the response status code should be 200
+    And I should see "Preview link"
+    And I should see the button "Save and regenerate preview link"
+
+  @api
+  Scenario: Site Administrator generates a preview link for a draft page
+    Given I am logged in as a user with the "Site Administrator" role
+    When I visit the "civictheme_page" content page with the title "[TEST] Preview Draft Page"
+    And I click "Preview Link"
+    Then the response status code should be 200
+    And I should see the button "Save and regenerate preview link"
+
+  @api
+  Scenario: Editor without the permission is not offered a preview link
+    Given I am logged in as a user with the "access content, access administration pages, access content overview, view any unpublished content" permissions
+    When I visit the "civictheme_page" content page with the title "[TEST] Preview Draft Page"
+    Then I should not see the link "Preview Link"
+
+  @api
+  Scenario: Site visitor cannot reach a draft page without a preview link
+    Given I am an anonymous user
+    When I visit the "civictheme_page" content page with the title "[TEST] Preview Draft Page"
+    Then the response status code should be 403

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -26,15 +26,51 @@ function do_base_mail_alter(array &$message): void {
  * Implements hook_page_attachments().
  */
 function do_base_page_attachments(array &$attachments): void {
-  // Attach a CSP nonce to script-src on every page so that Drupal core's
-  // inline scripts (BigPipe placeholders, drupalSettings, etc.) continue to
-  // run under a strict Content-Security-Policy. The fallback 'unsafe-inline'
-  // is only used by browsers that do not support CSP3 nonces; modern
-  // browsers ignore it when a nonce is present.
+  _do_base_protect_preview_link_page($attachments);
+  _do_base_attach_csp_nonce($attachments);
+}
+
+/**
+ * Confines a preview link page to the person holding the token.
+ */
+function _do_base_protect_preview_link_page(array &$attachments): void {
+  $route = \Drupal::routeMatch()->getRouteObject();
+
+  if ($route === NULL || $route->getOption('_preview_link_route') !== TRUE) {
+    return;
+  }
+
+  // A preview link renders unpublished content to anyone holding the token,
+  // and the URL is meant to be pasted into mail and chat clients that follow
+  // links, so the page must never reach a search index.
+  $attachments['#attached']['html_head'][] = [
+    [
+      '#tag' => 'meta',
+      '#attributes' => [
+        'name' => 'robots',
+        'content' => 'noindex, nofollow',
+      ],
+    ],
+    'do_base_preview_link_robots',
+  ];
+
+  // Rendering the page issues a session cookie and the response would
+  // otherwise be publicly cacheable, so a shared cache could keep serving the
+  // content after the link expires or is regenerated. Previews are rare
+  // enough that rendering each one costs nothing worth keeping.
+  \Drupal::service('page_cache_kill_switch')->trigger();
+}
+
+/**
+ * Attaches a CSP nonce so core's inline scripts survive a strict policy.
+ */
+function _do_base_attach_csp_nonce(array &$attachments): void {
   if (!class_exists(Csp::class)) {
     return;
   }
 
+  // The 'unsafe-inline' fallback is only used by browsers without CSP3 nonce
+  // support; modern browsers ignore it once a nonce is present.
   $existing = $attachments['#attached']['csp_nonce']['script'] ?? [];
   $attachments['#attached']['csp_nonce']['script'] = array_values(array_unique(array_merge($existing, [Csp::POLICY_UNSAFE_INLINE])));
 

--- a/web/modules/custom/do_base/do_base.module
+++ b/web/modules/custom/do_base/do_base.module
@@ -26,14 +26,14 @@ function do_base_mail_alter(array &$message): void {
  * Implements hook_page_attachments().
  */
 function do_base_page_attachments(array &$attachments): void {
-  _do_base_protect_preview_link_page($attachments);
+  _do_base_attach_preview_link_robots($attachments);
   _do_base_attach_csp_nonce($attachments);
 }
 
 /**
- * Confines a preview link page to the person holding the token.
+ * Keeps preview link pages out of search indexes.
  */
-function _do_base_protect_preview_link_page(array &$attachments): void {
+function _do_base_attach_preview_link_robots(array &$attachments): void {
   $route = \Drupal::routeMatch()->getRouteObject();
 
   if ($route === NULL || $route->getOption('_preview_link_route') !== TRUE) {
@@ -53,12 +53,6 @@ function _do_base_protect_preview_link_page(array &$attachments): void {
     ],
     'do_base_preview_link_robots',
   ];
-
-  // Rendering the page issues a session cookie and the response would
-  // otherwise be publicly cacheable, so a shared cache could keep serving the
-  // content after the link expires or is regenerated. Previews are rare
-  // enough that rendering each one costs nothing worth keeping.
-  \Drupal::service('page_cache_kill_switch')->trigger();
 }
 
 /**

--- a/web/modules/custom/do_base/do_base.services.yml
+++ b/web/modules/custom/do_base/do_base.services.yml
@@ -9,3 +9,8 @@ services:
     arguments: ['@class_resolver', '@theme_handler']
     tags:
       - { name: event_subscriber }
+  do_base.preview_link_cache_subscriber:
+    class: Drupal\do_base\EventSubscriber\PreviewLinkCacheSubscriber
+    arguments: ['@page_cache_kill_switch']
+    tags:
+      - { name: event_subscriber }

--- a/web/modules/custom/do_base/src/EventSubscriber/PreviewLinkCacheSubscriber.php
+++ b/web/modules/custom/do_base/src/EventSubscriber/PreviewLinkCacheSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\do_base\EventSubscriber;
+
+use Drupal\Core\PageCache\ResponsePolicy\KillSwitch;
+use Drupal\Core\Routing\RouteObjectInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Keeps preview link responses out of every cache.
+ *
+ * A preview link shows unpublished content to whoever holds its token, and that
+ * token can expire or be regenerated at any moment. Any stored copy outlives
+ * it: a shared cache would go on serving the content to whoever asks for that
+ * URL, and a browser cache would surface it from history once the token had
+ * stopped working.
+ */
+final class PreviewLinkCacheSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    protected KillSwitch $killSwitch,
+  ) {}
+
+  /**
+   * Marks a preview link response as never storable.
+   */
+  public function onResponse(ResponseEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $route = $event->getRequest()->attributes->get(RouteObjectInterface::ROUTE_OBJECT);
+
+    if (!$route instanceof Route || $route->getOption('_preview_link_route') !== TRUE) {
+      return;
+    }
+
+    // The internal page cache decides from the response policy rather than
+    // from the header, so setting the header alone would not stop it storing
+    // the page.
+    $this->killSwitch->trigger();
+
+    // Rendering the page starts a session, which on its own only earns the
+    // response 'private'. That bars shared caches but still lets the
+    // recipient's own browser keep a copy, so ask for no storage at all.
+    $event->getResponse()->headers->set('Cache-Control', 'no-store');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    // Later than FinishResponseSubscriber, which sets Cache-Control itself.
+    return [KernelEvents::RESPONSE => ['onResponse', -10]];
+  }
+
+}

--- a/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
+++ b/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
@@ -100,6 +100,10 @@ class PreviewLinkTest extends DoBaseFunctionalTestBase {
 
   /**
    * Tests that a link stops working once it expires.
+   *
+   * The link is opened first so the refusal is known to come from the expiry
+   * rather than from a URL that never worked, and the canonical route is
+   * checked afterwards because by then the session is holding a stale token.
    */
   public function testExpiredLinkIsRefused(): void {
     // Prepare.
@@ -107,11 +111,50 @@ class PreviewLinkTest extends DoBaseFunctionalTestBase {
     $preview_link = $this->createPreviewLink($node);
     $url = $preview_link->getUrl($node);
 
+    // Act.
+    $this->drupalGet($url);
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Prepare.
     $preview_link->setExpiry(new \DateTime('-1 minute'));
     $preview_link->save();
 
     // Act.
     $this->drupalGet($url);
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Act.
+    $this->drupalGet($node->toUrl());
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
+   * Tests that a link unlocks only the content it was created for.
+   *
+   * Preview links carry several entities so a page's paragraphs and media
+   * travel with it, which makes it worth proving that the session a token
+   * opens does not reach unpublished content the link never named.
+   */
+  public function testLinkDoesNotUnlockUnrelatedContent(): void {
+    // Prepare.
+    $linked = $this->createModeratedNode('[TEST] Linked Draft', 'draft');
+    $unrelated = $this->createModeratedNode('[TEST] Unrelated Draft', 'draft');
+    $preview_link = $this->createPreviewLink($linked);
+
+    // Act.
+    $this->drupalGet($preview_link->getUrl($linked));
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Act.
+    $this->drupalGet($unrelated->toUrl());
 
     // Assert.
     $this->assertSession()->statusCodeEquals(403);

--- a/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
+++ b/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
@@ -176,12 +176,13 @@ class PreviewLinkTest extends DoBaseFunctionalTestBase {
   }
 
   /**
-   * Tests that a preview page is never held by a shared cache.
+   * Tests that a preview page is never stored by any cache.
    *
-   * A cached copy would outlive the link, so an expired or regenerated token
-   * would keep serving the content until the cache entry lapsed.
+   * A stored copy outlives the link, so an expired or regenerated token would
+   * keep serving the content until the entry lapsed. Only 'no-store' covers
+   * the recipient's own browser as well as shared caches.
    */
-  public function testPreviewPageIsNotStoredBySharedCaches(): void {
+  public function testPreviewPageIsNotStoredByAnyCache(): void {
     // Prepare.
     $node = $this->createModeratedNode('[TEST] Uncached Draft', 'draft');
     $preview_link = $this->createPreviewLink($node);
@@ -197,9 +198,26 @@ class PreviewLinkTest extends DoBaseFunctionalTestBase {
     $this->drupalGet($preview_link->getUrl($node));
 
     // Assert.
+    $this->assertPreviewIsNotStorable();
+
+    // Act.
+    $this->drupalGet($node->toUrl());
+
+    // Assert.
+    $this->assertPreviewIsNotStorable('The canonical route reroutes to the preview while the token is held, so it must not be stored either.');
+  }
+
+  /**
+   * Asserts the current response may not be stored by any cache.
+   *
+   * The directives are matched individually because their order and any
+   * companions Symfony merges in are incidental to the guarantee.
+   */
+  protected function assertPreviewIsNotStorable(string $message = ''): void {
     $cache_control = (string) $this->getSession()->getResponseHeader('Cache-Control');
-    $this->assertStringContainsString('private', $cache_control);
-    $this->assertStringNotContainsString('public', $cache_control);
+
+    $this->assertStringContainsString('no-store', $cache_control, $message);
+    $this->assertStringNotContainsString('public', $cache_control, $message);
   }
 
   /**

--- a/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
+++ b/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_base\Functional;
+
+use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
+use Drupal\node\NodeInterface;
+use Drupal\preview_link\Entity\PreviewLinkInterface;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that a preview link shows unpublished content to its recipient only.
+ *
+ * The recipient is an anonymous visitor holding nothing but the token, so these
+ * tests never authenticate: what a logged-out request can and cannot reach is
+ * the whole contract.
+ */
+#[Group('do_base')]
+class PreviewLinkTest extends DoBaseFunctionalTestBase {
+
+  use ContentModerationTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'content_moderation',
+    'workflows',
+    'page_cache',
+    'preview_link',
+    'do_base',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Without a page lifetime every response is uncacheable anyway, which would
+    // pass the cache assertions without exercising anything.
+    $this->config('system.performance')->set('cache.page.max_age', 900)->save();
+    $this->config('preview_link.settings')->set('enabled_entity_types', ['node' => []])->save();
+
+    $this->drupalCreateContentType(['type' => 'page', 'name' => 'Page']);
+
+    $workflow = $this->createEditorialWorkflow();
+    $this->addEntityTypeAndBundleToWorkflow($workflow, 'node', 'page');
+  }
+
+  /**
+   * Tests that the recipient of a link reads content the public cannot.
+   */
+  public function testRecipientReadsUnpublishedContent(): void {
+    // Prepare.
+    $node = $this->createModeratedNode('[TEST] Draft Page', 'draft');
+    $preview_link = $this->createPreviewLink($node);
+
+    // Act.
+    $this->drupalGet($node->toUrl());
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Act.
+    $this->drupalGet($preview_link->getUrl($node));
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('[TEST] Draft Page');
+  }
+
+  /**
+   * Tests that a draft awaiting review is previewed, not the published page.
+   *
+   * The editorial workflow keeps a draft off the default revision, so a page
+   * that is already live still renders its published text everywhere except
+   * here. Previewing the pending revision is why this module was chosen.
+   */
+  public function testPendingDraftIsPreviewedOverThePublishedRevision(): void {
+    // Prepare.
+    $node = $this->createModeratedNode('[TEST] Published Page', 'published');
+    $node->setTitle('[TEST] Pending Draft');
+    $node->set('moderation_state', 'draft');
+    $node->setNewRevision();
+    $node->save();
+
+    $preview_link = $this->createPreviewLink($node);
+
+    // Act.
+    $this->drupalGet($preview_link->getUrl($node));
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('[TEST] Pending Draft');
+    $this->assertSession()->pageTextNotContains('[TEST] Published Page');
+  }
+
+  /**
+   * Tests that a link stops working once it expires.
+   */
+  public function testExpiredLinkIsRefused(): void {
+    // Prepare.
+    $node = $this->createModeratedNode('[TEST] Expired Draft', 'draft');
+    $preview_link = $this->createPreviewLink($node);
+    $url = $preview_link->getUrl($node);
+
+    $preview_link->setExpiry(new \DateTime('-1 minute'));
+    $preview_link->save();
+
+    // Act.
+    $this->drupalGet($url);
+
+    // Assert.
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
+   * Tests that a preview page is kept out of search indexes.
+   */
+  public function testPreviewPageIsNotIndexable(): void {
+    // Prepare.
+    $node = $this->createModeratedNode('[TEST] Unindexed Draft', 'draft');
+    $preview_link = $this->createPreviewLink($node);
+
+    // Act.
+    $this->drupalGet($preview_link->getUrl($node));
+
+    // Assert.
+    $this->assertSession()->elementExists('css', 'meta[name="robots"][content="noindex, nofollow"]');
+  }
+
+  /**
+   * Tests that a preview page is never held by a shared cache.
+   *
+   * A cached copy would outlive the link, so an expired or regenerated token
+   * would keep serving the content until the cache entry lapsed.
+   */
+  public function testPreviewPageIsNotStoredBySharedCaches(): void {
+    // Prepare.
+    $node = $this->createModeratedNode('[TEST] Uncached Draft', 'draft');
+    $preview_link = $this->createPreviewLink($node);
+    $published = $this->createModeratedNode('[TEST] Cached Page', 'published');
+
+    // Act.
+    $this->drupalGet($published->toUrl());
+
+    // Assert.
+    $this->assertStringContainsString('public', (string) $this->getSession()->getResponseHeader('Cache-Control'), 'An ordinary node page is expected to stay publicly cacheable.');
+
+    // Act.
+    $this->drupalGet($preview_link->getUrl($node));
+
+    // Assert.
+    $cache_control = (string) $this->getSession()->getResponseHeader('Cache-Control');
+    $this->assertStringContainsString('private', $cache_control);
+    $this->assertStringNotContainsString('public', $cache_control);
+  }
+
+  /**
+   * Creates a node in the given moderation state.
+   */
+  protected function createModeratedNode(string $title, string $moderation_state): NodeInterface {
+    $node = $this->drupalCreateNode([
+      'type' => 'page',
+      'title' => $title,
+      'moderation_state' => $moderation_state,
+    ]);
+
+    return $node;
+  }
+
+  /**
+   * Creates a preview link covering the given node.
+   */
+  protected function createPreviewLink(NodeInterface $node): PreviewLinkInterface {
+    $preview_link = $this->container->get('entity_type.manager')->getStorage('preview_link')->create(['entities' => [$node]]);
+    $preview_link->save();
+
+    return $preview_link;
+  }
+
+}

--- a/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
+++ b/web/modules/custom/do_base/tests/src/Functional/PreviewLinkTest.php
@@ -206,13 +206,11 @@ class PreviewLinkTest extends DoBaseFunctionalTestBase {
    * Creates a node in the given moderation state.
    */
   protected function createModeratedNode(string $title, string $moderation_state): NodeInterface {
-    $node = $this->drupalCreateNode([
+    return $this->drupalCreateNode([
       'type' => 'page',
       'title' => $title,
       'moderation_state' => $moderation_state,
     ]);
-
-    return $node;
   }
 
   /**
@@ -220,6 +218,11 @@ class PreviewLinkTest extends DoBaseFunctionalTestBase {
    */
   protected function createPreviewLink(NodeInterface $node): PreviewLinkInterface {
     $preview_link = $this->container->get('entity_type.manager')->getStorage('preview_link')->create(['entities' => [$node]]);
+
+    if (!$preview_link instanceof PreviewLinkInterface) {
+      throw new \UnexpectedValueException('Preview link storage returned an unexpected entity type.');
+    }
+
     $preview_link->save();
 
     return $preview_link;

--- a/web/modules/custom/do_base/tests/src/Traits/ExportedConfigTrait.php
+++ b/web/modules/custom/do_base/tests/src/Traits/ExportedConfigTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_base\Traits;
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Trait ExportedConfigTrait.
+ *
+ * Provides access to the configuration exported into the repository.
+ *
+ * @codeCoverageIgnore
+ */
+trait ExportedConfigTrait {
+
+  /**
+   * Reads an exported configuration file from the default config directory.
+   */
+  protected function loadConfig(string $file_name): array {
+    $path = dirname($this->root) . '/config/default/' . $file_name;
+    $this->assertFileExists($path);
+
+    return Yaml::parseFile($path);
+  }
+
+  /**
+   * Lists the bundle names of an entity type from its exported config files.
+   */
+  protected function loadBundleNames(string $config_prefix): array {
+    $files = glob(dirname($this->root) . '/config/default/' . $config_prefix . '.*.yml');
+    $this->assertNotEmpty($files, sprintf('No exported bundles found for "%s".', $config_prefix));
+
+    return array_map(static fn(string $file): string => substr(basename($file, '.yml'), strlen($config_prefix) + 1), $files);
+  }
+
+}

--- a/web/modules/custom/do_base/tests/src/Traits/ExportedConfigTrait.php
+++ b/web/modules/custom/do_base/tests/src/Traits/ExportedConfigTrait.php
@@ -29,7 +29,7 @@ trait ExportedConfigTrait {
    * Lists the bundle names of an entity type from its exported config files.
    */
   protected function loadBundleNames(string $config_prefix): array {
-    $files = glob(dirname($this->root) . '/config/default/' . $config_prefix . '.*.yml');
+    $files = glob(dirname($this->root) . '/config/default/' . $config_prefix . '.*.yml') ?: [];
     $this->assertNotEmpty($files, sprintf('No exported bundles found for "%s".', $config_prefix));
 
     return array_map(static fn(string $file): string => substr(basename($file, '.yml'), strlen($config_prefix) + 1), $files);

--- a/web/modules/custom/do_base/tests/src/Unit/DateFormatConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/DateFormatConfigTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Drupal\Tests\do_base\Unit;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\do_base\Traits\ExportedConfigTrait;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Tests that the exported date configuration renders Australian dates.
@@ -21,6 +21,8 @@ use Symfony\Component\Yaml\Yaml;
 #[CoversNothing]
 #[Group('do_base')]
 class DateFormatConfigTest extends UnitTestCase {
+
+  use ExportedConfigTrait;
 
   /**
    * Reference date rendered through each pattern: 4 August 2026, 2:30pm.
@@ -111,16 +113,6 @@ class DateFormatConfigTest extends UnitTestCase {
     yield 'default timezone' => [['timezone', 'default'], 'Australia/Melbourne'];
     yield 'default country' => [['country', 'default'], 'AU'];
     yield 'week starts on Monday' => [['first_day'], 1];
-  }
-
-  /**
-   * Reads an exported configuration file from the default config directory.
-   */
-  protected function loadConfig(string $file_name): array {
-    $path = dirname($this->root) . '/config/default/' . $file_name;
-    $this->assertFileExists($path);
-
-    return Yaml::parseFile($path);
   }
 
 }

--- a/web/modules/custom/do_base/tests/src/Unit/PathautoPatternConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PathautoPatternConfigTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Drupal\Tests\do_base\Unit;
 
 use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\do_base\Traits\ExportedConfigTrait;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Tests the URL alias patterns exported for each content type.
@@ -20,6 +20,8 @@ use Symfony\Component\Yaml\Yaml;
 #[CoversNothing]
 #[Group('do_base')]
 class PathautoPatternConfigTest extends UnitTestCase {
+
+  use ExportedConfigTrait;
 
   /**
    * Tests that a content type generates aliases under its expected prefix.
@@ -66,16 +68,6 @@ class PathautoPatternConfigTest extends UnitTestCase {
     yield 'blog post' => ['blog'];
     yield 'event' => ['civictheme_event'];
     yield 'project' => ['project'];
-  }
-
-  /**
-   * Reads an exported configuration file from the default config directory.
-   */
-  protected function loadConfig(string $file_name): array {
-    $path = dirname($this->root) . '/config/default/' . $file_name;
-    $this->assertFileExists($path);
-
-    return Yaml::parseFile($path);
   }
 
 }

--- a/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
@@ -142,7 +142,7 @@ class PreviewLinkConfigTest extends UnitTestCase {
    * The token is the only credential a recipient has, so granting either
    * permission to a site-wide role would hand it to every visitor instead.
    */
-  #[DataProvider('dataProviderUnprivilegedRole')]
+  #[DataProvider('dataProviderUnprivilegedRoleCannotGenerate')]
   public function testUnprivilegedRoleCannotGenerate(string $role_id): void {
     // Act.
     $permissions = $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'];
@@ -154,7 +154,7 @@ class PreviewLinkConfigTest extends UnitTestCase {
   /**
    * Data provider for testUnprivilegedRoleCannotGenerate.
    */
-  public static function dataProviderUnprivilegedRole(): \Iterator {
+  public static function dataProviderUnprivilegedRoleCannotGenerate(): \Iterator {
     yield 'anonymous' => ['anonymous'];
     yield 'authenticated' => ['authenticated'];
   }

--- a/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
@@ -106,12 +106,16 @@ class PreviewLinkConfigTest extends UnitTestCase {
   }
 
   /**
-   * Tests that no role beyond the editorial three can mint a preview link.
+   * Tests that no role beyond the expected ones holds each permission.
    *
-   * Naming the roles that must not hold the permission would leave a role
-   * added later untested, so every exported role is weighed against the
-   * allowlist instead. A recipient needs no permission at all, so a site-wide
-   * role holding this one would hand link creation to every visitor.
+   * Naming the roles that must not hold a permission would leave a role added
+   * later untested, so every exported role is weighed against the allowlist
+   * instead. A recipient needs no permission at all, so a site-wide role
+   * holding one of these would hand link creation to every visitor.
+   *
+   * A role flagged 'is_admin' holds every permission without listing any, so
+   * it counts as granted here. Reading only the explicit list would let a new
+   * administrative role pick both permissions up unnoticed.
    */
   #[DataProvider('dataProviderPermissionIsConfinedToItsRoles')]
   public function testPermissionIsConfinedToItsRoles(string $permission, array $expected): void {
@@ -119,7 +123,9 @@ class PreviewLinkConfigTest extends UnitTestCase {
     $granted = [];
 
     foreach ($this->loadBundleNames('user.role') as $role_id) {
-      if (in_array($permission, $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'] ?? [], TRUE)) {
+      $role = $this->loadConfig('user.role.' . $role_id . '.yml');
+
+      if (($role['is_admin'] ?? FALSE) === TRUE || in_array($permission, $role['permissions'] ?? [], TRUE)) {
         $granted[] = $role_id;
       }
     }
@@ -132,18 +138,15 @@ class PreviewLinkConfigTest extends UnitTestCase {
 
   /**
    * Data provider for testPermissionIsConfinedToItsRoles.
-   *
-   * The administrator role carries 'is_admin', so it holds every permission
-   * without listing any, and is absent from these lists by design.
    */
   public static function dataProviderPermissionIsConfinedToItsRoles(): \Iterator {
     yield 'generating links' => [
       'generate preview links',
-      ['civictheme_content_approver', 'civictheme_content_author', 'civictheme_site_administrator'],
+      ['administrator', 'civictheme_content_approver', 'civictheme_content_author', 'civictheme_site_administrator'],
     ];
     yield 'changing the bounds' => [
       'administer preview link settings',
-      ['civictheme_site_administrator'],
+      ['administrator', 'civictheme_site_administrator'],
     ];
   }
 

--- a/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
@@ -104,59 +104,45 @@ class PreviewLinkConfigTest extends UnitTestCase {
   }
 
   /**
-   * Tests that site administrators can change the preview link bounds.
-   */
-  public function testSiteAdministratorCanAdminister(): void {
-    // Act.
-    $permissions = $this->loadConfig('user.role.civictheme_site_administrator.yml')['permissions'];
-
-    // Assert.
-    $this->assertContains('administer preview link settings', $permissions);
-  }
-
-  /**
-   * Tests that no other role can change the preview link bounds.
-   */
-  #[DataProvider('dataProviderRoleCannotAdminister')]
-  public function testRoleCannotAdminister(string $role_id): void {
-    // Act.
-    $permissions = $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'];
-
-    // Assert.
-    $this->assertNotContains('administer preview link settings', $permissions);
-  }
-
-  /**
-   * Data provider for testRoleCannotAdminister.
-   */
-  public static function dataProviderRoleCannotAdminister(): \Iterator {
-    yield 'content author' => ['civictheme_content_author'];
-    yield 'content approver' => ['civictheme_content_approver'];
-    yield 'anonymous' => ['anonymous'];
-    yield 'authenticated' => ['authenticated'];
-  }
-
-  /**
-   * Tests that a preview link needs no permission to open.
+   * Tests that no role beyond the editorial three can mint a preview link.
    *
-   * The token is the only credential a recipient has, so granting either
-   * permission to a site-wide role would hand it to every visitor instead.
+   * Naming the roles that must not hold the permission would leave a role
+   * added later untested, so every exported role is weighed against the
+   * allowlist instead. A recipient needs no permission at all, so a site-wide
+   * role holding this one would hand link creation to every visitor.
    */
-  #[DataProvider('dataProviderUnprivilegedRoleCannotGenerate')]
-  public function testUnprivilegedRoleCannotGenerate(string $role_id): void {
+  #[DataProvider('dataProviderPermissionIsConfinedToItsRoles')]
+  public function testPermissionIsConfinedToItsRoles(string $permission, array $expected): void {
     // Act.
-    $permissions = $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'];
+    $granted = [];
+
+    foreach ($this->loadBundleNames('user.role') as $role_id) {
+      if (in_array($permission, $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'] ?? [], TRUE)) {
+        $granted[] = $role_id;
+      }
+    }
+
+    sort($granted);
 
     // Assert.
-    $this->assertNotContains('generate preview links', $permissions);
+    $this->assertSame($expected, $granted);
   }
 
   /**
-   * Data provider for testUnprivilegedRoleCannotGenerate.
+   * Data provider for testPermissionIsConfinedToItsRoles.
+   *
+   * The administrator role carries 'is_admin', so it holds every permission
+   * without listing any, and is absent from these lists by design.
    */
-  public static function dataProviderUnprivilegedRoleCannotGenerate(): \Iterator {
-    yield 'anonymous' => ['anonymous'];
-    yield 'authenticated' => ['authenticated'];
+  public static function dataProviderPermissionIsConfinedToItsRoles(): \Iterator {
+    yield 'generating links' => [
+      'generate preview links',
+      ['civictheme_content_approver', 'civictheme_content_author', 'civictheme_site_administrator'],
+    ];
+    yield 'changing the bounds' => [
+      'administer preview link settings',
+      ['civictheme_site_administrator'],
+    ];
   }
 
 }

--- a/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
@@ -104,7 +104,18 @@ class PreviewLinkConfigTest extends UnitTestCase {
   }
 
   /**
-   * Tests that only site administrators can change the preview link bounds.
+   * Tests that site administrators can change the preview link bounds.
+   */
+  public function testSiteAdministratorCanAdminister(): void {
+    // Act.
+    $permissions = $this->loadConfig('user.role.civictheme_site_administrator.yml')['permissions'];
+
+    // Assert.
+    $this->assertContains('administer preview link settings', $permissions);
+  }
+
+  /**
+   * Tests that no other role can change the preview link bounds.
    */
   #[DataProvider('dataProviderRoleCannotAdminister')]
   public function testRoleCannotAdminister(string $role_id): void {

--- a/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
@@ -56,7 +56,9 @@ class PreviewLinkConfigTest extends UnitTestCase {
     // A page is assembled from paragraphs and media, which have to travel with
     // the node for the preview to render the way the published page will.
     yield 'a link can carry referenced entities' => ['multiple_entities', TRUE];
-    yield 'the editor is told a link was created' => ['display_message', 'subsequent'];
+    // The notice reaches the recipient only when a normal URL redirected them
+    // here, so landing on the link itself opens on the content, not a banner.
+    yield 'a redirected recipient is told why they can see the page' => ['display_message', 'subsequent'];
   }
 
   /**

--- a/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_base\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\do_base\Traits\ExportedConfigTrait;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the exported configuration behind shareable preview links.
+ *
+ * A preview link exposes unpublished content on a public URL, so the settings
+ * that bound it and the roles allowed to mint one are pinned here. Every one of
+ * these values is reachable from the admin UI and lands back in the repository
+ * through a routine re-export, where a widened lifetime or a dropped permission
+ * reads as noise in a large diff.
+ */
+#[CoversNothing]
+#[Group('do_base')]
+class PreviewLinkConfigTest extends UnitTestCase {
+
+  use ExportedConfigTrait;
+
+  /**
+   * Tests that the module providing preview links stays installed.
+   */
+  public function testModuleIsInstalled(): void {
+    // Act.
+    $modules = $this->loadConfig('core.extension.yml')['module'];
+
+    // Assert.
+    $this->assertArrayHasKey('preview_link', $modules);
+  }
+
+  /**
+   * Tests that a preview link's bounds are exported as intended.
+   */
+  #[DataProvider('dataProviderSetting')]
+  public function testSetting(string $key, mixed $expected): void {
+    // Act.
+    $settings = $this->loadConfig('preview_link.settings.yml');
+
+    // Assert.
+    $this->assertSame($expected, $settings[$key]);
+  }
+
+  /**
+   * Data provider for testSetting.
+   */
+  public static function dataProviderSetting(): \Iterator {
+    yield 'links expire after a week' => ['expiry_seconds', 604800];
+    // A page is assembled from paragraphs and media, which have to travel with
+    // the node for the preview to render the way the published page will.
+    yield 'a link can carry referenced entities' => ['multiple_entities', TRUE];
+    yield 'the editor is told a link was created' => ['display_message', 'subsequent'];
+  }
+
+  /**
+   * Tests that every content type can be previewed.
+   *
+   * An empty bundle list means the entity type is enabled for all of its
+   * bundles, which is what keeps a content type added later from silently
+   * shipping without preview links.
+   */
+  public function testEveryContentTypeIsPreviewable(): void {
+    // Prepare.
+    $enabled = $this->loadConfig('preview_link.settings.yml')['enabled_entity_types'];
+    $this->assertArrayHasKey('node', $enabled, 'Preview links are not enabled for any content type.');
+
+    if ($enabled['node'] === []) {
+      return;
+    }
+
+    // Act.
+    $missing = array_diff($this->loadBundleNames('node.type'), $enabled['node']);
+
+    // Assert.
+    $this->assertSame([], array_values($missing), 'Content types are missing from the preview link settings.');
+  }
+
+  /**
+   * Tests that the editorial roles can mint a preview link.
+   */
+  #[DataProvider('dataProviderRoleCanGenerate')]
+  public function testRoleCanGenerate(string $role_id): void {
+    // Act.
+    $permissions = $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'];
+
+    // Assert.
+    $this->assertContains('generate preview links', $permissions);
+  }
+
+  /**
+   * Data provider for testRoleCanGenerate.
+   */
+  public static function dataProviderRoleCanGenerate(): \Iterator {
+    yield 'content author' => ['civictheme_content_author'];
+    yield 'content approver' => ['civictheme_content_approver'];
+    yield 'site administrator' => ['civictheme_site_administrator'];
+  }
+
+  /**
+   * Tests that only site administrators can change the preview link bounds.
+   */
+  #[DataProvider('dataProviderRoleCannotAdminister')]
+  public function testRoleCannotAdminister(string $role_id): void {
+    // Act.
+    $permissions = $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'];
+
+    // Assert.
+    $this->assertNotContains('administer preview link settings', $permissions);
+  }
+
+  /**
+   * Data provider for testRoleCannotAdminister.
+   */
+  public static function dataProviderRoleCannotAdminister(): \Iterator {
+    yield 'content author' => ['civictheme_content_author'];
+    yield 'content approver' => ['civictheme_content_approver'];
+    yield 'anonymous' => ['anonymous'];
+    yield 'authenticated' => ['authenticated'];
+  }
+
+  /**
+   * Tests that a preview link needs no permission to open.
+   *
+   * The token is the only credential a recipient has, so granting either
+   * permission to a site-wide role would hand it to every visitor instead.
+   */
+  #[DataProvider('dataProviderUnprivilegedRole')]
+  public function testUnprivilegedRoleCannotGenerate(string $role_id): void {
+    // Act.
+    $permissions = $this->loadConfig('user.role.' . $role_id . '.yml')['permissions'];
+
+    // Assert.
+    $this->assertNotContains('generate preview links', $permissions);
+  }
+
+  /**
+   * Data provider for testUnprivilegedRoleCannotGenerate.
+   */
+  public static function dataProviderUnprivilegedRole(): \Iterator {
+    yield 'anonymous' => ['anonymous'];
+    yield 'authenticated' => ['authenticated'];
+  }
+
+}

--- a/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/PreviewLinkConfigTest.php
@@ -52,7 +52,7 @@ class PreviewLinkConfigTest extends UnitTestCase {
    * Data provider for testSetting.
    */
   public static function dataProviderSetting(): \Iterator {
-    yield 'links expire after a week' => ['expiry_seconds', 604800];
+    yield 'links expire after a fortnight' => ['expiry_seconds', 1209600];
     // A page is assembled from paragraphs and media, which have to travel with
     // the node for the preview to render the way the published page will.
     yield 'a link can carry referenced entities' => ['multiple_entities', TRUE];


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Added the `drupal/preview_link` contrib module (`composer.json`, `composer.lock`) and enabled it (`config/default/core.extension.yml`), so editors can generate a tokenised, expiring URL to the latest revision of a node - covering both a node that has never been published and a draft sitting behind an already-published revision, which `drupal/access_unpublished` cannot do since it only unlocks entities whose default revision is unpublished.
2. Exported `preview_link.settings.yml`: links expire after `1209600` seconds (14 days, chosen over the module's 7-day default so a review spanning a fortnight outlives its link), cover every node bundle (`enabled_entity_types: node: {  }` with no bundle list, so a content type added later is covered without a config change), carry referenced entities (`multiple_entities: true`, so paragraphs and media travel with the node), and show the "why am I seeing this" notice only when a visitor is redirected from the canonical URL rather than on the preview link itself (`display_message: subsequent`).
3. Granted `generate preview links` to the Content Author, Content Approver and Site Administrator roles, and `administer preview link settings` to Site Administrator only (`config/default/user.role.*.yml`). Recipients need no permission at all, since the token is the entire credential.
4. Added `preview_link` to the `entity_clone` cloneable entities list (`config/default/entity_clone.cloneable_entities.yml`).
5. Added `_do_base_attach_preview_link_robots()` to `web/modules/custom/do_base/do_base.module`, which adds a `noindex, nofollow` meta tag on any route flagged `_preview_link_route`, because a preview URL is meant to be pasted into mail and chat clients that follow links. The pre-existing CSP nonce logic moved into its own `_do_base_attach_csp_nonce()` helper so `hook_page_attachments()` reads as a dispatcher.
6. Added `PreviewLinkCacheSubscriber` (`web/modules/custom/do_base/src/EventSubscriber/`, registered in `do_base.services.yml`) to keep preview responses out of every cache. Left alone the response is `max-age=900, public`, and starting a session only downgrades it to `private`, which bars shared caches but still lets the recipient's own browser hold a copy that outlives the link. The subscriber sets `Cache-Control: no-store` and trips the page cache kill switch, since Drupal's internal page cache decides from the response policy rather than from the header.
7. Added `PreviewLinkTest` (functional) covering that a link's recipient reads content the public cannot, that a pending draft is previewed over its already-published revision, that an expired link is refused (the link itself, and the canonical route while the session still holds the stale token), that a link does not unlock unrelated unpublished content, that the preview page is non-indexable, and that neither the preview URL nor the rerouted canonical URL may be stored by any cache while an ordinary node page stays publicly cacheable.
8. Added `PreviewLinkConfigTest` (unit) pinning the exported settings, module installation and per-bundle coverage against config drift. Rather than naming the roles that must not hold each permission, which would leave a role added later untested, it walks every exported `user.role.*.yml` and asserts the set of roles granted each permission equals the allowlist exactly. A role flagged `is_admin` counts as granted, so the assertion is about effective rather than merely explicit permissions and a new administrative role cannot pick either permission up unnoticed. The `loadConfig()` helper duplicated across `DateFormatConfigTest` and `PathautoPatternConfigTest` was extracted into a shared `ExportedConfigTrait`, which also gained `loadBundleNames()`.
9. Added a Behat feature (`tests/behat/features/preview_link.feature`) covering the editor-facing flow: a Content Author opens the `Preview Link` tab, presses `Save and regenerate preview link` and gets a generated URL with an expiry; a Site Administrator can reach the same form; an editor without the permission is not offered the tab; and an anonymous visitor gets a 403 on the draft without a link.
10. Documented the feature in `docs/preview-links.md` and referenced it from `AGENTS.md`.

## Screenshots

![Preview Link tab on the node edit form](https://raw.githubusercontent.com/drevops/website/3b7a8fa753dc535a11fa34c5bf3328baa0ffa11f/feature-preview-links/3250be3a2ce65f2972c50dae69895ef13a768a0e.png)

## Before / After

```
BEFORE
┌────────────────────────────────────────────────┐
│ Unpublished / draft node                       │
└────────────────────────────────────────────────┘
        │
        v
┌────────────────────────────────────────────────┐
│ No shareable URL exists                        │
│ Reviewer needs a site account and              │
│ the "view any unpublished content"             │
│ permission                                     │
└────────────────────────────────────────────────┘

AFTER
┌────────────────────────────────────────────────┐
│ Unpublished / draft node                       │
└────────────────────────────────────────────────┘
        │
        │  editor opens the "Preview Link" tab
        v
┌────────────────────────────────────────────────┐
│ Tokenised URL, expires in 1209600s (14d)       │
└────────────────────────────────────────────────┘
        │
        │  recipient opens the link, no account needed
        v
┌────────────────────────────────────────────────┐
│ do_base hook:        "noindex, nofollow" meta  │
│ do_base subscriber:  Cache-Control: no-store   │
│                      + page cache kill switch  │
└────────────────────────────────────────────────┘
        │
        v
┌────────────────────────────────────────────────┐
│ Latest revision renders, kept out of search    │
│ indexes and of every cache, shared or browser  │
└────────────────────────────────────────────────┘
```

Response headers on the preview route, measured against the running site:

```
BEFORE   cache-control: max-age=900, public
         x-drupal-cache: MISS            (stored, and shared-cacheable)

AFTER    cache-control: no-store, private
         x-drupal-cache: UNCACHEABLE (response policy)

An ordinary page is unchanged:
         cache-control: max-age=900, public
         x-drupal-cache: HIT
```
