### PR TITLE
Re-anchored the work page Behat assertions on fixtures under test mode.

### DIFF
--- a/scripts/provision-10-enable-dev-modules.sh
+++ b/scripts/provision-10-enable-dev-modules.sh
@@ -28,4 +28,12 @@ if echo "${environment}" | grep -q -e local -e ci; then
   drush pm:enable sdc_devel
 fi
 
+# Scenarios tagged "@testmode" restrict lists to test content, so the module
+# has to be enabled wherever the test suite runs. It is excluded from the
+# exported configuration, which is why it is enabled here rather than shipped
+# as installed.
+if echo "${environment}" | grep -q -e local -e ci; then
+  drush pm:enable testmode
+fi
+
 info "Finished enabling development modules."

--- a/tests/behat/features/our_work_page.feature
+++ b/tests/behat/features/our_work_page.feature
@@ -2,15 +2,8 @@
 Feature: Our work page
 
   As a site visitor
-  I want to reach the work section from anywhere on the site
-  So that I can find the projects that have been delivered
-
-  # CI provisions from the production database, so editorial copy and the
-  # number of published projects change without a code change. Assertions
-  # here stay on the route and the navigation structure; project rendering,
-  # listing and pagination are covered against fixtures in
-  # project_content_type.feature and
-  # paragraph_civictheme_automated_list_pager.feature.
+  I want to browse the projects that have been delivered
+  So that I can judge the depth of the work before making contact
 
   @api
   Scenario: The work section is reachable and leads the primary navigation
@@ -19,3 +12,29 @@ Feature: Our work page
     Then the response status code should be 200
     # The link leads the menu, so the first item is the one that must point here.
     And the element ".ct-navigation__menu .ct-menu__item--level-0:first-child .ct-menu__item__link" with the attribute "href" and the value "/work" should exist
+
+  @api @testmode
+  Scenario: Each list shows only the published projects tagged for it
+    Given the following "project" content:
+      | title                         | moderation_state | field_c_n_topics   | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
+      | [TEST] Client project 01      | published        | Custom development | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Client project 02      | published        | Custom development | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Client project 03      | published        | Custom development | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Client project 04      | published        | Custom development | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Client project 05      | published        | Custom development | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Client project 06      | published        | Custom development | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Open source project 01 | published        | Open source        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Open source project 02 | published        | Open source        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Open source project 03 | published        | Open source        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Open source project 04 | published        | Open source        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Open source project 05 | published        | Open source        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Open source project 06 | published        | Open source        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
+      | [TEST] Client draft           | draft            | Custom development | 2025            | ongoing           | large                 | inherit                | normal                      | both                       |
+    And I am an anonymous user
+    When I go to "/work"
+    Then the response status code should be 200
+    And the element ".block-field-blocknodecivictheme-pagefield-c-n-components > .ct-list:first-child" should contain 6 elements matching ".ct-promo-card"
+    And the element ".block-field-blocknodecivictheme-pagefield-c-n-components > .ct-list:last-child" should contain 6 elements matching ".ct-promo-card"
+    And I should see "[TEST] Client project 01" in the ".block-field-blocknodecivictheme-pagefield-c-n-components > .ct-list:first-child" element
+    And I should see "[TEST] Open source project 01" in the ".block-field-blocknodecivictheme-pagefield-c-n-components > .ct-list:last-child" element
+    And I should not see the text "[TEST] Client draft"

--- a/tests/behat/features/our_work_page.feature
+++ b/tests/behat/features/our_work_page.feature
@@ -2,45 +2,20 @@
 Feature: Our work page
 
   As a site visitor
-  I want to browse the projects that have been delivered
-  So that I can judge the depth of the work before making contact
+  I want to reach the work section from anywhere on the site
+  So that I can find the projects that have been delivered
+
+  # CI provisions from the production database, so editorial copy and the
+  # number of published projects change without a code change. Assertions
+  # here stay on the route and the navigation structure; project rendering,
+  # listing and pagination are covered against fixtures in
+  # project_content_type.feature and
+  # paragraph_civictheme_automated_list_pager.feature.
 
   @api
-  Scenario: The page opens the primary navigation and introduces the work
+  Scenario: The work section is reachable and leads the primary navigation
     Given I am an anonymous user
     When I go to "/work"
     Then the response status code should be 200
-    And I should see the text "Work you can go and look at."
-    And I should see the text "Client work"
-    And I should see the text "Open Source work"
     # The link leads the menu, so the first item is the one that must point here.
     And the element ".ct-navigation__menu .ct-menu__item--level-0:first-child .ct-menu__item__link" with the attribute "href" and the value "/work" should exist
