### PR TITLE
[#302] Cropped the banner featured image on its focal point and gave the divider and figure images a style.

### DIFF
--- a/config/default/image.style.banner_featured.yml
+++ b/config/default/image.style.banner_featured.yml
@@ -1,0 +1,23 @@
+uuid: fb579dc8-21da-4a99-887b-920afb0cde42
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: banner_featured
+label: 'Banner featured image (1090x818, WebP)'
+effects:
+  24958aa6-09b2-48bd-b29e-b38b76f1168d:
+    uuid: 24958aa6-09b2-48bd-b29e-b38b76f1168d
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1090
+      height: 818
+      crop_type: focal_point
+  a405d584-d557-469f-bdc0-9e7fb2b290d9:
+    uuid: a405d584-d557-469f-bdc0-9e7fb2b290d9
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/config/default/image.style.divider.yml
+++ b/config/default/image.style.divider.yml
@@ -1,0 +1,21 @@
+uuid: 12950d43-9e28-4023-af34-1ad10d79a313
+langcode: en
+status: true
+dependencies: {  }
+name: divider
+label: 'Divider (480 tall, WebP)'
+effects:
+  8bef4bca-0946-4c77-b443-d3e6bdecf045:
+    uuid: 8bef4bca-0946-4c77-b443-d3e6bdecf045
+    id: image_scale
+    weight: 1
+    data:
+      width: 1090
+      height: 480
+      upscale: false
+  bd7d2701-0350-48a9-8961-3697c2dfd7c6:
+    uuid: bd7d2701-0350-48a9-8961-3697c2dfd7c6
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -9,11 +9,17 @@ An image style does two things here: it caps the pixel dimensions, and it conver
 | Style | Used for |
 |---|---|
 | `banner_background` | The banner background: scaled to 1920 wide, converted to WebP |
+| `banner_featured` | The banner featured image: cropped to 1090x818 around the focal point, converted to WebP |
 | `civictheme_*` | Cards, campaigns and slides: cropped by the CivicTheme sizes, converted to WebP |
-| `wide` | The banner featured image |
+| `divider` | The divider graphic: scaled to fit within 1090x480, converted to WebP |
+| `wide` | An image placed in content and rendered as a figure |
 | `social_share` | Share cards, deliberately **not** converted, because some social crawlers still handle WebP badly |
 
-CivicTheme resolves both banner images with no image style at all, which yields the URL of the original upload. `_drevops_banner_apply_image_styles()` re-resolves them. It covers the block field and the node field, because the node's value wins when both are set.
+CivicTheme resolves several of these with no image style at all, which yields the URL of the original upload. Three preprocessors here re-resolve them: `_drevops_banner_apply_image_styles()` for the two banner images, `drevops_preprocess_paragraph__divider()` for the divider, and `drevops_preprocess_media__civictheme_image()` for the figure. The banner one covers the block field and the node field, because the node's value wins when both are set.
+
+The featured image sits in a box 40% of the viewport wide and no more than 600px tall, filled with `object-fit: cover`. Its ratio moves with the viewport and with how tall the banner's own content makes it, so the browser trims a different part of the image on every screen. A focal point crop puts the subject at the centre of the derivative, which is the part `cover` keeps whichever way it trims.
+
+`drevops_preprocess_media__civictheme_image()` also clears the width and height CivicTheme measured on the source file, because they describe a different image once a style has resized it.
 
 When adding an image style that renders photographic content, copy the `image_convert` effect from `image.style.large.yml`. A style with only a crop effect ships whatever format was uploaded.
 

--- a/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\do_base\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\do_base\Traits\ExportedConfigTrait;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the image styles the theme renders images through.
+ *
+ * A style name reaches the theme layer as a plain string, so a missing style or
+ * an effect dropped in a routine re-export fails silently. The page still
+ * renders; only the size and the crop of the image change.
+ */
+#[CoversNothing]
+#[Group('do_base')]
+class ImageStyleConfigTest extends UnitTestCase {
+
+  use ExportedConfigTrait;
+
+  /**
+   * Machine name of the style behind the banner's featured image.
+   */
+  protected const FEATURED_STYLE = 'banner_featured';
+
+  /**
+   * Tests that every style the theme asks for by name is exported.
+   */
+  #[DataProvider('dataProviderStyleNamedByTheme')]
+  public function testStyleNamedByThemeIsExported(string $name): void {
+    // Act.
+    $style = $this->loadConfig('image.style.' . $name . '.yml');
+
+    // Assert.
+    $this->assertSame($name, $style['name']);
+  }
+
+  /**
+   * Data provider for testStyleNamedByThemeIsExported.
+   */
+  public static function dataProviderStyleNamedByTheme(): \Iterator {
+    foreach (static::themeStyleNames() as $name) {
+      yield $name => [$name];
+    }
+  }
+
+  /**
+   * Tests that the featured image is cropped around the editor's focal point.
+   *
+   * The banner sizes the image with CSS, so the browser trims everything
+   * outside a centred box. A focal point crop places the subject at that
+   * centre.
+   */
+  public function testFeaturedImageCropsOnTheFocalPoint(): void {
+    // Act.
+    $effect = $this->effect(static::FEATURED_STYLE, 'focal_point_scale_and_crop');
+
+    // Assert.
+    $this->assertNotNull($effect, 'The featured image style does not crop on a focal point.');
+    $this->assertSame('focal_point', $effect['data']['crop_type']);
+    $this->assertGreaterThan(0, $effect['data']['width']);
+    $this->assertGreaterThan(0, $effect['data']['height']);
+  }
+
+  /**
+   * Tests that the styles rendering uploaded imagery convert to WebP.
+   *
+   * The theme renders only photographic content through a style: brand renders
+   * and generated art uploaded as multi-megabyte PNGs. A style without a
+   * convert effect serves the uploaded format.
+   */
+  #[DataProvider('dataProviderStyleNamedByTheme')]
+  public function testStyleNamedByThemeConvertsToWebp(string $name): void {
+    // Act.
+    $effect = $this->effect($name, 'image_convert');
+
+    // Assert.
+    $this->assertNotNull($effect, sprintf('Style "%s" does not convert.', $name));
+    $this->assertSame('webp', $effect['data']['extension']);
+  }
+
+  /**
+   * Returns an effect of a style, or NULL when the style does not have one.
+   */
+  protected function effect(string $name, string $effect_id): ?array {
+    $effects = $this->loadConfig('image.style.' . $name . '.yml')['effects'];
+
+    foreach ($effects as $effect) {
+      if ($effect['id'] === $effect_id) {
+        return $effect;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Lists the style names the theme passes to the image render helpers.
+   *
+   * Names are read from the theme rather than listed here, so a component that
+   * starts rendering through a style of its own is covered without editing this
+   * test.
+   */
+  protected static function themeStyleNames(): array {
+    $helpers = [
+      'civictheme_media_image_get_variables',
+      '_civictheme_preprocess_paragraph__paragraph_field__image',
+      '_civictheme_preprocess_paragraph__node_field__image',
+    ];
+
+    $pattern = sprintf('~(?:%s)\([^)]*,\s*\'([a-z0-9_]+)\'\s*\)~', implode('|', $helpers));
+
+    $names = [];
+
+    foreach (glob(dirname(__DIR__, 7) . '/web/themes/custom/drevops/includes/*.inc') ?: [] as $file) {
+      if (preg_match_all($pattern, (string) file_get_contents($file), $matches) === 0) {
+        continue;
+      }
+
+      $names = array_merge($names, $matches[1]);
+    }
+
+    $names = array_unique($names);
+    sort($names);
+
+    if ($names === []) {
+      throw new \RuntimeException('No image styles found in the theme; the scanned helper names are out of date.');
+    }
+
+    return $names;
+  }
+
+}

--- a/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
@@ -115,7 +115,7 @@ class ImageStyleConfigTest extends UnitTestCase {
    * Returns an effect of a style, or NULL when the style does not have one.
    */
   protected function effect(string $name, string $effect_id): ?array {
-    $effects = $this->loadConfig('image.style.' . $name . '.yml')['effects'];
+    $effects = $this->loadConfig('image.style.' . $name . '.yml')['effects'] ?? [];
 
     foreach ($effects as $effect) {
       if ($effect['id'] === $effect_id) {

--- a/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
@@ -29,6 +29,11 @@ class ImageStyleConfigTest extends UnitTestCase {
   protected const FEATURED_STYLE = 'banner_featured';
 
   /**
+   * Machine name of the style behind the divider graphic.
+   */
+  protected const DIVIDER_STYLE = 'divider';
+
+  /**
    * Tests that every style the theme asks for by name is exported.
    */
   #[DataProvider('dataProviderStyleNamedByTheme')]
@@ -65,6 +70,23 @@ class ImageStyleConfigTest extends UnitTestCase {
     $this->assertSame('focal_point', $effect['data']['crop_type']);
     $this->assertGreaterThan(0, $effect['data']['width']);
     $this->assertGreaterThan(0, $effect['data']['height']);
+  }
+
+  /**
+   * Tests that the divider graphic is capped at the size it is drawn at.
+   *
+   * CSS bounds the rendered height, so an uncapped derivative sends pixels the
+   * page never draws. Upscaling a small graphic to the cap blurs it instead.
+   */
+  public function testDividerIsScaledWithinBounds(): void {
+    // Act.
+    $effect = $this->effect(static::DIVIDER_STYLE, 'image_scale');
+
+    // Assert.
+    $this->assertNotNull($effect, 'The divider style does not scale.');
+    $this->assertGreaterThan(0, $effect['data']['width']);
+    $this->assertGreaterThan(0, $effect['data']['height']);
+    $this->assertFalse($effect['data']['upscale']);
   }
 
   /**

--- a/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
+++ b/web/modules/custom/do_base/tests/src/Unit/ImageStyleConfigTest.php
@@ -36,7 +36,7 @@ class ImageStyleConfigTest extends UnitTestCase {
   /**
    * Tests that every style the theme asks for by name is exported.
    */
-  #[DataProvider('dataProviderStyleNamedByTheme')]
+  #[DataProvider('dataProviderStyleNamedByThemeIsExported')]
   public function testStyleNamedByThemeIsExported(string $name): void {
     // Act.
     $style = $this->loadConfig('image.style.' . $name . '.yml');
@@ -48,10 +48,8 @@ class ImageStyleConfigTest extends UnitTestCase {
   /**
    * Data provider for testStyleNamedByThemeIsExported.
    */
-  public static function dataProviderStyleNamedByTheme(): \Iterator {
-    foreach (static::themeStyleNames() as $name) {
-      yield $name => [$name];
-    }
+  public static function dataProviderStyleNamedByThemeIsExported(): \Iterator {
+    yield from static::styleNameCases();
   }
 
   /**
@@ -96,7 +94,7 @@ class ImageStyleConfigTest extends UnitTestCase {
    * and generated art uploaded as multi-megabyte PNGs. A style without a
    * convert effect serves the uploaded format.
    */
-  #[DataProvider('dataProviderStyleNamedByTheme')]
+  #[DataProvider('dataProviderStyleNamedByThemeConvertsToWebp')]
   public function testStyleNamedByThemeConvertsToWebp(string $name): void {
     // Act.
     $effect = $this->effect($name, 'image_convert');
@@ -104,6 +102,13 @@ class ImageStyleConfigTest extends UnitTestCase {
     // Assert.
     $this->assertNotNull($effect, sprintf('Style "%s" does not convert.', $name));
     $this->assertSame('webp', $effect['data']['extension']);
+  }
+
+  /**
+   * Data provider for testStyleNamedByThemeConvertsToWebp.
+   */
+  public static function dataProviderStyleNamedByThemeConvertsToWebp(): \Iterator {
+    yield from static::styleNameCases();
   }
 
   /**
@@ -119,6 +124,15 @@ class ImageStyleConfigTest extends UnitTestCase {
     }
 
     return NULL;
+  }
+
+  /**
+   * Yields one case per style name, keyed by the name.
+   */
+  protected static function styleNameCases(): \Iterator {
+    foreach (static::themeStyleNames() as $name) {
+      yield $name => [$name];
+    }
   }
 
   /**

--- a/web/themes/custom/drevops/components/01-atoms/image/image.component.yml
+++ b/web/themes/custom/drevops/components/01-atoms/image/image.component.yml
@@ -33,3 +33,7 @@ props:
       type: string
       title: Modifier classes
       description: Additional CSS classes.
+    attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Additional HTML attributes
+      description: Additional HTML attributes to add to the component.

--- a/web/themes/custom/drevops/components/03-organisms/divider/divider.scss
+++ b/web/themes/custom/drevops/components/03-organisms/divider/divider.scss
@@ -9,6 +9,9 @@
   border-bottom: solid ct-particle(0.125);
 
   img {
+    // The dimension attributes set a width, so clamping the height alone would
+    // distort the image.
+    width: auto;
     height: 100%;
     max-width: 100%;
   }

--- a/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
+++ b/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
@@ -25,7 +25,7 @@
 <div class="ct-divider {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
   {% block image %}
     {{ include('civictheme:image', {
-      theme: theme,
+      theme: theme|default('light'),
       url: image.url,
       alt: '',
       attributes: create_attribute({'role': 'presentation'}),

--- a/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
+++ b/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
@@ -28,7 +28,7 @@
       theme: theme|default('light'),
       url: image.url,
       alt: '',
-      attributes: create_attribute({'role': 'presentation'}),
+      attributes: create_attribute({role: 'presentation'}),
     }, with_context: false) }}
   {% endblock %}
 </div>

--- a/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
+++ b/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
@@ -24,11 +24,13 @@
 
 <div class="ct-divider {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
   {% block image %}
-    {{ include('civictheme:image', {
-      theme: theme|default('light'),
-      url: image.url,
-      alt: '',
-      attributes: create_attribute({role: 'presentation'}),
-    }, with_context: false) }}
+    {% if image is defined and image.url is not empty %}
+      {{ include('civictheme:image', {
+        theme: theme|default('light'),
+        url: image.url,
+        alt: '',
+        attributes: create_attribute({role: 'presentation'}),
+      }, with_context: false) }}
+    {% endif %}
   {% endblock %}
 </div>

--- a/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
+++ b/web/themes/custom/drevops/components/03-organisms/divider/divider.twig
@@ -24,6 +24,11 @@
 
 <div class="ct-divider {{ modifier_class -}}" {% if attributes is defined and attributes is not null %}{{- attributes -}}{% endif %}>
   {% block image %}
-    <img src="{{ image.url }}" alt="" role="presentation">
+    {{ include('civictheme:image', {
+      theme: theme,
+      url: image.url,
+      alt: '',
+      attributes: create_attribute({'role': 'presentation'}),
+    }, with_context: false) }}
   {% endblock %}
 </div>

--- a/web/themes/custom/drevops/drevops.theme
+++ b/web/themes/custom/drevops/drevops.theme
@@ -13,6 +13,7 @@ require_once __DIR__ . '/includes/system_main_block.inc';
 require_once __DIR__ . '/includes/banner.inc';
 require_once __DIR__ . '/includes/paragraphs.inc';
 require_once __DIR__ . '/includes/divider.inc';
+require_once __DIR__ . '/includes/media.inc';
 require_once __DIR__ . '/includes/manual_list.inc';
 require_once __DIR__ . '/includes/steps.inc';
 require_once __DIR__ . '/includes/page.inc';

--- a/web/themes/custom/drevops/includes/banner.inc
+++ b/web/themes/custom/drevops/includes/banner.inc
@@ -75,7 +75,7 @@ function _drevops_banner_apply_image_styles(array &$variables, FieldableEntityIn
   $featured = $featured ?: civictheme_get_field_value($block, 'field_c_b_featured_image', TRUE, build: $variables);
 
   if ($featured instanceof MediaInterface) {
-    $variables['featured_image'] = civictheme_media_image_get_variables($featured, 'wide');
+    $variables['featured_image'] = civictheme_media_image_get_variables($featured, 'banner_featured');
   }
 }
 

--- a/web/themes/custom/drevops/includes/divider.inc
+++ b/web/themes/custom/drevops/includes/divider.inc
@@ -13,7 +13,7 @@ declare(strict_types=1);
 function drevops_preprocess_paragraph__divider(array &$variables): void {
   _civictheme_preprocess_paragraph__paragraph_field__theme($variables);
   _civictheme_preprocess_paragraph__paragraph_field__vertical_spacing($variables);
-  _civictheme_preprocess_paragraph__paragraph_field__image($variables);
+  _civictheme_preprocess_paragraph__paragraph_field__image($variables, 'divider');
 
   _drevops_preprocess_paragraph__paragraph_field__size($variables);
   _drevops_preprocess_paragraph__paragraph_field__alignment($variables);

--- a/web/themes/custom/drevops/includes/media.inc
+++ b/web/themes/custom/drevops/includes/media.inc
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Media component alterations.
+ */
+
+declare(strict_types=1);
+
+use Drupal\media\MediaInterface;
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function drevops_preprocess_media__civictheme_image(array &$variables): void {
+  $media = $variables['media'] ?? NULL;
+
+  // A source file that cannot be read as an image leaves the URL empty.
+  if (!$media instanceof MediaInterface || empty($variables['url'])) {
+    return;
+  }
+
+  // CivicTheme builds this URL from the source file, so it serves the original
+  // upload.
+  $image = civictheme_media_image_get_variables($media, 'wide');
+
+  if (empty($image['url'])) {
+    return;
+  }
+
+  $variables['url'] = $image['url'];
+
+  // Dimensions measured on the source no longer match once a style resizes the
+  // image. The image component resolves them from the URL.
+  $variables['width'] = NULL;
+  $variables['height'] = NULL;
+}


### PR DESCRIPTION
Closes #302

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. The banner featured image was resolved through the `wide` style, a plain scale. The banner sizes it with CSS (`object-fit: cover` in a box 40% of the viewport wide, capped at 600px tall), so the visible crop was decided by the browser and landed wherever the subject happened to sit. A new `banner_featured` image style (`config/default/image.style.banner_featured.yml`) crops to 1090x818 around the editor's focal point and converts to WebP, wired in through `_drevops_banner_apply_image_styles()` in `web/themes/custom/drevops/includes/banner.inc`.
2. Two other components resolved images with no style at all and served the original upload: the divider paragraph, and the in-content figure (a media image rendered through a new `drevops_preprocess_media__civictheme_image()` hook in `web/themes/custom/drevops/includes/media.inc`). The divider gets its own `divider` style (`config/default/image.style.divider.yml`, scaled to fit 1090x480, WebP); the figure reuses `wide`, which already matches the content column width. On `/blog/meet-vortex` that turns a 3036x1520 PNG of 183 KB into a 1090x546 WebP of 27 KB.
3. `drevops_preprocess_media__civictheme_image()` clears the width and height CivicTheme measured on the source file, because they describe a different image once a style has resized it; the image component resolves them from the derivative URL instead.
4. The divider template (`divider.twig`) now includes the shared `civictheme:image` component instead of writing its own `<img>`, so it gains width and height like every other image. That gave the image a specified width, which made `max-height` clamp the height without preserving the ratio, so `width: auto` was added to `.ct-divider img` in `divider.scss`. The `attributes` prop was added to the image component's schema (`image.component.yml`) so `role="presentation"` can still be passed through.
5. A unit test (`ImageStyleConfigTest`) reads the style names out of the theme's own preprocess code and asserts each is exported, converts to WebP, that the featured style crops on a focal point, and that the divider style caps its derivative without upscaling.
6. `docs/performance.md` records the new styles and the reasoning behind each.
7. Verification: every URL in the sitemap (92 pages) was fetched and every image reference checked for an image style, for width/height, and for an alt attribute, with 0 findings. All 111 distinct image URLs resolve.

## Screenshots

![Featured image cropped on focal point](https://raw.githubusercontent.com/drevops/website/5a026f112b9cebdb592adca5ac6e1eaee8710a3e/feature-302-featured-image-style/878a18b1c72221d4e800dbcc00bda29069714a9b.png)

## Before / After

```
BEFORE                                          AFTER
┌─────────────────────────────┐                 ┌─────────────────────────────┐
│ Banner featured image        │                 │ Banner featured image        │
│  style: wide (plain scale)   │   ──────────▶   │  style: banner_featured      │
│  crop decided by CSS         │                 │  focal-point crop, WebP      │
│  object-fit: cover           │                 │  1090x818                    │
└─────────────────────────────┘                 └─────────────────────────────┘

┌─────────────────────────────┐                 ┌─────────────────────────────┐
│ Divider paragraph            │                 │ Divider paragraph            │
│  <img> tag, no style         │   ──────────▶   │  civictheme:image component  │
│  serves original upload      │                 │  style: divider, WebP        │
│  no width/height attrs       │                 │  fits 1090x480, no upscale   │
└─────────────────────────────┘                 └─────────────────────────────┘

┌─────────────────────────────┐                 ┌─────────────────────────────┐
│ In-content figure            │                 │ In-content figure            │
│  media image, no style       │   ──────────▶   │  style: wide, WebP           │
│  3036x1520 PNG, 183 KB       │                 │  1090x546, 27 KB             │
└─────────────────────────────┘                 └─────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optimized image handling for featured banners and dividers, including WebP conversion and responsive sizing.
  - Featured banner images now use focal-point cropping to preserve important content.
  - Divider images scale within defined limits while maintaining their proportions.
  - Improved image rendering support for media-based components and custom HTML attributes.

- **Bug Fixes**
  - Improved fallback behavior when image media cannot be resolved.
  - Prevented unnecessary image upscaling and corrected displayed dimensions after resizing.

- **Documentation**
  - Updated performance guidance with the supported image styles, dimensions, and optimization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->