### PR TITLE
[#308] Fixed sticky header offset when site alerts are present.

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -178,6 +178,28 @@ class FeatureContext extends DrupalContext {
   }
 
   /**
+   * Assert that an element sits flush against the top of the viewport.
+   *
+   * The behat-steps "at the top of the viewport" step accepts any offset
+   * between zero and the viewport height, so it passes for an element that
+   * merely happens to be on screen. A sticky element has to be flush.
+   *
+   * @code
+   * Then the element ".ct-header" should be pinned to the top of the viewport
+   * @endcode
+   *
+   * @javascript
+   */
+  #[Then('the element :selector should be pinned to the top of the viewport')]
+  public function elementAssertPinnedToViewportTop(string $selector): void {
+    $offset = (int) round((float) $this->elementExecuteJs($selector, 'return {{ELEMENT}}.getBoundingClientRect().top;'));
+
+    if ($offset !== 0) {
+      throw new \RuntimeException(sprintf('Expected element "%s" to be pinned to the top of the viewport, but it is %dpx from it.', $selector, $offset));
+    }
+  }
+
+  /**
    * Assert that an element resolves to a computed style value.
    *
    * Asserting on markup alone cannot tell whether a rule reached the element:

--- a/tests/behat/features/admin_navigation.feature
+++ b/tests/behat/features/admin_navigation.feature
@@ -15,7 +15,7 @@ Feature: Administration navigation for site administrator
   Scenario: Site administrator sees the administration top bar above the sticky site header
     Given I am logged in as a user with the "civictheme_site_administrator" role
     When I visit "/"
-    Then the element ".top-bar" should stack above the element ".ct-header--sticky"
+    Then the element ".top-bar" should stack above the element ".ct-page__header--sticky"
 
   @api @javascript
   Scenario: Site administrator sees the open mobile navigation above the administration top bar
@@ -24,4 +24,4 @@ Feature: Administration navigation for site administrator
     And I set the viewport to 390 by 844
     And I trigger the JS event "click" on the element ".ct-mobile-navigation-trigger"
     And I wait for 1 second
-    Then the element ".ct-header--sticky" should stack above the element ".top-bar"
+    Then the element ".ct-page__header--sticky" should stack above the element ".top-bar"

--- a/tests/behat/features/sticky_header.feature
+++ b/tests/behat/features/sticky_header.feature
@@ -1,0 +1,22 @@
+@header @p1 @drevops
+Feature: Sticky site header
+
+  As a site visitor
+  I want the site header to stay at the top of the window while I scroll
+  So that I can navigate away from anywhere on a long page
+
+  @api @javascript
+  Scenario: Site visitor sees the header pinned to the top of the window while an alert is shown above it
+    Given the following "civictheme_alert" content:
+      | title             | moderation_state | field_c_n_alert_type | field_c_n_body:value    | :format              | field_c_n_date_range:value | :end_value          |
+      | [TEST] Site Alert | published        | information          | [TEST] Alert body copy. | civictheme_rich_text | 2020-01-01T00:00:00        | 2099-01-01T00:00:00 |
+
+    And I am an anonymous user
+
+    When I visit "/"
+    And I wait for 2 seconds
+    Then I should see the text "[TEST] Site Alert"
+    And the element ".ct-header" should appear after the element ".ct-alert"
+
+    When I scroll to the element ".ct-footer"
+    Then the element ".ct-header" should be pinned to the top of the viewport

--- a/web/themes/custom/drevops/components/03-organisms/header/header.scss
+++ b/web/themes/custom/drevops/components/03-organisms/header/header.scss
@@ -7,21 +7,6 @@
 
   border-bottom: solid ct-particle(0.125);
 
-  // Custom: Add sticky header support with fixed positioning.
-  &--sticky {
-    position: fixed;
-    width: 100%;
-    z-index: $ct-header-sticky-zindex;
-
-    // The mobile navigation flyout sits inside the header, so the header's
-    // stacking context caps how high the flyout panel can rise. Lift the
-    // header to the flyout tier while the flyout is open, so the panel keeps
-    // covering everything else the way a full-screen overlay should.
-    &:has([data-flyout-expanded]) {
-      z-index: $ct-flyout-zindex;
-    }
-  }
-
   &__top {
     padding-top: ct-spacing();
     padding-bottom: ct-spacing();

--- a/web/themes/custom/drevops/components/04-templates/page/page.scss
+++ b/web/themes/custom/drevops/components/04-templates/page/page.scss
@@ -5,6 +5,32 @@
 .ct-page {
   $root: &;
 
+  // Custom: Carry the sticky positioning on a rail of zero height rather than
+  // on the header itself. The rail reserves no space, so page content still
+  // starts at the top of the page and scrolls under the header, and anything
+  // rendered ahead of the header - alerts are injected there once they load -
+  // scrolls away before the header pins. A fixed header would instead park at
+  // its static position, which those alerts push down the page.
+  #{$root}__header {
+    &--sticky {
+      position: sticky;
+      // Administration chrome that reserves space at the top of the viewport
+      // publishes it through this variable, so the header pins below the
+      // administration top bar instead of underneath it.
+      top: var(--drupal-displace-offset-top, 0px);
+      height: 0;
+      z-index: $ct-header-sticky-zindex;
+
+      // The mobile navigation flyout sits inside the header, so the rail's
+      // stacking context caps how high the flyout panel can rise. Lift the
+      // rail to the flyout tier while the flyout is open, so the panel keeps
+      // covering everything else the way a full-screen overlay should.
+      &:has([data-flyout-expanded]) {
+        z-index: $ct-flyout-zindex;
+      }
+    }
+  }
+
   @include ct-component-theme($root) using($root, $theme) {
     @include ct-component-property($root, $theme, background-color);
   }

--- a/web/themes/custom/drevops/components/04-templates/page/page.scss
+++ b/web/themes/custom/drevops/components/04-templates/page/page.scss
@@ -14,10 +14,11 @@
   #{$root}__header {
     &--sticky {
       position: sticky;
+
       // Administration chrome that reserves space at the top of the viewport
       // publishes it through this variable, so the header pins below the
       // administration top bar instead of underneath it.
-      top: var(--drupal-displace-offset-top, 0px);
+      top: var(--drupal-displace-offset-top, 0);
       height: 0;
       z-index: $ct-header-sticky-zindex;
 

--- a/web/themes/custom/drevops/components/04-templates/page/page.twig
+++ b/web/themes/custom/drevops/components/04-templates/page/page.twig
@@ -66,17 +66,20 @@
 
   {% block header_block %}
     {# Custom: Use include() instead of {% include only %} and add is_sticky support. #}
-    {{ include('civictheme:header', {
-      theme: header_theme,
-      is_sticky: header_is_sticky,
-      content_top1: header_top_1,
-      content_top2: header_top_2,
-      content_top3: header_top_3,
-      content_middle1: header_middle_1,
-      content_middle2: header_middle_2,
-      content_middle3: header_middle_3,
-      content_bottom1: header_bottom_1,
-    }, with_context: false) }}
+    {% set header_sticky_class = header_is_sticky ? 'ct-page__header--sticky' : '' %}
+    <div class="ct-page__header {{ header_sticky_class }}">
+      {{ include('civictheme:header', {
+        theme: header_theme,
+        is_sticky: header_is_sticky,
+        content_top1: header_top_1,
+        content_top2: header_top_2,
+        content_top3: header_top_3,
+        content_middle1: header_middle_1,
+        content_middle2: header_middle_2,
+        content_middle3: header_middle_3,
+        content_bottom1: header_bottom_1,
+      }, with_context: false) }}
+    </div>
   {% endblock %}
 
   {% block banner_block %}


### PR DESCRIPTION
Closes #308

## Checklist before requesting a review

- [x] Subject includes ticket number as `[#123] Verb in past tense.`
- [x] Ticket number `#123` added to description
- [x] Added context in `Changed` section
- [x] Self-reviewed code and commented in commented complex areas.
- [x] Added tests for fix/feature.
- [x] Relevant tests run and passed locally.

## Changed

1. Replaced `.ct-header--sticky`'s `position: fixed` (with no `top`, so it painted at its static position and never moved on scroll) with a zero-height `position: sticky` rail, `.ct-page__header--sticky`, wrapped around the header in `page.twig`.
2. Because the rail has no height it reserves no space in the page flow, so content still starts at the top of the page and slides under the header exactly as before; because it is sticky, it starts at the alerts' bottom edge and pins at the top of the window once the page scrolls past them, for an alert of any height added or dismissed at any time.
3. Pinned the rail at `top: var(--drupal-displace-offset-top, 0)` so it sits below core Navigation's administration top bar (published via `Drupal.displace()`) instead of underneath it.
4. Moved the header's `z-index` and its `:has([data-flyout-expanded])` mobile-flyout lift onto the rail, since `position: sticky` always creates its own stacking context; `.ct-header--sticky` now only carries its transparency and backdrop-blur treatment.
5. Retargeted `admin_navigation.feature`'s two stacking assertions from `.ct-header--sticky` to `.ct-page__header--sticky`, where the z-index now lives.
6. Added `tests/behat/features/sticky_header.feature`, which publishes a site-wide alert, loads the homepage, confirms the alert renders ahead of the header, scrolls to the footer, and asserts the header is flush with the top of the window.
7. Backed the new scenario with a `the element :selector should be pinned to the top of the viewport` step in `FeatureContext.php`, since the existing behat-steps "at the top of the viewport" step accepts any offset up to the viewport height and passes on the broken build.

Verified in the browser at desktop and mobile widths, with and without an alert, as an anonymous visitor and as an administrator, and with the mobile navigation flyout open. The new scenario was checked both ways: it fails against the old CSS with `Expected element ".ct-header" to be pinned to the top of the viewport, but it is 266px from it.` and passes against the fix.

## Screenshots

![Sticky header pinned flush to the top of the window on a scrolled homepage](https://raw.githubusercontent.com/drevops/website/62838756f7a69c70566ffd385de87a32d7eac361/feature-308-sticky-hdr-alerts/63244d4699481a18cb9c91b483a80fb481010b28.png)

## Before / After

**Before:** `.ct-header--sticky` is `position: fixed` with no `top` (defaults to `auto`)

```
.ct-page
├── .ct-alert
└── .ct-header--sticky

.ct-alert is injected by alert.js, ahead of the header.
.ct-header--sticky: position: fixed; top: auto -> paints at its
own static position, the slot it would occupy in normal flow,
which the alert's height pushes down. That offset is fixed at
layout time and never moves again, even once the page scrolls
past the alert (measured 188px on the homepage at 1265px wide).

  scrollY 0        scrollY 600
  ┌──────────┐     ┌──────────┐
  │ alert    │     │ content  │  <- content scrolls above
  ├──────────┤     ├──────────┤
  │ HEADER   │     │ HEADER   │  <- stuck at 188px, always
  ├──────────┤     ├──────────┤
  │ content  │     │ content  │  <- and behind
  └──────────┘     └──────────┘
```

**After:** positioning moves to a zero-height sticky rail around the header

```
.ct-page
├── .ct-alert
└── .ct-page__header--sticky
    └── .ct-header

.ct-page__header--sticky: position: sticky; height: 0;
top: var(--drupal-displace-offset-top, 0). height: 0 reserves
no space, so content still starts at the top of the page and
slides under the header exactly as before. Because it is
position: sticky, it starts at the alert's bottom edge and pins
at `top` once the page scrolls past it - correct for an alert of
any height, added or dismissed at any time. z-index and the
flyout :has(...) lift moved here too, since position: sticky
always creates its own stacking context; .ct-header--sticky now
only carries its transparency/backdrop-blur treatment.

  scrollY 0        scrollY 100      scrollY 600
  ┌──────────┐     ┌──────────┐     ┌──────────┐
  │ alert    │     │ alert    │     │ HEADER   │  <- pinned at 0
  ├──────────┤     ├──────────┤     ├──────────┤
  │ HEADER   │     │ HEADER   │     │ content  │
  ├──────────┤     ├──────────┤     │          │
  │ content  │     │ content  │     │          │
  └──────────┘     └──────────┘     └──────────┘
     188px            88px             0px
```