-
-  @api
-  Scenario: Published projects are listed as promo cards, twelve to a page
-    Given the following "project" content:
-      | title                     | moderation_state | field_do_n_year | field_do_n_status | field_c_n_banner_type | field_c_n_banner_theme | field_c_n_banner_blend_mode | field_c_n_vertical_spacing |
-      | [TEST] Our work project 01 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 02 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 03 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 04 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 05 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 06 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 07 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 08 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 09 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 10 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 11 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 12 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work project 13 | published        | 2025            | completed         | large                 | inherit                | normal                      | both                       |
-      | [TEST] Our work draft      | draft            | 2025            | ongoing           | large                 | inherit                | normal                      | both                       |
-    And I am an anonymous user
-    When I go to "/work"
-    Then the response status code should be 200
-    # The page carries more than one list, so the count is scoped to the first
-    # one - the paginated list of client projects - rather than to the whole
-    # main region. Asserting the page fills rather than the total keeps projects
-    # already on the site from changing the outcome.
-    And the element "[data-component-id='civictheme:list']" should contain 12 elements matching ".ct-promo-card"
-    And should see a ".ct-pagination__items" element
-    And I should not see the text "[TEST] Our work draft"

--- a/tests/phpunit/Drupal/EnvironmentSettingsTest.php
+++ b/tests/phpunit/Drupal/EnvironmentSettingsTest.php
@@ -259,6 +259,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
     $config['shield.settings']['shield_enable'] = TRUE;
     $config['system.performance']['cache']['page']['max_age'] = 900;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;
@@ -333,6 +334,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
     $config['shield.settings']['shield_enable'] = TRUE;
     $config['system.performance']['cache']['page']['max_age'] = 1800;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     // Verify settings overrides.
@@ -417,6 +419,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['purge_control.settings']['purge_auto_control'] = FALSE;
     $config['seckit.settings']['seckit_xss']['csp']['checkbox'] = FALSE;
     $config['seckit.settings']['seckit_xss']['csp']['upgrade-req'] = FALSE;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;
@@ -471,6 +474,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['purge_control.settings']['purge_auto_control'] = FALSE;
     $config['seckit.settings']['seckit_xss']['csp']['checkbox'] = FALSE;
     $config['seckit.settings']['seckit_xss']['csp']['upgrade-req'] = FALSE;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;
@@ -527,6 +531,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['purge_control.settings']['purge_auto_control'] = FALSE;
     $config['seckit.settings']['seckit_xss']['csp']['checkbox'] = FALSE;
     $config['seckit.settings']['seckit_xss']['csp']['upgrade-req'] = FALSE;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;
@@ -579,6 +584,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
     $config['shield.settings']['shield_enable'] = TRUE;
     $config['system.performance']['cache']['page']['max_age'] = 900;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;
@@ -634,6 +640,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
     $config['shield.settings']['shield_enable'] = TRUE;
     $config['system.performance']['cache']['page']['max_age'] = 900;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;
@@ -689,6 +696,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['robotstxt.settings']['content'] = "User-agent: *\nDisallow: /";
     $config['shield.settings']['shield_enable'] = TRUE;
     $config['system.performance']['cache']['page']['max_age'] = 900;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;
@@ -744,6 +752,7 @@ class EnvironmentSettingsTest extends SettingsTestCase {
     $config['system.performance']['cache']['page']['max_age'] = 900;
     $config['system.performance']['css']['preprocess'] = TRUE;
     $config['system.performance']['js']['preprocess'] = TRUE;
+    $config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];
     $this->assertConfig($config);
 
     $settings['auto_create_htaccess'] = FALSE;

--- a/web/sites/default/includes/modules/settings.testmode.php
+++ b/web/sites/default/includes/modules/settings.testmode.php
@@ -8,3 +8,9 @@
 declare(strict_types=1);
 
 $settings['config_exclude_modules'][] = 'testmode';
+
+// The automated list view backs every CivicTheme list component. Listing it
+// here restricts those lists to test content while test mode is on, so a
+// scenario counting list items is not affected by the content already in the
+// database.
+$config['testmode.settings']['views_node'] = ['content', 'civictheme_automated_list'];


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] Subject includes ticket number as `[#123] Verb in past tense.`
- [ ] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [ ] Relevant tests run and passed locally.

## Changed

CI provisions from the production database (`VORTEX_FETCH_DB_ENVIRONMENT: main`), so any assertion measuring live editorial content breaks the pipeline without a code change. Two such assertions in `tests/behat/features/our_work_page.feature` did exactly that on `develop`: a headline that editors have since replaced, and a promo-card count that only ever measured how many real projects happened to be published. The scenarios are kept, but re-anchored on fixtures.

