### PR TITLE
Replaced 'promote' with 'sticky' as the pinning sort in automated lists.

### DIFF
--- a/config/default/views.view.civictheme_automated_list.yml
+++ b/config/default/views.view.civictheme_automated_list.yml
@@ -126,15 +126,15 @@ display:
           content: '<div class="ct-basic-content"><p>No results found.</p></div>'
           tokenize: false
       sorts:
-        promote:
-          id: promote
+        sticky:
+          id: sticky
           table: node_field_data
-          field: promote
+          field: sticky
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: promote
+          entity_field: sticky
           plugin_id: standard
           order: DESC
           expose:

--- a/tests/behat/features/paragraph_civictheme_automated_list_sort.feature
+++ b/tests/behat/features/paragraph_civictheme_automated_list_sort.feature
@@ -1,0 +1,51 @@
+@p0 @civictheme @civictheme_automated_list
+Feature: Automated list sorting
+
+  As a content editor
+  I want sticky content pinned to the top of an automated list
+  So that I can highlight important content without changing its authored date
+
+  Background:
+    Given the following "civictheme_topics" terms:
+      | name              |
+      | [TEST] List Topic |
+
+    And the following "civictheme_page" content:
+      | title                      | moderation_state |
+      | [TEST] Automated List Page | published        |
+
+    And the following fields for the paragraph "civictheme_automated_list" exist in the field "field_c_n_components" within the "civictheme_page" "node" identified by the field "title" and the value "[TEST] Automated List Page":
+      | field_c_p_title             | [TEST] Automated list title |
+      | field_c_p_list_content_type | civictheme_page             |
+      | field_c_p_list_topics       | [TEST] List Topic           |
+
+  @api
+  Scenario: Sticky content appears above more recently authored content
+    Given I am an anonymous user
+    And the following "civictheme_page" content:
+      | title                | moderation_state | created            | sticky | promote | field_c_n_topics  |
+      | [TEST] Newest Page   | published        | [relative:-1 day]  | 0      | 0       | [TEST] List Topic |
+      | [TEST] Sticky Page   | published        | [relative:-2 days] | 1      | 0       | [TEST] List Topic |
+      | [TEST] Promoted Page | published        | [relative:-3 days] | 0      | 1       | [TEST] List Topic |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Automated List Page"
+    Then I should see the text "[TEST] Automated list title"
+    And I should see 3 ".ct-promo-card" elements
+
+    And the text "[TEST] Newest Page" should appear after the text "[TEST] Sticky Page"
+    And the text "[TEST] Promoted Page" should appear after the text "[TEST] Newest Page"
+
+  @api
+  Scenario: Content without a sticky flag is ordered by the authored date
+    Given I am an anonymous user
+    And the following "civictheme_page" content:
+      | title                | moderation_state | created            | sticky | promote | field_c_n_topics  |
+      | [TEST] Newest Page   | published        | [relative:-1 day]  | 0      | 0       | [TEST] List Topic |
+      | [TEST] Middle Page   | published        | [relative:-2 days] | 0      | 0       | [TEST] List Topic |
+      | [TEST] Promoted Page | published        | [relative:-3 days] | 0      | 1       | [TEST] List Topic |
+
+    When I visit the "civictheme_page" content page with the title "[TEST] Automated List Page"
+    Then I should see 3 ".ct-promo-card" elements
+
+    And the text "[TEST] Middle Page" should appear after the text "[TEST] Newest Page"
+    And the text "[TEST] Promoted Page" should appear after the text "[TEST] Middle Page"


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Swapped the `promote` sort for a `sticky` sort as the first (primary) sort in the `civictheme_automated_list` view (`config/default/views.view.civictheme_automated_list.yml`), keeping `DESC` order. The `Authored on` (`created`) DESC secondary sort is unchanged. `promote` controls front-page promotion, not list pinning, so editors could not pin an item to the top of an automated list without also promoting it to the front page; `sticky` (`Sticky at top of lists`) now drives the pinning instead.
2. Added `tests/behat/features/paragraph_civictheme_automated_list_sort.feature` with two `@api` scenarios: one confirms a sticky item renders above a more recently authored, non-sticky item (and above a merely promoted item); the other confirms that, with nothing sticky, ordering still falls back to authored date. Both were verified locally against the fix (pass) and against the prior `promote`-based config (fail).

## Screenshots

N/A - config-only change to a view's sort order, plus a Behat feature file. No template, styling, or layout changes.

## Before / After

```
BEFORE - sort stack: promote DESC, then created DESC
┌─────────────────────────────────────────────┐
│ 1. Promoted Page    (promote=1)              │  <- pinned by accident
│ 2. Newest Page      (created -1 day)         │
│ 3. Sticky Page      (created -2 days)        │  <- meant to be pinned, buried
└─────────────────────────────────────────────┘

AFTER - sort stack: sticky DESC, then created DESC
┌─────────────────────────────────────────────┐
│ 1. Sticky Page      (sticky=1)               │  <- pinned as intended
│ 2. Newest Page      (created -1 day)         │
│ 3. Promoted Page    (created -3 days)        │  <- promotion no longer pins it
└─────────────────────────────────────────────┘
```