1. Dropped the editorial-copy assertions from the first scenario. The page no longer contains `Work you can go and look at.` - its `h1` is now `Projects, and what we did on them.` The scenario keeps the `200` check and the structural primary-navigation assertion (the menu's first level-0 item points at `/work`). Its name and the feature's user story were adjusted to match what is asserted.
2. Rebuilt the promo-card scenario for the two automated lists the page now carries. It creates six published projects tagged `Custom development` (the top list), six tagged `Open source` (the bottom list), and one draft, then asserts six promo cards in each list, a title scoped into each list so the tag filtering itself is proven, and that the draft stays invisible. The counts come entirely from the fixtures, so publishing or unpublishing a real project cannot move them.
3. Tagged that scenario `@testmode` and taught testmode about the list view. `@testmode` alone would have filtered nothing: the module only rewrites views named in `testmode.settings.views_node`, which defaults to `content`. `web/sites/default/includes/modules/settings.testmode.php` now adds `civictheme_automated_list`, the view behind every CivicTheme list component, whose `node_field_data` base table is what testmode's `title LIKE '[TEST%'` filter targets. The override is inert until test mode is switched on, so it has no effect outside the test run.
4. Enabled `testmode` during provisioning on `local` and `ci`. The module ships in `require` but was enabled nowhere, so the `@testmode` hook died with `Class "Drupal\testmode\Testmode" not found`. It is listed in `config_exclude_modules` and therefore deliberately absent from the exported configuration, which makes `scripts/provision-10-enable-dev-modules.sh` the right place to enable it, alongside `sdc_devel`.
5. Added the new config override to the nine full-array expectations in `tests/phpunit/Drupal/EnvironmentSettingsTest.php`, since `assertConfig()` compares the whole config array rather than a subset.

Each list is addressed through the components block rather than through its heading text or its `ct-automated-list-<pid>` id: the headings are editorial copy and the ids are paragraph ids, so both would reintroduce the coupling this PR removes. The two outer `.ct-list` elements are the only children of that block, which makes `> .ct-list:first-child` and `> .ct-list:last-child` stable handles.

One related item is left unchanged: `error_pages.feature` still visits the live editorial page `/about-us` for its "not an error page" control scenario. Its assertions are purely structural and it is passing, so it is out of scope here.

## Screenshots

N/A

## Before / After

BEFORE: assertions measured live production content
┌──────────────────────────────────────────────────────────────────────────┐
│ Scenario: page opens primary navigation and introduces the work
│   - sees "Work you can go and look at."       <- copy since replaced
│                                                  by "Projects, and what
│                                                  we did on them."
│
│ Scenario: Published projects listed as promo cards, 12 to a page
│   - creates 13 [TEST] project fixtures, untagged
│   - asserts 12 ".ct-promo-card" in the FIRST list
│                                               <- fixtures never enter a
│                                                  tag-filtered list, so
│                                                  this counted the 9 real
│                                                  client projects
└──────────────────────────────────────────────────────────────────────────┘
                    an editor publishes or unpublishes -> CI red

AFTER: assertions measure the fixtures only
┌──────────────────────────────────────────────────────────────────────────┐
│ Scenario: The work section is reachable and leads the primary navigation
│   - 200 response
│   - primary-nav first level-0 item points at /work
│
│ Scenario (@testmode): Each list shows only the published projects
│                       tagged for it
│   - 6 published  + tag "Custom development"  -> top list
│   - 6 published  + tag "Open source"         -> bottom list
│   - 1 draft      + tag "Custom development"
│   - test mode filters both lists to titles LIKE "[TEST%"
│   - asserts 6 cards per list, a known title inside each list,
│     and the draft absent
└──────────────────────────────────────────────────────────────────────────┘
                    real content is filtered out -> CI stays green

How the lists are addressed:

  div.block-field-blocknodecivictheme-pagefield-c-n-components
    |
    +-- div.ct-list   <- "> .ct-list:first-child"   Client work
    |
    +-- div.ct-list   <- "> .ct-list:last-child"    Open Source work

Wiring needed to make @testmode actually filter:

  provision-10-enable-dev-modules.sh   enables testmode on local + ci
              |
              v
  settings.testmode.php                views_node += civictheme_automated_list
              |
              v
  testmode_views_query_alter()         node_field_data.title LIKE '[TEST%'
              |
              v
  both /work lists                     fixtures only, real projects excluded
